### PR TITLE
Fix grammar in party_management_service.proto

### DIFF
--- a/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto
+++ b/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/participant/v30/party_management_service.proto
@@ -253,7 +253,7 @@ message ExportPartyAcsRequest {
 
   // The maximum duration the service will wait to find the topology transaction that activates the party on
   // the target participant.
-  // If not set, the service use will use a default timeout.
+  // If not set, the service will use a default timeout.
   // Optional
   google.protobuf.Duration wait_for_activation_timeout = 5;
 }
@@ -342,7 +342,7 @@ message ClearPartyOnboardingFlagRequest {
 
   // The maximum duration the service will wait to find the topology transaction
   // that activates the party.
-  // If not set, the service use will use a default timeout.
+  // If not set, the service will use a default timeout.
   // Optional
   google.protobuf.Duration wait_for_activation_timeout = 4;
 }


### PR DESCRIPTION
## Description

Fixes a grammar error in `party_management_service.proto` documentation comments.

## Changes

Replaces redundant verb usage "the service use will use" with "the service will use" in two locations:
- Line 256: `ExportPartyAcsRequest.wait_for_activation_timeout` field comment
- Line 345: `ClearPartyOnboardingFlagRequest.wait_for_activation_timeout` field comment

## Type of Change

- [x] Bug fix (documentation grammar)
- [ ] New feature
- [ ] Breaking change

## Testing

No code changes, only comment/documentation corrections. No testing required.