### PR TITLE
Improvement to retry policy.

### DIFF
--- a/community/base/src/main/scala/com/digitalasset/canton/util/retry/Policy.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/util/retry/Policy.scala
@@ -4,15 +4,9 @@
 package com.digitalasset.canton.util.retry
 
 import cats.syntax.flatMap.*
-import com.digitalasset.canton.DiscardOps
 import com.digitalasset.canton.concurrent.DirectExecutionContext
 import com.digitalasset.canton.lifecycle.UnlessShutdown.{AbortedDueToShutdown, Outcome}
-import com.digitalasset.canton.lifecycle.{
-  FlagCloseable,
-  FutureUnlessShutdown,
-  RunOnShutdown,
-  UnlessShutdown,
-}
+import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown, UnlessShutdown}
 import com.digitalasset.canton.logging.{ErrorLoggingContext, TracedLogger}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
@@ -26,8 +20,9 @@ import com.digitalasset.canton.util.retry.RetryWithDelay.{RetryOutcome, RetryTer
 import com.digitalasset.canton.util.{DelayUtil, LoggerUtil}
 import org.slf4j.event.Level
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.DurationConverters.*
 import scala.util.control.NonFatal
 import scala.util.{Failure, Try}
 
@@ -108,6 +103,7 @@ abstract class RetryWithDelay(
     actionable: Option[String], // How to mitigate the error
     initialDelay: FiniteDuration,
     totalMaxRetries: Int,
+    resetRetriesAfter: FiniteDuration,
     flagCloseable: FlagCloseable,
     retryLogLevel: Option[Level],
 ) extends Policy(logger) {
@@ -176,6 +172,9 @@ abstract class RetryWithDelay(
 
     import LoggerUtil.logOnThrow
 
+    val clock = java.time.Clock.systemUTC()
+    import java.time.Duration as JDuration, clock.instant as now
+
     def runTask(): Future[T] = Future.fromTry(Try(task)).flatten
 
     def run(
@@ -185,7 +184,9 @@ abstract class RetryWithDelay(
         retriesOfLastErrorKind: Int,
         delay: FiniteDuration,
     ): Future[RetryOutcome[T]] = logOnThrow {
+      val startedAt = now()
       previousResult.transformWith { x =>
+        val finishedAt = now()
         logOnThrow(x match {
           case succ @ util.Success(result) if success.predicate(result) =>
             logger.trace(
@@ -232,92 +233,67 @@ abstract class RetryWithDelay(
                 // No need to log the exception in outcome, as this has been logged by retryable.retryOk.
               )
 
-              val invocationP = Promise[Future[RetryOutcome[T]]]()
-              val abortedOnShutdownTask = new RunOnShutdown {
-                override def done: Boolean = invocationP.isCompleted
-
-                override def name: String = s"'$operationName' / $longDescription"
-
-                override def run(): Unit = logOnThrow {
-                  val wrappedOutcome =
-                    Future.successful(RetryOutcome(outcome, RetryTermination.Shutdown))
-                  val promiseCompleted = invocationP.trySuccess(wrappedOutcome)
-                  if (promiseCompleted) {
-                    logger.info(
-                      s"The operation '$operationName' has been cancelled. Aborting. $longDescription"
+              val delayedF = DelayUtil.delayIfNotClosing(operationName, delay, flagCloseable)
+              delayedF
+                .flatMap { _ =>
+                  logOnThrow {
+                    LoggerUtil.logAtLevel(
+                      level,
+                      s"Now retrying operation '$operationName'. $longDescription$actionableMessage",
                     )
+                    // Run the task again on the normal execution context as the task might take a long time.
+                    // `performUnlessClosingF` guards against closing the execution context.
+                    val nextRunUnlessShutdown =
+                      flagCloseable
+                        .performUnlessClosingF(operationName)(runTask())(
+                          executionContext,
+                          traceContext,
+                        )
+                    @SuppressWarnings(Array("org.wartremover.warts.TryPartial"))
+                    val nextRunF = nextRunUnlessShutdown
+                      .onShutdown {
+                        // If we're closing, report the previous `outcome` and recurse.
+                        // This will enter the case branch with `flagCloseable.isClosing`
+                        // and therefore yield the termination reason `Shutdown`.
+                        outcome.get
+                      }(
+                        // Use the direct execution context as this is a small task.
+                        // The surrounding `performUnlessClosing` ensures that this post-processing
+                        // is registered with the normal execution context before it can close.
+                        directExecutionContext
+                      )
+                    import scala.math.Ordering.Implicits.*
+                    val (nextTotalRetries, nextDelayIs) =
+                      if (resetRetriesAfter.toJava <= JDuration.between(startedAt, finishedAt))
+                        (0, initialDelay)
+                      else
+                        (totalRetries + 1, nextDelay(totalRetries + 1, delay))
+                    FutureUnlessShutdown.outcomeF(
+                      run(
+                        nextRunF,
+                        nextTotalRetries,
+                        errorKind,
+                        retriesOfErrorKind + 1,
+                        nextDelayIs,
+                      )
+                    )(executionContext)
                   }
-                }
-              }
-              flagCloseable.runOnShutdown(abortedOnShutdownTask)
-
-              val delayedF = DelayUtil.delay(operationName, delay, flagCloseable)
-              flagCloseable
-                .performUnlessClosing(operationName) {
-                  // if delayedF doesn't complete, then we can be sure that the `abortedOnShutdownTask.run` will run due to shutdown
-                  delayedF.onComplete {
-                    case util.Success(()) =>
-                      logOnThrow { // if this one doesn't run, then the `abortedOnShutdownTask` will run
-                        flagCloseable.performUnlessClosing(operationName) {
-                          val retryP = Promise[RetryOutcome[T]]()
-                          // ensure that the abort task doesn't get executed anymore (because we
-                          // want to return the "last outcome" and here, we can be sure that `run` will give us a new outcome
-                          invocationP.trySuccess(retryP.future).discard
-                          LoggerUtil.logAtLevel(
-                            level,
-                            s"Now retrying operation '$operationName'. $longDescription$actionableMessage",
-                          )
-                          // Run the task again on the normal execution context as the task might take a long time.
-                          // `performUnlessClosingF` guards against closing the execution context.
-                          val nextRunUnlessShutdown =
-                            flagCloseable
-                              .performUnlessClosingF(operationName)(runTask())(
-                                executionContext,
-                                traceContext,
-                              )
-                          @SuppressWarnings(Array("org.wartremover.warts.TryPartial"))
-                          val nextRunF = nextRunUnlessShutdown
-                            .onShutdown {
-                              // If we're closing, report the previous `outcome` and recurse.
-                              // This will enter the case branch with `flagCloseable.isClosing`
-                              // and therefore yield the termination reason `Shutdown`.
-                              outcome.get
-                            }(
-                              // Use the direct execution context as this is a small task.
-                              // The surrounding `performUnlessClosing` ensures that this post-processing
-                              // is registered with the normal execution context before it can close.
-                              directExecutionContext
-                            )
-                          val retryF = run(
-                            nextRunF,
-                            totalRetries + 1,
-                            errorKind,
-                            retriesOfErrorKind + 1,
-                            nextDelay(totalRetries + 1, delay),
-                          )
-                          retryP.completeWith(retryF)
-                        }(traceContext)
-                      }
-                    case failure: Failure[_] =>
-                      logger.error("DelayUtil failed unexpectedly", failure)
-                  }(
-                    // It is safe to use the general execution context here by the following argument.
-                    // - If the `onComplete` executes before `DelayUtil` completes the returned promise,
-                    //   then the completion of the promise will schedule the function immediately.
-                    //   Since this completion is guarded by `performUnlessClosing`,
-                    //   the body gets scheduled with `executionContext` before `flagCloseable`'s close method completes.
-                    // - If `DelayUtil` completes the returned promise before the `onComplete` call executes,
-                    //   the `onComplete` call itself will schedule the body
-                    //   and this is guarded by the `performUnlessClosing` above.
-                    // Therefore the execution context is still open when the scheduling happens.
-                    executionContext
-                  )
-                }
-                .onShutdown(
-                  // If the `onComplete` does not run, then `abortedDueToShutdownTask.run` will run due to shutdown
-                  ()
+                }(
+                  // It is safe to use the general execution context here by the following argument.
+                  // - If the `onComplete` executes before `DelayUtil` completes the returned promise,
+                  //   then the completion of the promise will schedule the function immediately.
+                  //   Since this completion is guarded by `performUnlessClosing`,
+                  //   the body gets scheduled with `executionContext` before `flagCloseable`'s close method completes.
+                  // - If `DelayUtil` completes the returned promise before the `onComplete` call executes,
+                  //   the `onComplete` call itself will schedule the body
+                  //   and this is guarded by the `performUnlessClosing` above.
+                  // Therefore the execution context is still open when the scheduling happens.
+                  executionContext
                 )
-              invocationP.future.flatten
+                .onShutdown(
+                  RetryOutcome(outcome, RetryTermination.Shutdown)
+                )(executionContext)
+
             } else {
               logger.info(
                 messageOfOutcome(
@@ -399,6 +375,7 @@ final case class Directly(
       None,
       Duration.Zero,
       maxRetries,
+      resetRetriesAfter = 24.hours,
       flagCloseable,
       retryLogLevel,
     ) {
@@ -423,6 +400,7 @@ final case class Pause(
       actionable,
       delay,
       maxRetries,
+      resetRetriesAfter = 24.hours,
       flagCloseable,
       retryLogLevel,
     ) {
@@ -470,6 +448,7 @@ final case class Backoff(
     initialDelay: FiniteDuration,
     maxDelay: Duration,
     operationName: String,
+    resetRetriesAfter: FiniteDuration = 24.hours,
     longDescription: String = "",
     actionable: Option[String] = None,
     retryLogLevel: Option[Level] = None,
@@ -481,6 +460,7 @@ final case class Backoff(
       actionable,
       initialDelay,
       maxRetries,
+      resetRetriesAfter,
       flagCloseable,
       retryLogLevel,
     ) {


### PR DESCRIPTION
(From an issue downstream) Currently, the retry logic seems unnecessarily convoluted. In particular this place:

https://github.com/digital-asset/canton/blob/982b17ad78af5a94d85abcd03023efad26f83c9f/community/base/src/main/scala/com/digitalasset/canton/util/retry/Policy.scala#L258

delayedF can never complete if we're shut down. This doesn't result in issues since the RunOnShutdown above is run.

However, afaict it does leak the delayedF future. It also just seems unnecessarily confusing. If delayedF already has logic to handle shutdowns it should also be able to complete in some form instead of relying on a separate RunOnShutdown for this.