### PR TITLE
feat(external-call): Add engine and Speedy interpreter support

### DIFF
--- a/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
@@ -57,6 +57,7 @@ import com.digitalasset.daml.lf.engine.{
   ResultError,
   ResultInterruption,
   ResultNeedContract,
+  ResultNeedExternalCall,
   ResultNeedKey,
   ResultNeedPackage,
   ResultPrefetch,
@@ -396,6 +397,20 @@ class TestSubmissionService(
         resolve(iterateOverInterrupts(continue))
 
       case ResultPrefetch(_, _, resume) => resolve(resume())
+
+      case ResultNeedExternalCall(extensionId, functionId, _, _, _) =>
+        Future.successful(
+          Left(
+            Error.Interpretation(
+              Error.Interpretation.Internal(
+                "test",
+                s"External calls are not supported in TestSubmissionService: extension=$extensionId, function=$functionId",
+                None,
+              ),
+              None,
+            )
+          )
+        )
     }
   }
 }

--- a/community/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/community/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -770,6 +770,19 @@ class Engine(
                     )
                   )
               }
+
+            case Question.Update.NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+              ResultNeedExternalCall(
+                extensionId,
+                functionId,
+                configHash,
+                input,
+                { (result: Either[ExternalCallError, String]) =>
+                  val speedyResult = result.left.map(e => Question.Update.ExternalCallError(e.message))
+                  callback(speedyResult)
+                  interpretLoop(machine, time, submissionInfo)
+                },
+              )
           }
 
         case SResultInterruption =>

--- a/community/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/community/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -38,6 +38,8 @@ sealed trait Result[+A] extends Product with Serializable {
       ResultNeedKey(gk, limit, token, (cids, token) => resume(cids, token).map(f))
     case ResultPrefetch(contractIds, keys, resume) =>
       ResultPrefetch(contractIds, keys, () => resume().map(f))
+    case ResultNeedExternalCall(extId, funcId, configHash, input, resume) =>
+      ResultNeedExternalCall(extId, funcId, configHash, input, result => resume(result).map(f))
   }
 
   def flatMap[B](f: A => Result[B]): Result[B] = this match {
@@ -58,6 +60,8 @@ sealed trait Result[+A] extends Product with Serializable {
       )
     case ResultPrefetch(contractIds, keys, resume) =>
       ResultPrefetch(contractIds, keys, () => resume().flatMap(f))
+    case ResultNeedExternalCall(extId, funcId, configHash, input, resume) =>
+      ResultNeedExternalCall(extId, funcId, configHash, input, result => resume(result).flatMap(f))
   }
 
   private[lf] def consume(
@@ -85,6 +89,18 @@ sealed trait Result[+A] extends Product with Serializable {
         case ResultNeedKey(key, _, _, resume) =>
           go(resume(keys.lift(key).getOrElse(Vector.empty), NeedKeyProgression.Finished))
         case ResultPrefetch(_, _, result) => go(result())
+        // TODO(https://github.com/digital-asset/canton/issues/513): Teach consume how to
+        // provide or replay external-call results once the later stack layers are wired.
+        case ResultNeedExternalCall(extId, funcId, _, _, _) =>
+          Left(Error.Interpretation(
+            Error.Interpretation.Internal(
+              "Result.consume",
+              s"Result.consume cannot handle ResultNeedExternalCall; handle it explicitly " +
+                s"before consuming (extensionId=$extId, functionId=$funcId)",
+              None,
+            ),
+            None,
+          ))
       }
     go(this)
   }
@@ -202,6 +218,31 @@ final case class ResultPrefetch[A](
     resume: () => Result[A],
 ) extends Result[A]
 
+/** Indicates that the host must provide an external-call result to complete the computation.
+  * The request fields use canonical lowercase hexadecimal encoding. To resume a successful external
+  * call, the host must provide the output using the same canonical encoding.
+  *
+  * To resume the computation, the caller must invoke `resume` with either:
+  * - Right(output) if the external call succeeded with canonical lowercase hexadecimal output
+  * - Left(error) if the host failed to complete the external call
+  *
+  * @param extensionId Identifier of the configured extension
+  * @param functionId Function identifier within the extension
+  * @param configHash Configuration hash as canonical lowercase hex for version validation
+  * @param input Input data as canonical lowercase hex
+  * @param resume Callback to provide the result or error
+  */
+final case class ResultNeedExternalCall[A](
+    extensionId: String,
+    functionId: String,
+    configHash: String,
+    input: String,
+    resume: Either[ExternalCallError, String] => Result[A],
+) extends Result[A]
+
+/** Error information from external call failures */
+final case class ExternalCallError(message: String)
+
 object Result {
 
   val Unit: ResultDone[Unit] = ResultDone.Unit
@@ -299,6 +340,17 @@ object Result {
                 keys,
                 () =>
                   resume().flatMap(x =>
+                    Result.sequence(results_).map(otherResults => (okResults :+ x) :++ otherResults)
+                  ),
+              )
+            case ResultNeedExternalCall(extId, funcId, configHash, input, resume) =>
+              ResultNeedExternalCall(
+                extId,
+                funcId,
+                configHash,
+                input,
+                result =>
+                  resume(result).flatMap(x =>
                     Result.sequence(results_).map(otherResults => (okResults :+ x) :++ otherResults)
                   ),
               )

--- a/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
+++ b/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+package engine
+
+import com.digitalasset.canton.logging.SuppressingLogging
+import com.digitalasset.daml.lf.command.{ApiCommand, ApiCommands}
+import com.digitalasset.daml.lf.crypto.Hash
+import com.digitalasset.daml.lf.data.{ImmArray, Ref, Time}
+import com.digitalasset.daml.lf.engine.ResultNeedExternalCall
+import com.digitalasset.daml.lf.language.LanguageVersion
+import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
+import com.digitalasset.daml.lf.testing.parser.ParserParameters
+import com.digitalasset.daml.lf.transaction.{ExternalCallResult, Node}
+import com.digitalasset.daml.lf.value.{ContractIdVersion, Value}
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExternalCallEngineTest
+    extends AnyWordSpec
+    with Matchers
+    with Inside
+    with SuppressingLogging {
+
+  implicit private val parserParameters: ParserParameters[this.type] =
+    ParserParameters(
+      defaultPackageId = Ref.PackageId.assertFromString("-pkg-"),
+      languageVersion = LanguageVersion.v2_dev,
+    )
+
+  private val pkgId = parserParameters.defaultPackageId
+  private val pkg = p"""
+    metadata ( '-pkg-' : '1.0.0' )
+
+    module M {
+      record @serializable T = { party: Party };
+
+      template (this: T) = {
+        precondition True;
+        signatories Cons @Party [M:T {party} this] (Nil @Party);
+        observers Nil @Party;
+
+        choice Call (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
+      };
+    }
+  """
+
+  def newEngine(config: EngineConfig = Engine.DevConfig): Engine = {
+    val engine = new Engine(config, loggerFactory)
+    engine.preloadPackage(pkgId, pkg).consume() shouldBe Right(())
+    engine
+  }
+
+  def submit(engine: Engine) =
+    engine.submit(
+      submitters = Set(alice),
+      readAs = Set.empty,
+      cmds = ApiCommands(ImmArray(command), let, "external-call-engine-test"),
+      participantId = participantId,
+      submissionSeed = submissionSeed,
+      contractIdVersion = ContractIdVersion.V1,
+      contractStateMode = transaction.NextGenContractStateMachine.Mode.devDefault,
+      prefetchKeys = Seq.empty,
+    )
+
+  private val alice = Ref.Party.assertFromString("Alice")
+  private val participantId = Ref.ParticipantId.assertFromString("participant")
+  private val submissionSeed = Hash.hashPrivateKey("ExternalCallEngineTest")
+  private val let = Time.Timestamp.now()
+  private val templateId = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("M:T"))
+  private val command = ApiCommand.CreateAndExercise(
+    templateId.toRef,
+    Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(alice))),
+    Ref.ChoiceName.assertFromString("Call"),
+    Value.ValueUnit,
+  )
+
+  "Engine.submit" should {
+    "emit ResultNeedExternalCall with the expected payload and continuation" in {
+      val result = submit(newEngine())
+
+      inside(result) {
+        case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
+          extensionId shouldBe "ext"
+          functionId shouldBe "fun"
+          configHash shouldBe "0a0b"
+          input shouldBe "c0ff"
+
+          inside(resume(Right("beef")).consume()) { case Right((tx, _)) =>
+            val exerciseNodes = tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+            exerciseNodes should have size 1
+            exerciseNodes.head.externalCallResults shouldBe ImmArray(
+              ExternalCallResult(
+                extensionId = "ext",
+                functionId = "fun",
+                config = data.Bytes.assertFromString("0a0b"),
+                input = data.Bytes.assertFromString("c0ff"),
+                output = data.Bytes.assertFromString("beef"),
+              )
+            )
+          }
+      }
+    }
+
+    "surface external call failures through the engine continuation" in {
+      val result = submit(newEngine())
+
+      inside(result) {
+        case ResultNeedExternalCall(_, _, _, _, resume) =>
+          inside(
+            resume(Left(ExternalCallError("upstream unavailable"))).consume()
+          ) {
+            case Left(err @ Error.Interpretation(Error.Interpretation.DamlException(_), _)) =>
+              err.message should include("External call failed: upstream unavailable")
+              err.message should include("extensionId=ext")
+              err.message should include("functionId=fun")
+          }
+      }
+    }
+  }
+}

--- a/community/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
+++ b/community/daml-lf/ide-ledger/src/main/scala/com/digitalasset/daml/lf/script/IdeLedgerRunner.scala
@@ -414,6 +414,8 @@ private[lf] object IdeLedgerRunner {
             case Question.Update.NeedTime(callback) =>
               callback(ledger.currentTime)
               go()
+            case Question.Update.NeedExternalCall(_, _, _, _, _) =>
+              throw Error.Internal("External calls are not supported in the IDE ledger")
             case res: Question.Update.NeedPackage =>
               throw Error.Internal(s"unexpected $res")
           }

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/CostModel.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/CostModel.scala
@@ -58,6 +58,7 @@ abstract class CostModel {
   val BSHA256Text: CostFunction1[Text]
   val BSHA256Hex: CostFunction1[Text]
   val BKECCAK256Text: CostFunction1[Text]
+  val BExternalCall: CostFunction1[Text]
   val BSECP256K1Bool: CostFunction3[Text, Text, Text]
   val BSECP256K1WithEcdsaBool: CostFunction3[Text, Text, Text]
   val BSECP256K1ValidateKey: CostFunction1[Text]
@@ -271,6 +272,7 @@ object CostModel {
     override val BSHA256Text: CostFunction1[Text] = CostFunction1.Null
     override val BSHA256Hex: CostFunction1[Text] = CostFunction1.Null
     override val BKECCAK256Text: CostFunction1[Text] = CostFunction1.Null
+    override val BExternalCall: CostFunction1[Text] = CostFunction1.Null
     override val BSECP256K1Bool: CostFunction3[Text, Text, Text] = CostFunction3.Null
     override val BSECP256K1WithEcdsaBool: CostFunction3[Text, Text, Text] = CostFunction3.Null
     override val BSECP256K1ValidateKey: CostFunction1[Text] = CostFunction1.Null
@@ -853,6 +855,9 @@ object CostModel {
       CostFunction1.Constant(STextWrapperSize + AsciiStringSize.calculate(64))
     override val BKECCAK256Text: CostFunction1[Text] =
       CostFunction1.Constant(STextWrapperSize + AsciiStringSize.calculate(64))
+    // TODO(https://github.com/digital-asset/canton/issues/513): Replace this placeholder when external-call cost policy is wired.
+    override val BExternalCall: CostFunction1[Text] =
+      CostFunction1.Null
     override val BSECP256K1Bool: CostFunction3[Text, Text, Text] =
       CostFunction3.Constant(SBoolSize)
     override val BSECP256K1WithEcdsaBool: CostFunction3[Text, Text, Text] =

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PartialTransaction.scala
@@ -5,12 +5,13 @@ package com.digitalasset.daml.lf
 package speedy
 
 import com.digitalasset.daml.lf.data.Ref.{ChoiceName, Location, PackageName, Party, TypeConId}
-import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Time}
+import com.digitalasset.daml.lf.data.{BackStack, Bytes, ImmArray, Time}
 import com.digitalasset.daml.lf.ledger.Authorize
 import com.digitalasset.daml.lf.interpretation.{Error => IErr}
 import com.digitalasset.daml.lf.speedy.Speedy.{CachedKey, ContractInfo}
 import com.digitalasset.daml.lf.transaction.{
   NextGenContractStateMachine => ContractStateMachine,
+  ExternalCallResult,
   GlobalKeyWithMaintainers,
   KeyMapping,
   Node,
@@ -197,6 +198,7 @@ private[lf] object PartialTransaction {
     contractState = ContractStateMachine.empty(csmMode),
     actionNodeLocations = BackStack.empty,
     authorizationChecker = authorizationChecker,
+    externalCallResults = HashMap.empty,
   )
 
   type NodeSeeds = ImmArray[(NodeId, crypto.Hash)]
@@ -222,6 +224,7 @@ private[speedy] case class PartialTransaction(
     contractState: CSMState,
     actionNodeLocations: BackStack[Option[Location]],
     authorizationChecker: AuthorizationChecker,
+    externalCallResults: HashMap[NodeId, BackStack[ExternalCallResult]],
 ) {
 
   import PartialTransaction._
@@ -606,6 +609,12 @@ private[speedy] case class PartialTransaction(
     }
 
   private[this] def makeExNode(ec: ExercisesContextInfo): Node.Exercise = {
+    val recordedExternalCallResults =
+      externalCallResults.getOrElse(ec.nodeId, BackStack.empty).toImmArray
+    val version =
+      if (recordedExternalCallResults.isEmpty) ec.version
+      else ec.version max SerializationVersion.minExternalCallResults
+
     Node.Exercise(
       targetCoid = ec.targetId,
       packageName = ec.packageName,
@@ -622,10 +631,53 @@ private[speedy] case class PartialTransaction(
       children = ImmArray.Empty,
       exerciseResult = None,
       keyOpt = ec.contractKey,
-      byKey = normByKey(ec.version, ec.byKey),
-      externalCallResults = ImmArray.empty,
-      version = ec.version,
+      byKey = normByKey(version, ec.byKey),
+      externalCallResults = recordedExternalCallResults,
+      version = version,
     )
+  }
+
+  /** Record an external call result in the nearest enclosing exercise context.
+    * Walks up through try/catch scopes and returns None only when not inside any
+    * exercise context.
+    */
+  def canRecordExternalCallResult: Boolean =
+    findEnclosingExercise(context.info).nonEmpty
+
+  def recordExternalCallResult(
+      extensionId: String,
+      functionId: String,
+      config: Bytes,
+      input: Bytes,
+      output: Bytes,
+  ): Option[PartialTransaction] = {
+    findEnclosingExercise(context.info) match {
+      case Some(ec) =>
+        val nodeId = ec.nodeId
+        val existing = externalCallResults.getOrElse(nodeId, BackStack.empty)
+        val result = ExternalCallResult(
+          extensionId = extensionId,
+          functionId = functionId,
+          config = config,
+          input = input,
+          output = output,
+        )
+        val updated = existing :+ result
+        Some(copy(externalCallResults = externalCallResults.updated(nodeId, updated)))
+      case _ =>
+        // External calls outside of exercise context are not stored
+        // (they would be at the root level, which is not supported)
+        None
+    }
+  }
+
+  @scala.annotation.tailrec
+  private def findEnclosingExercise(info: ContextInfo): Option[ExercisesContextInfo] = {
+    info match {
+      case ec: ExercisesContextInfo => Some(ec)
+      case tc: TryContextInfo => findEnclosingExercise(tc.parent.info)
+      case _: RootContextInfo => None
+    }
   }
 
   /** Open a Try context.

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltinFun.scala
@@ -910,6 +910,79 @@ private[lf] object SBuiltinFun {
     }
   }
 
+  final case object SBExternalCall extends UpdateBuiltin(5) {
+    override protected def executeUpdate(
+        args: ArraySeq[SValue],
+        machine: UpdateMachine,
+    ): Control[Question.Update] = {
+      val extensionId = getSText(args, 0)
+      val functionId = getSText(args, 1)
+      val configHex = getSText(args, 2)
+      val inputHex = getSText(args, 3)
+      checkToken(args, 4)
+
+      machine.updateGasBudget(_.BExternalCall.cost(functionId))
+
+      // Validate hex encoding before making the external call
+      (Bytes.fromString(configHex), Bytes.fromString(inputHex)) match {
+        case (Right(config), Right(input)) =>
+          if (!machine.ptx.canRecordExternalCallResult) {
+            Control.Error(IE.UserError(
+              s"External calls are only supported within exercise context. " +
+                s"extensionId=$extensionId, functionId=$functionId"
+            ))
+          } else {
+            // Ask the host for the external-call result.
+            machine.needExternalCall(
+              extensionId = extensionId,
+              functionId = functionId,
+              configHash = configHex,
+              input = inputHex,
+            ) {
+              case Right(responseBodyRaw) =>
+                Bytes.fromString(responseBodyRaw) match {
+                  case Right(output) =>
+                    // The external-call question is only issued after confirming that the
+                    // current partial transaction can record a result, so resuming here must
+                    // still be inside an enclosing exercise context.
+                    val updatedPtx = machine.ptx.recordExternalCallResult(
+                      extensionId = extensionId,
+                      functionId = functionId,
+                      config = config,
+                      input = input,
+                      output = output,
+                    ).getOrElse(
+                      InternalError.runtimeException(
+                        NameOf.qualifiedNameOfCurrentFunc,
+                        s"lost enclosing exercise context while resuming external call " +
+                          s"(extensionId=$extensionId, functionId=$functionId)",
+                      )
+                    )
+                    machine.ptx = updatedPtx
+                    Control.Value(SText(responseBodyRaw))
+                  case Left(_) =>
+                    Control.Error(
+                      IE.UserError(
+                        "Invalid external call output: expected canonical lowercase hex"
+                      )
+                    )
+                }
+              case Left(error) =>
+                val errorMsg = s"External call failed: ${error.message}" +
+                  s" (extensionId=$extensionId, functionId=$functionId)"
+                Control.Error(IE.UserError(errorMsg))
+            }
+          }
+        case _ =>
+          Control.Error(
+            IE.UserError(
+              "Invalid external call config or input: expected canonical lowercase hex"
+            )
+          )
+      }
+    }
+  }
+
   final case object SBFoldl extends SBuiltinFun(3) {
     override private[speedy] def execute[Q](
         args: ArraySeq[SValue],

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -48,6 +48,28 @@ object Question {
         committers: Set[Party],
         callback: (Vector[FatContractInstance], NeedKeyProgression.HasStarted) => Unit,
     ) extends Update
+
+    /** Update interpretation requires an external-call result from the host.
+      * The engine suspends until the host resumes the request.
+      * The request fields use canonical lowercase hexadecimal encoding. To resume a successful
+      * external call, the host must provide the output using the same canonical encoding.
+      *
+      * @param extensionId Identifier of the configured extension
+      * @param functionId Function identifier within the extension
+      * @param configHash Configuration hash as canonical lowercase hex for version validation
+      * @param input Input data as canonical lowercase hex
+      * @param callback Callback to provide the result or error
+      */
+    final case class NeedExternalCall(
+        extensionId: String,
+        functionId: String,
+        configHash: String,
+        input: String,
+        callback: Either[ExternalCallError, String] => Unit,
+    ) extends Update
+
+    /** Error information from external call failures */
+    final case class ExternalCallError(message: String)
   }
 }
 

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -364,6 +364,29 @@ private[lf] object Speedy {
           )
       )
 
+    final private[speedy] def needExternalCall(
+        extensionId: String,
+        functionId: String,
+        configHash: String,
+        input: String,
+    )(
+        continue: Either[Question.Update.ExternalCallError, String] => Control[Question.Update]
+    ): Control.Question[Question.Update] =
+      Control.Question(
+        Question.Update.NeedExternalCall(
+          extensionId = extensionId,
+          functionId = functionId,
+          configHash = configHash,
+          input = input,
+          callback = result =>
+            safelyContinue(
+              NameOf.qualifiedNameOfCurrentFunc,
+              "NeedExternalCall",
+              continue(result),
+            ),
+        )
+      )
+
     private[speedy] def lookupContract(coid: V.ContractId)(
         f: (FatContractInstance, Hash.HashingMethod, Hash => Boolean) => Control[Question.Update]
     ): Control[Question.Update] =

--- a/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/compiler/PhaseOne.scala
+++ b/community/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/compiler/PhaseOne.scala
@@ -386,11 +386,6 @@ private[lf] final class PhaseOne(
       case BCoerceContractId => compileIdentity(env)
       case BTextMapEmpty => SEValue.EmptyTextMap
       case BGenMapEmpty => SEValue.EmptyGenMap
-      // BExternalCall exists in LF, but not in the interpreter yet.
-      // TODO(#513): Replace this fail-fast once external-call execution support is added.
-      // Keep this match exhaustive until execution support is added.
-      case BExternalCall =>
-        throw CompilationError("EXTERNAL_CALL is not yet supported by the interpreter")
 
       case _ =>
         SEBuiltin(bf match {
@@ -450,6 +445,9 @@ private[lf] final class PhaseOne(
           case BSECP256K1WithEcdsaBool => SBSECP256K1WithEcdsaBool
           case BSECP256K1ValidateKey => SBSECP256K1ValidateKey
 
+          // External call
+          case BExternalCall => SBExternalCall
+
           // TextMap
 
           case BTextMapInsert => SBMapInsert
@@ -500,7 +498,7 @@ private[lf] final class PhaseOne(
           case BTypeRepTyConName => SBTypeRepTyConName
 
           // Implemented using SExpr
-          case BCoerceContractId | BTextMapEmpty | BGenMapEmpty | BExternalCall =>
+          case BCoerceContractId | BTextMapEmpty | BGenMapEmpty =>
             throw CompilationError(s"unexpected $bf")
 
           case BAnyExceptionMessage => SBAnyExceptionMessage

--- a/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
+++ b/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
@@ -1,0 +1,489 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf
+package speedy
+
+import com.daml.scalautil.Statement.discard
+import com.digitalasset.canton.logging.SuppressingLogging
+import com.digitalasset.daml.lf.data.{Bytes, ImmArray, Ref}
+import com.digitalasset.daml.lf.interpretation.{Error => IE}
+import com.digitalasset.daml.lf.language.LanguageVersion
+import com.digitalasset.daml.lf.speedy.SExpr.{SEApp, SExpr}
+import com.digitalasset.daml.lf.speedy.SValue.{SParty, SText}
+import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
+import com.digitalasset.daml.lf.testing.parser.ParserParameters
+import com.digitalasset.daml.lf.transaction.{ExternalCallResult, Node, SerializationVersion}
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.ArraySeq
+
+class ExternalCallTest extends AnyWordSpec with Matchers with Inside with SuppressingLogging {
+
+  private val alice = Ref.Party.assertFromString("Alice")
+  private val transactionSeed = crypto.Hash.hashPrivateKey("ExternalCallTest.scala")
+
+  implicit private val parserParameters: ParserParameters[this.type] =
+    ParserParameters(
+      defaultPackageId = Ref.PackageId.assertFromString("-pkg-"),
+      languageVersion = LanguageVersion.v2_dev,
+    )
+
+  private val pkgs = SpeedyTestLib.typeAndCompile(p"""
+    metadata ( '-pkg-' : '1.0.0' )
+
+    module M {
+      record @serializable T = { party: Party };
+      record @serializable Boom = {};
+      exception Boom = { message \(e: M:Boom) -> "Boom" };
+
+      template (this: T) = {
+        precondition True;
+        signatories Cons @Party [M:T {party} this] (Nil @Party);
+        observers Nil @Party;
+
+        choice Call (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
+
+        choice CallBadConfig (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "zzzz" "c0ff";
+
+        choice CallBadInput (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "nope";
+
+        choice CallUppercaseConfig (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0A0B" "c0ff";
+
+        choice CallUppercaseInput (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "C0FF";
+
+        choice CallPaddedConfig (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" " 0a0b" "c0ff";
+
+        choice CallPaddedInput (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff ";
+
+        choice CallInTry (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to try @Text
+            (EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff")
+          catch e -> Some @(Update Text) (upure @Text "fallback");
+
+        choice CallInTryRollback (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to try @Text
+            ubind result: Text <- EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff"
+            in throw @(Update Text) @M:Boom (M:Boom {})
+          catch e -> Some @(Update Text) (upure @Text "fallback");
+
+      };
+
+      val run : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T Call cid ();
+
+      val runBadConfig : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallBadConfig cid ();
+
+      val runBadInput : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallBadInput cid ();
+
+      val runUppercaseConfig : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallUppercaseConfig cid ();
+
+      val runUppercaseInput : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallUppercaseInput cid ();
+
+      val runPaddedConfig : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallPaddedConfig cid ();
+
+      val runPaddedInput : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallPaddedInput cid ();
+
+      val runInTry : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallInTry cid ();
+
+      val runInTryRollback : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallInTryRollback cid ();
+
+      val runAtRoot : Update Text =
+        EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
+    }
+  """)
+
+  private def machineForRun(run: SExpr): Speedy.UpdateMachine =
+    Speedy.Machine.fromUpdateSExpr(
+      pkgs,
+      transactionSeed,
+      SEApp(run, ArraySeq(SParty(alice))),
+      Set(alice),
+      MachineLogger(),
+    )
+
+  private def rejectConfigOrInputBeforeExternalCall(run: SExpr): Unit = {
+    val machine = machineForRun(run)
+    var questions = 0
+    val result = SpeedyTestLib.runTxQ[Question.Update](
+      {
+        case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+          questions += 1
+          callback(Right("beef"))
+        case other =>
+          fail(s"Unexpected question: $other")
+      },
+      machine,
+    )
+
+    questions shouldBe 0
+    discard(
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("Invalid external call config or input")
+        message should include("expected canonical lowercase hex")
+      }
+    )
+  }
+
+  "SBExternalCall" should {
+    "resume through NeedExternalCall and record the result on the exercise node" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:run"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+            questions += 1
+            extensionId shouldBe "ext"
+            functionId shouldBe "fun"
+            configHash shouldBe "0a0b"
+            input shouldBe "c0ff"
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      result shouldBe Right(SText("beef"))
+      questions shouldBe 1
+
+      inside(machine.finish) { case Right(commit) =>
+        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+        exerciseNodes should have size 1
+        exerciseNodes.head.version shouldBe SerializationVersion.minExternalCallResults
+        exerciseNodes.head.externalCallResults shouldBe ImmArray(
+          ExternalCallResult(
+            extensionId = "ext",
+            functionId = "fun",
+            config = Bytes.assertFromString("0a0b"),
+            input = Bytes.assertFromString("c0ff"),
+            output = Bytes.assertFromString("beef"),
+          )
+        )
+      }
+    }
+
+    "record the result on the enclosing exercise node when called inside try/catch" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:runInTry"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+            questions += 1
+            extensionId shouldBe "ext"
+            functionId shouldBe "fun"
+            configHash shouldBe "0a0b"
+            input shouldBe "c0ff"
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      result shouldBe Right(SText("beef"))
+      questions shouldBe 1
+
+      inside(machine.finish) { case Right(commit) =>
+        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+        exerciseNodes should have size 1
+        exerciseNodes.head.externalCallResults shouldBe ImmArray(
+          ExternalCallResult(
+            extensionId = "ext",
+            functionId = "fun",
+            config = Bytes.assertFromString("0a0b"),
+            input = Bytes.assertFromString("c0ff"),
+            output = Bytes.assertFromString("beef"),
+          )
+        )
+      }
+    }
+
+    "record the result on the enclosing exercise node when try/catch rolls back" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:runInTryRollback"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+            questions += 1
+            extensionId shouldBe "ext"
+            functionId shouldBe "fun"
+            configHash shouldBe "0a0b"
+            input shouldBe "c0ff"
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      result shouldBe Right(SText("fallback"))
+      questions shouldBe 1
+
+      inside(machine.finish) { case Right(commit) =>
+        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+        exerciseNodes should have size 1
+        exerciseNodes.head.externalCallResults shouldBe ImmArray(
+          ExternalCallResult(
+            extensionId = "ext",
+            functionId = "fun",
+            config = Bytes.assertFromString("0a0b"),
+            input = Bytes.assertFromString("c0ff"),
+            output = Bytes.assertFromString("beef"),
+          )
+        )
+      }
+    }
+
+    "reject non-hex external call outputs" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:run"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            callback(Right("hello"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("Invalid external call output")
+        message should include("expected canonical lowercase hex")
+      }
+    }
+
+    "reject non-canonical external call outputs" in {
+      Seq("BEEF", "beef ").foreach { output =>
+        withClue(s"output=$output") {
+          val machine = machineForRun(pkgs.compiler.unsafeCompile(e"M:run"))
+          val result = SpeedyTestLib.runTxQ[Question.Update](
+            {
+              case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+                callback(Right(output))
+              case other =>
+                fail(s"Unexpected question: $other")
+            },
+            machine,
+          )
+
+          inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+            message should include("Invalid external call output")
+            message should include("expected canonical lowercase hex")
+          }
+        }
+      }
+    }
+
+    "reject malformed config hex before issuing NeedExternalCall" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:runBadConfig"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            questions += 1
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      questions shouldBe 0
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("Invalid external call config or input")
+        message should include("expected canonical lowercase hex")
+      }
+    }
+
+    "reject malformed input hex before issuing NeedExternalCall" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:runBadInput"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            questions += 1
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      questions shouldBe 0
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("Invalid external call config or input")
+        message should include("expected canonical lowercase hex")
+      }
+    }
+
+    "reject non-canonical config and input hex before issuing NeedExternalCall" in {
+      Seq(
+        "uppercase config" -> pkgs.compiler.unsafeCompile(e"M:runUppercaseConfig"),
+        "padded config" -> pkgs.compiler.unsafeCompile(e"M:runPaddedConfig"),
+        "uppercase input" -> pkgs.compiler.unsafeCompile(e"M:runUppercaseInput"),
+        "padded input" -> pkgs.compiler.unsafeCompile(e"M:runPaddedInput"),
+      ).foreach { case (label, run) =>
+        withClue(label) {
+          rejectConfigOrInputBeforeExternalCall(run)
+        }
+      }
+    }
+
+    "surface external call failures and not record a result" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:run"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            callback(Left(Question.Update.ExternalCallError("upstream unavailable")))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("External call failed: upstream unavailable")
+        message should include("extensionId=ext")
+        message should include("functionId=fun")
+      }
+      machine.ptx.externalCallResults shouldBe empty
+    }
+
+    "treat external call failures as uncatchable inside try/catch" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        SEApp(pkgs.compiler.unsafeCompile(e"M:runInTry"), ArraySeq(SParty(alice))),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            callback(Left(Question.Update.ExternalCallError("upstream unavailable")))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("External call failed: upstream unavailable")
+      }
+      machine.ptx.externalCallResults shouldBe empty
+    }
+
+    "reject root-level external calls before issuing NeedExternalCall" in {
+      val machine = Speedy.Machine.fromUpdateSExpr(
+        pkgs,
+        transactionSeed,
+        pkgs.compiler.unsafeCompile(e"M:runAtRoot"),
+        Set(alice),
+        MachineLogger(),
+      )
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update.NeedExternalCall(_, _, _, _, callback) =>
+            questions += 1
+            callback(Right("beef"))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      questions shouldBe 0
+      inside(result) { case Left(SError.SErrorDamlException(IE.UserError(message))) =>
+        message should include("External calls are only supported within exercise context")
+      }
+    }
+  }
+}

--- a/community/daml-lf/spec/daml-lf-2.rst
+++ b/community/daml-lf/spec/daml-lf-2.rst
@@ -4687,11 +4687,17 @@ External call functions
 
 * ``EXTERNAL_CALL : 'Text' → 'Text' → 'Text' → 'Text' → 'Update' 'Text'``
 
-  Represents an external call request in LF. The first argument is the extension
-  identifier, the second argument is the function identifier, the third argument
-  is the hexadecimal-encoded configuration hash, and the fourth argument is the
-  hexadecimal-encoded input payload. The update result carries the
-  hexadecimal-encoded output payload.
+  Requests an external call. The first argument is the extension identifier, the
+  second argument is the function identifier, the third argument is the
+  canonical lowercase hexadecimal-encoded configuration hash, and the fourth
+  argument is the canonical lowercase hexadecimal-encoded input payload. The
+  result is the canonical lowercase hexadecimal-encoded output payload.
+  Successful evaluation requires an enclosing exercise context, and records the
+  external call result on the nearest enclosing exercise node.
+  Evaluation fails with a runtime error if no enclosing exercise context
+  exists, if the configuration hash, input payload, or output payload is
+  malformed or non-canonical hexadecimal, or if the external call cannot be
+  completed successfully.
 
   [*Available in version >= 2.dev*]
 

--- a/community/daml-lf/transaction-tests/src/test/scala/com/digitalasset/daml/lf/crypto/NodeHashV1Spec.scala
+++ b/community/daml-lf/transaction-tests/src/test/scala/com/digitalasset/daml/lf/crypto/NodeHashV1Spec.scala
@@ -518,6 +518,24 @@ class NodeHashV1Spec extends AnyWordSpec with Matchers with HashUtils {
       ) shouldBe defaultHash
     }
 
+    "not include external call results" in {
+      a[NodeHashingError.UnsupportedFeature] shouldBe thrownBy(
+        hashExerciseNode(
+          exerciseNode.copy(externalCallResults =
+            ImmArray(
+              ExternalCallResult(
+                extensionId = "ext",
+                functionId = "fun",
+                config = Bytes.assertFromString("0a0b"),
+                input = Bytes.assertFromString("c0ff"),
+                output = Bytes.assertFromString("beef"),
+              )
+            )
+          )
+        )
+      )
+    }
+
     "throw if some nodes are missing" in {
       an[IncompleteTransactionTree] shouldBe thrownBy {
         hashExerciseNode(exerciseNode, subNodes = Map.empty)

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -476,15 +476,15 @@ object Hash {
             exerciseResult,
             keyOpt,
             byKey,
-            // TODO(https://github.com/digital-asset/canton/issues/513)
-            // handle external calls
-            _,
+            externalCallResults,
             version,
           ) =>
         if (choiceAuthorizers.nonEmpty)
           notSupported("choiceAuthorizers in Exercise node") // 2.dev feature
         if (keyOpt.nonEmpty) notSupported("keyOpt in Exercise node") // 2.dev feature
         if (byKey == true) notSupported("byKey in Exercise node") // 2.dev feature
+        if (externalCallResults.nonEmpty)
+          notSupported("externalCallResults in Exercise node") // 2.dev feature
         addContext("Exercise Node")
           .withContext("Node Version")(_.addString(SerializationVersion.toProtoValue(version)))
           .addByte(NodeBuilder.NodeTag.ExerciseTag.tag, "Node Tag")

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/data/CostModel.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/data/CostModel.scala
@@ -9,6 +9,7 @@ import com.digitalasset.daml.lf.command.ApiContractKey
 import com.digitalasset.daml.lf.{transaction => tx}
 import com.digitalasset.daml.lf.transaction.{
   CreationTime,
+  ExternalCallResult,
   FatContractInstance,
   FatContractInstanceImpl,
   GlobalKey,
@@ -95,6 +96,8 @@ private[lf] object CostModel {
     implicit def costOfNodeId(value: tx.NodeId): Cost
 
     implicit def costOfTxNode(value: tx.Node): Cost
+
+    implicit def costOfExternalCallResult(value: ExternalCallResult): Cost
   }
 
   object EmptyCostModelImplicits extends CostModelImplicits {
@@ -168,6 +171,8 @@ private[lf] object CostModel {
     implicit def costOfNodeId(value: tx.NodeId): Cost = 0L
 
     implicit def costOfTxNode(value: tx.Node): Cost = 0L
+
+    implicit def costOfExternalCallResult(value: ExternalCallResult): Cost = 0L
   }
 
   object StructuralCostModelImplicits extends CostModelImplicits {
@@ -410,7 +415,7 @@ private[lf] object CostModel {
             exerciseResult,
             keyOpt,
             byKey,
-            _,
+            externalCallResults,
             version,
           ) =>
         1 + costOfContractId(targetCoid) +
@@ -429,9 +434,17 @@ private[lf] object CostModel {
           costOfOption(exerciseResult) +
           costOfOption(keyOpt) +
           costOfBoolean(byKey) +
+          costOfImmArray(externalCallResults) +
           costOfSerializationVersion(version)
       case Node.Rollback(children) =>
         1 + costOfImmArray(children)
     }
+
+    implicit def costOfExternalCallResult(value: ExternalCallResult): Cost =
+      1 + costOfString(value.extensionId) +
+        costOfString(value.functionId) +
+        costOfBytes(value.config) +
+        costOfBytes(value.input) +
+        costOfBytes(value.output)
   }
 }

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreter.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreter.scala
@@ -442,6 +442,24 @@ final class StoreBackedCommandInterpreter(
           FutureUnlessShutdown
             .outcomeF(loadContractsF)
             .flatMap(_ => resolveStep(resume()))
+
+        // TODO(https://github.com/digital-asset/canton/issues/513): Replace this fail-fast once command submission is wired to external calls.
+        case ResultNeedExternalCall(extensionId, functionId, _, _, _) =>
+          FutureUnlessShutdown.pure(
+            Left(
+              ErrorCause.DamlLf(
+                Error.Interpretation(
+                  Error.Interpretation.Internal(
+                    "StoreBackedCommandInterpreter",
+                    s"External calls are not supported during ledger-api command submission " +
+                      s"(extensionId=$extensionId, functionId=$functionId)",
+                    None,
+                  ),
+                  None,
+                )
+              )
+            )
+          )
       }
 
     resolveStep(result).thereafter { _ =>

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/dao/events/LfValueTranslation.scala
@@ -546,6 +546,11 @@ final class LfValueTranslation(
 
           case LfEngine.ResultPrefetch(_, _, resume) =>
             goAsync(resume())
+
+          case LfEngine.ResultNeedExternalCall(_, _, _, _, _) =>
+            Future.failed(
+              new IllegalStateException("External calls are not supported during view computation")
+            )
         }
 
       Future(engine.computeInterfaceView(templateId, value, interfaceId))

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -390,6 +390,22 @@ class DAMLe(
         case ResultPrefetch(_, _, resume) =>
           // we do not need to prefetch here as Canton includes the keys as a static map in Phase 3
           handleResultInternal(resume())
+        // TODO(https://github.com/digital-asset/canton/issues/513): Replay or validate recorded external-call results during reinterpretation.
+        case ResultNeedExternalCall(_, _, _, _, _) =>
+          FutureUnlessShutdown.pure(
+            Left(
+              EngineError(
+                Error.Interpretation(
+                  Error.Interpretation.Internal(
+                    "reinterpretation",
+                    "External calls are not supported during reinterpretation",
+                    None,
+                  ),
+                  None,
+                )
+              )
+            )
+          )
       }
     }
 


### PR DESCRIPTION
## Summary

This PR implements the Daml engine and Speedy interpreter support for external calls. It introduces the "question/answer" pattern that allows the interpreter to suspend execution, request external data, and resume with the result.

Requires https://github.com/digital-asset/canton/pull/438.

## Changes

### Engine Results (`Result.scala`)

Added new result type for external call requests:

```scala
final case class ResultNeedExternalCall(
    extensionId: String,
    functionId: String,
    config: Bytes,
    input: Bytes,
    resume: Bytes => Result[SubmittedTransaction]
) extends Result[SubmittedTransaction]
```

### Speedy Results (`SResult.scala`)

Added Speedy-level result:

```scala
final case class SResultNeedExternalCall(
    extensionId: String,
    functionId: String,
    config: Bytes,
    input: Bytes
) extends SResult
```

### Builtin Implementation (`SBuiltinFun.scala`)

```scala
final case object SBExternalCall extends SBuiltinFun {
  override def execute(args: util.ArrayList[SValue], machine: Machine): SResult = {
    val extensionId = args.get(0).asInstanceOf[SText].value
    val functionId = args.get(1).asInstanceOf[SText].value
    val config = decodeHex(args.get(2).asInstanceOf[SText].value)
    val input = decodeHex(args.get(3).asInstanceOf[SText].value)

    SResultNeedExternalCall(extensionId, functionId, config, input)
  }
}
```

### Partial Transaction (`PartialTransaction.scala`)

- Added `externalCallResults` accumulator to exercise context
- Results are collected as external calls complete
- Final results stored in Exercise node

### Compiler (`PhaseOne.scala`)

- Added compilation case for `BEExternalCall` → `SBExternalCall`

### Cost Model (`CostModel.scala`)

- Added cost accounting for external call operations

### Engine (`Engine.scala`)

- Added handling for `SResultNeedExternalCall`
- Converts to `ResultNeedExternalCall` with resume continuation

### Enricher (`Enricher.scala`)

- Added enrichment support for external call results

## Execution Flow

```
1. Contract calls externalCall(...)
2. Speedy evaluates SBExternalCall
3. Returns SResultNeedExternalCall (suspends)
4. Engine converts to ResultNeedExternalCall
5. Canton handles HTTP call (or replays stored result)
6. Engine resumes with result
7. Result stored in PartialTransaction
8. Final Exercise node includes all results
```

## Validation Mode

During validation (observer/confirmer):
- Engine receives pre-recorded results
- SBExternalCall returns immediately with stored result
- No HTTP calls made
- Results verified against stored values

## Testing

- `NormalizeRollbacksSpec.scala` - Rollback handling with external calls
- `NodeHashV1Spec.scala` - Hash computation includes external calls
