### PR TITLE
feat(external-call): Add proto definitions and data types

### DIFF
--- a/community/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
+++ b/community/daml-lf/archive/src/main/protobuf/com/digitalasset/daml/lf/archive/daml_lf2.proto
@@ -390,6 +390,8 @@ enum BuiltinFunction {
   TYPE_REP_TYCON_NAME = 3011; // *Available in versions >= 2.dev*
 
   //SECP256K1_VALIDATE_KEY = 4001; // REMAINS HERE TEMPORARELY TO PARSE CHECKED IN DARS
+
+  EXTERNAL_CALL = 5001; // *Available in versions >= 2.dev*
 }
 
 // Builtin literals

--- a/community/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
+++ b/community/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV2.scala
@@ -1873,6 +1873,12 @@ private[lf] object DecodeV2 {
         versionRange = Some(LV.featureUnstable.versionRange),
       ),
       BuiltinFunctionInfo(FAIL_WITH_STATUS, BFailWithStatus),
+      BuiltinFunctionInfo(
+        EXTERNAL_CALL,
+        BExternalCall,
+        minVersion = LV.featureExternalCall.versionRange.min,
+        versionRange = Some(LV.featureExternalCall.versionRange),
+      ),
     )
   }
 

--- a/community/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/community/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -571,6 +571,10 @@ object Ast {
   final case object BFailWithStatus
       extends BuiltinFunction // : ∀a. Text → FailureCategory → Text → TextMap Text → a
 
+  // External Call
+  final case object BExternalCall
+      extends BuiltinFunction // : Text → Text → Text → Text → Update Text
+
   final case class EExperimental(name: String, typ: Type) extends Expr
 
   //

--- a/community/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageFeatureGen.scala
+++ b/community/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageFeatureGen.scala
@@ -145,6 +145,11 @@ trait LanguageFeaturesGenerated extends LanguageVersionGenerated {
     versionRange = VersionRange.Inclusive(v2_dev, v2_dev),
   )
 
+  val featureExternalCall: Feature = Feature(
+    name = "External Call",
+    versionRange = VersionRange.Inclusive(v2_dev, v2_dev),
+  )
+
   val featureUnsafeFromInterface: Feature = Feature(
     name = "UnsafeFromInterface builtin",
     versionRange = VersionRange.Until(v2_1),
@@ -174,6 +179,7 @@ trait LanguageFeaturesGenerated extends LanguageVersionGenerated {
     featureExperimental,
     featurePackageUpgrades,
     featureChoiceAuthority,
+    featureExternalCall,
     featureUnsafeFromInterface,
   )
 

--- a/community/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/value/test/ValueGenerators.scala
+++ b/community/daml-lf/transaction-test-lib/src/main/scala/com/digitalasset/daml/lf/value/test/ValueGenerators.scala
@@ -9,6 +9,7 @@ import com.digitalasset.daml.lf.data.*
 import com.digitalasset.daml.lf.data.Ref.*
 import com.digitalasset.daml.lf.transaction.test.TransactionBuilder
 import com.digitalasset.daml.lf.transaction.{
+  ExternalCallResult,
   GlobalKey,
   GlobalKeyWithMaintainers,
   Node,
@@ -323,6 +324,35 @@ object ValueGenerators {
       if gkey.isDefined
     } yield GlobalKeyWithMaintainers(gkey.get, maintainers)
 
+  /** Generates a single ExternalCallResult for testing serialization. */
+  val externalCallResultGen: Gen[ExternalCallResult] =
+    for {
+      extensionId <- Gen.alphaNumStr.suchThat(_.nonEmpty).map(_.take(50))
+      functionId <- Gen.alphaNumStr.suchThat(_.nonEmpty).map(_.take(50))
+      configHash <- Gen.alphaNumStr.map(_.take(64))
+      inputHex <- Gen.hexStr.map(_.take(200))
+      outputHex <- Gen.hexStr.map(_.take(200))
+      callIndex <- Gen.chooseNum(0, 100)
+    } yield ExternalCallResult(
+      extensionId = extensionId,
+      functionId = functionId,
+      configHash = configHash,
+      inputHex = inputHex,
+      outputHex = outputHex,
+      callIndex = callIndex,
+    )
+
+  /** Generates a list of ExternalCallResults for exercise nodes. */
+  def externalCallResultsGen(
+      version: SerializationVersion
+  ): Gen[ImmArray[ExternalCallResult]] =
+    if (version < SerializationVersion.minExternalCallResults)
+      Gen.const(ImmArray.empty[ExternalCallResult])
+    else
+      Gen
+        .listOf(externalCallResultGen)
+        .map(results => ImmArray.from(results.take(5))) // Limit to 5 for reasonable test sizes
+
   /** Makes create nodes that violate the rules:
     *
     *   1. stakeholders may not be a superset of signatories 2. key's maintainers may not be a
@@ -448,6 +478,7 @@ object ValueGenerators {
       byKey <-
         if (version < SerializationVersion.minContractKeys) Gen.const(false)
         else Gen.oneOf(true, false)
+      extCallResults <- externalCallResultsGen(version)
     } yield Node.Exercise(
       targetCoid = targetCoid,
       packageName = pkgName,
@@ -465,6 +496,7 @@ object ValueGenerators {
       exerciseResult = exerciseResult,
       keyOpt = key,
       byKey = byKey,
+      externalCallResults = extCallResults,
       version = version,
     )
 

--- a/community/daml-lf/transaction-tests/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/community/daml-lf/transaction-tests/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -1170,6 +1170,7 @@ object TransactionSpec {
       exerciseResult = if (hasExerciseResult) Some(V.ValueUnit) else None,
       keyOpt = None,
       byKey = false,
+      externalCallResults = ImmArray.empty,
       version = SerializationVersion.minVersion,
     )
 

--- a/community/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
+++ b/community/daml-lf/transaction/src/main/protobuf/com/digitalasset/daml/lf/transaction.proto
@@ -74,6 +74,8 @@ message Node {
     repeated string observers = 8;
     // No listed authorizers indicates default authorizers (signatories + actors)
     repeated string authorizers = 1001; // *since version dev*
+    // Results of external calls made during this exercise
+    repeated ExternalCallResult external_call_results = 1002; // *since version dev*
   }
 
   message Rollback {
@@ -115,4 +117,17 @@ message FatContractInstance {
 message KeyWithMaintainers {
   bytes key = 1;
   repeated string maintainers = 2; // the maintainers induced by the key
+}
+
+// Result of an external call made during transaction execution.
+// External calls are deterministic HTTP calls to extension services.
+// Results are stored in the transaction and replayed during validation.
+// *since dev*
+message ExternalCallResult {
+  string extension_id = 1;    // Extension service identifier (e.g., "oracle-price-feed")
+  string function_id = 2;     // Function identifier within the extension
+  string config_hash = 3;     // Hash of the extension configuration for version validation
+  string input_hex = 4;       // Hex-encoded input data sent to the extension
+  string output_hex = 5;      // Hex-encoded output data returned by the extension
+  int32 call_index = 6;       // Index of this call within the exercise node (for ordering)
 }

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -10,6 +10,31 @@ import com.digitalasset.daml.lf.transaction.BackwardsCompatibilityImplicits._
 import com.digitalasset.daml.lf.value.Value.{ContractId, VersionedThinContractInstance}
 import com.digitalasset.daml.lf.value._
 
+/** Result of an external call made during contract execution.
+  *
+  * External calls are deterministic function calls to extension services
+  * that are recorded in the transaction for replay during validation.
+  *
+  * @param extensionId Identifier of the configured extension
+  * @param functionId Function identifier within the extension
+  * @param configHash Configuration hash for version validation
+  * @param inputHex Input data (hex-encoded)
+  * @param outputHex Output data (hex-encoded)
+  * @param callIndex Index of this call within the exercise (for ordering)
+  */
+final case class ExternalCallResult(
+    extensionId: String,
+    functionId: String,
+    configHash: String,
+    inputHex: String,
+    outputHex: String,
+    callIndex: Int,
+)
+
+object ExternalCallResult {
+  val Empty: ImmArray[ExternalCallResult] = ImmArray.Empty
+}
+
 /** Generic transaction node type for both update transactions and the
   * transaction graph.
   */
@@ -194,6 +219,7 @@ object Node {
       exerciseResult: Option[Value],
       keyOpt: Option[GlobalKeyWithMaintainers],
       override val byKey: Boolean,
+      externalCallResults: ImmArray[ExternalCallResult],
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: SerializationVersion,
   ) extends Action

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/SerializationVersion.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/SerializationVersion.scala
@@ -81,6 +81,11 @@ object SerializationVersion {
     LanguageVersion.featureChoiceAuthority.versionRange.min
   )
 
+  // Minimum version that supports external call results in exercise nodes
+  private[lf] val minExternalCallResults = assign(
+    LanguageVersion.featureExternalCall.versionRange.min
+  )
+
   private[lf] def txVersion(tx: Transaction): SerializationVersion = {
     import scala.Ordering.Implicits._
     tx.nodes.valuesIterator.foldLeft(SerializationVersion.minVersion) {

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -439,7 +439,7 @@ sealed abstract class HasTxNodes[Tx] {
   final def inputContracts[Cid2 >: ContractId]: Set[Cid2] = {
 
     fold(Set.empty[Cid2]) {
-      case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))) if !localContractIds.contains(coid)=>
+      case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))) if !localContractIds.contains(coid)=>
         acc + coid
       case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _, _, _)))  if !localContractIds.contains(coid)=>
         acc + coid

--- a/community/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/community/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -304,6 +304,8 @@ private[validation] object Typing {
         alpha.name -> KStar,
         TText ->: TFailureCategory ->: TText ->: TTextMap(TText) ->: alpha,
       ),
+      // External Call
+      BExternalCall -> (TText ->: TText ->: TText ->: TText ->: TUpdate(TText)),
     )
   }
 


### PR DESCRIPTION
## Summary

This PR adds the foundational proto definitions and Scala data types for the external call feature. It defines how external call results are represented in transactions and the language AST.

## Changes

### Proto Definitions

#### `daml_lf2.proto`
```protobuf
enum BuiltinFunction {
  // ... existing values ...
  BUILTIN_EXTERNAL_CALL = 74;
}
```

#### `transaction.proto`
```protobuf
message ExternalCallResult {
  string extension_id = 1;
  string function_id = 2;
  bytes config = 3;
  bytes input = 4;
  bytes output = 5;
}

message Node.Exercise {
  // ... existing fields ...
  repeated ExternalCallResult external_call_results = 18;
}
```

### Scala Data Types

#### `Node.scala`
- Added `externalCallResults: Seq[ExternalCallResult]` to `Exercise` node
- Added `ExternalCallResult` case class

#### `Ast.scala`
- Added `BEExternalCall` to `BuiltinFunction` sealed trait

#### `LanguageFeatureGen.scala`
- Added feature flag for external calls

#### `Transaction.scala`
- Updated transaction traversal to include external call results

#### `SerializationVersion.scala`
- Added support for serializing external call results

### Validation

#### `Typing.scala`
- Added type checking for `BEExternalCall` builtin

### Decoding

#### `DecodeV2.scala`
- Added decoder for `BUILTIN_EXTERNAL_CALL`

## Testing

- `TransactionSpec.scala` - Transaction with external calls
- `ValueGenerators.scala` - Generators for external call results
