### PR TITLE
Update DamlPackageLoader.validateDar to enforce the intended 1 GB ceiling

### DIFF
--- a/community/common/src/main/scala/com/digitalasset/canton/util/DamlPackageLoader.scala
+++ b/community/common/src/main/scala/com/digitalasset/canton/util/DamlPackageLoader.scala
@@ -48,7 +48,7 @@ object DamlPackageLoader {
   def validateDar(
       name: String,
       content: ByteString,
-      unzippedMaxBytes: Int = 1064 * 1064 * 1064,
+      unzippedMaxBytes: Int = 1024 * 1024 * 1024,
   ): Either[String, Unit] =
     DarReader
       .readArchive(


### PR DESCRIPTION
**Summary**

- Corrected the default unzipped byte limit in DamlPackageLoader.validateDar to enforce the intended 1 GB ceiling during DAR validation.

**Testing**

- sbt test