### PR TITLE
topology_util.sh: Fix for xxd versions before 2022-01-14

### DIFF
--- a/community/app/src/pack/scripts/topology/topology_util.sh
+++ b/community/app/src/pack/scripts/topology/topology_util.sh
@@ -25,7 +25,9 @@ decode_from_base64() {
 
 # Encode bytes read from stdin to hexadecimal
 encode_to_hex() {
-  xxd -ps -c 0
+  local hex; hex=$(xxd -ps -c 0)
+  hex="${hex//$'\n'/}"  # Remove newlines for xxd < 2022-01-14, see https://github.com/vim/vim/commit/c0a1d370fa655cea9eaa74f5e605b95825dc9de1
+  echo "$hex"
 }
 # [end byte utility functions]
 


### PR DESCRIPTION
Before 2022-01-14 xxd was adding new lines for every 30 columns with `-ps -c 0` flags. See
https://github.com/vim/vim/commit/c0a1d370fa655cea9eaa74f5e605b95825dc9de1

Before 2022-01-14:
```
echo test{1..10} | xxd -ps -c0
746573743120746573743220746573743320746573743420746573743520
746573743620746573743720746573743820746573743920746573743130
0a
```

Starting from 2022-01-14 and with the fix:
```
echo test{1..10} | xxd -ps -c0
7465737431207465737432207465737433207465737434207465737435207465737436207465737437207465737438207465737439207465737431300a
```