### PR TITLE
feat(external-call): add extension service client support

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/config/ExtensionServiceConfig.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/config/ExtensionServiceConfig.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.config
+
+import com.daml.tls.TlsClientConfigOnlyTrustFile
+import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port}
+import com.digitalasset.canton.config.{NonNegativeFiniteDuration, PositiveFiniteDuration}
+
+/** Configuration for a single engine extension service.
+  *
+  * Extension services allow Daml contracts to make external calls to deterministic services. The
+  * participant manages connection pooling and HTTP calls on behalf of the engine.
+  *
+  * @param address
+  *   Hostname of the extension service
+  * @param port
+  *   Port of the extension service
+  * @param version
+  *   API version path segment exposed by the extension service
+  * @param tls
+  *   Optional TLS configuration for the connection.
+  * @param auth
+  *   Authentication configuration for outbound calls to the extension service
+  * @param connectTimeout
+  *   Connection timeout
+  * @param requestTimeout
+  *   Request timeout for individual HTTP requests
+  * @param maxRetries
+  *   Maximum number of retry attempts
+  * @param retryInitialDelay
+  *   Initial delay before first retry
+  * @param retryMaxDelay
+  *   Maximum delay between retries
+  * @param validateOnStartup
+  *   Whether participant startup should validate that the configured extension service endpoint is
+  *   reachable.
+  */
+final case class ExtensionServiceConfig(
+    address: String,
+    port: Port,
+    version: String = "v1",
+    tls: Option[TlsClientConfigOnlyTrustFile] = None,
+    auth: ExtensionServiceAuthConfig = ExtensionServiceAuthConfig.None,
+    connectTimeout: PositiveFiniteDuration = PositiveFiniteDuration.ofMillis(500),
+    requestTimeout: PositiveFiniteDuration = PositiveFiniteDuration.ofSeconds(8),
+    maxRetries: NonNegativeInt = NonNegativeInt.tryCreate(3),
+    retryInitialDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofMillis(1000),
+    retryMaxDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(10),
+    validateOnStartup: Boolean = false,
+)
+
+/** Authentication configuration for outbound calls to an extension service. */
+sealed trait ExtensionServiceAuthConfig extends Product with Serializable
+
+object ExtensionServiceAuthConfig {
+
+  /** [default] Send no authorization header. */
+  case object None extends ExtensionServiceAuthConfig
+
+  /** Send the configured file contents as an HTTP bearer token. */
+  final case class BearerTokenFile(tokenFile: ExistingFile) extends ExtensionServiceAuthConfig
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/config/ExtensionServiceConfig.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/config/ExtensionServiceConfig.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.participant.config
 
 import com.daml.tls.TlsClientConfigOnlyTrustFile
-import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port}
+import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port, PositiveInt}
 import com.digitalasset.canton.config.{NonNegativeFiniteDuration, PositiveFiniteDuration}
 
 /** Configuration for a single engine extension service.
@@ -35,6 +35,8 @@ import com.digitalasset.canton.config.{NonNegativeFiniteDuration, PositiveFinite
   * @param validateOnStartup
   *   Whether participant startup should validate that the configured extension service endpoint is
   *   reachable.
+  * @param maxResponseBodyBytes
+  *   Maximum HTTP response body size accepted from the extension service.
   */
 final case class ExtensionServiceConfig(
     address: String,
@@ -48,7 +50,12 @@ final case class ExtensionServiceConfig(
     retryInitialDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofMillis(1000),
     retryMaxDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(10),
     validateOnStartup: Boolean = false,
+    maxResponseBodyBytes: PositiveInt = ExtensionServiceConfig.DefaultMaxResponseBodyBytes,
 )
+
+object ExtensionServiceConfig {
+  val DefaultMaxResponseBodyBytes: PositiveInt = PositiveInt.tryCreate(20 * 1024 * 1024)
+}
 
 /** Authentication configuration for outbound calls to an extension service. */
 sealed trait ExtensionServiceAuthConfig extends Product with Serializable

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.tracing.TraceContext
+
+/** Error information from external call failures. */
+final case class ExtensionCallError(
+    statusCode: Int,
+    message: String,
+    requestId: Option[String],
+    retryable: Boolean,
+)
+
+/** Result of validating an extension service at startup. */
+sealed trait ExtensionValidationResult extends Product with Serializable
+
+object ExtensionValidationResult {
+  case object Valid extends ExtensionValidationResult
+
+  final case class Invalid(errors: Seq[String]) extends ExtensionValidationResult
+}
+
+/** Execution modes Canton currently emits for external calls. */
+sealed abstract class ExternalCallMode(val headerValue: String) extends Product with Serializable
+
+object ExternalCallMode {
+  case object Submission extends ExternalCallMode("submission")
+  case object Validation extends ExternalCallMode("validation")
+}
+
+/** Trait for extension service clients.
+  *
+  * Each configured extension service has its own client that handles HTTP communication with
+  * connection pooling managed at the participant level.
+  */
+trait ExtensionServiceClient {
+
+  /** The extension identifier (from Canton config) */
+  def extensionId: String
+
+  /** Make an external call to the extension service.
+    *
+    * @param functionId
+    *   Function identifier within the extension
+    * @param configHash
+    *   Configuration hash (hex) for version validation
+    * @param input
+    *   Input data (hex)
+    * @param mode
+    *   Execution mode
+    * @return
+    *   Either an error or the response body (hex)
+    */
+  def call(
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]]
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.config.{PemFileOrString, ProcessingTimeout}
+import com.digitalasset.canton.http.HttpService
+import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown}
+import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.participant.config.ExtensionServiceConfig
+import com.digitalasset.canton.tracing.TraceContext
+
+import java.net.http.HttpClient
+import java.security.cert.CertificateFactory
+import java.security.KeyStore
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
+
+/** Manages extension service connections with per-extension pooled HTTP clients.
+  *
+  * This manager is responsible for:
+  *   - Creating and managing per-extension HTTP clients with connection pooling
+  *   - Dispatching external call requests to the appropriate extension service
+  *
+  * @param extensionConfigs
+  *   Map of extension ID to configuration
+  * @param loggerFactory
+  *   Logger factory
+  * @param timeouts
+  *   Processing timeouts used for lifecycle synchronization
+  * @param ec
+  *   Execution context
+  */
+class ExtensionServiceManager(
+    extensionConfigs: Map[String, ExtensionServiceConfig],
+    override protected val loggerFactory: NamedLoggerFactory,
+    override protected val timeouts: ProcessingTimeout,
+)(implicit ec: ExecutionContext)
+    extends NamedLogging
+    with FlagCloseable {
+
+  // Extension clients by ID
+  private val clients: Map[String, HttpExtensionServiceClient] =
+    extensionConfigs.map { case (id, config) =>
+      id -> new HttpExtensionServiceClient(
+        id,
+        config,
+        ExtensionServiceManager.createHttpClient(config),
+        this,
+        loggerFactory,
+      )
+    }
+
+  /** Get a client for the specified extension.
+    *
+    * @param extensionId
+    *   The extension identifier
+    * @return
+    *   Some(client) if configured, None otherwise
+    */
+  def getClient(extensionId: String): Option[ExtensionServiceClient] =
+    clients.get(extensionId)
+
+  /** Handle an external call question from the engine.
+    *
+    * This is the main entry point for external calls from the Daml engine.
+    *
+    * @param extensionId
+    *   The extension identifier
+    * @param functionId
+    *   Function identifier within the extension
+    * @param configHash
+    *   Configuration hash (hex) for version validation
+    * @param input
+    *   Input data (hex)
+    * @param mode
+    *   Execution mode
+    * @return
+    *   Either an error or the response body (hex)
+    */
+  def handleExternalCall(
+      extensionId: String,
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] =
+    clients.get(extensionId) match {
+      case Some(client) =>
+        client.call(functionId, configHash, input, mode)
+      case None =>
+        FutureUnlessShutdown.pure(
+          Left(
+            ExtensionCallError(
+              statusCode = 404,
+              message = s"Extension '$extensionId' not configured",
+              requestId = None,
+              retryable = false,
+            )
+          )
+        )
+    }
+
+  def initializeOnStartup()(implicit
+      tc: TraceContext
+  ): FutureUnlessShutdown[Either[String, Unit]] = {
+    val localPreflightErrors =
+      clients.toSeq.flatMap { case (id, client) =>
+        client.startupLocalPreflight().left.toOption.map(error => s"Extension '$id': $error")
+      }
+
+    if (localPreflightErrors.nonEmpty) {
+      val message =
+        s"Extension startup local preflight failed: ${localPreflightErrors.mkString("; ")}"
+      logger.error(message)
+      FutureUnlessShutdown.pure(Left(message))
+    } else {
+      val clientsToValidate =
+        clients.toSeq.filter { case (id, _) =>
+          extensionConfigs.get(id).exists(_.validateOnStartup)
+        }
+
+      if (clientsToValidate.isEmpty) {
+        FutureUnlessShutdown.pure(Right(()))
+      } else {
+        logger.info(
+          s"Validating ${clientsToValidate.size} extension service connection(s) on startup"
+        )
+        FutureUnlessShutdown
+          .sequence(
+            clientsToValidate.map { case (id, client) =>
+              client.validateConnection().map(result => id -> result)
+            }
+          )
+          .map { results =>
+            val invalidResults = results.collect {
+              case (id, ExtensionValidationResult.Invalid(errors)) =>
+                s"Extension '$id': ${errors.mkString(", ")}"
+            }
+
+            if (invalidResults.isEmpty) {
+              Right(())
+            } else {
+              val message =
+                s"Extension startup validation failed: ${invalidResults.mkString("; ")}"
+              logger.error(message)
+              Left(message)
+            }
+          }
+      }
+    }
+  }
+
+  /** Check if the manager has any configured extensions. */
+  def hasExtensions: Boolean = clients.nonEmpty
+
+  /** Get the list of configured extension IDs. */
+  def extensionIds: Set[String] = clients.keySet
+}
+
+object ExtensionServiceManager {
+
+  private[extension] def createHttpClient(
+      config: ExtensionServiceConfig
+  )(implicit ec: ExecutionContext): HttpClient = {
+    val builder = HttpClient
+      .newBuilder()
+      .version(HttpClient.Version.HTTP_1_1)
+      .connectTimeout(config.connectTimeout.asJava)
+      .executor((command: Runnable) => ec.execute(command))
+
+    config.tls.filter(_.enabled).flatMap(_.trustCollectionFile).foreach { trustCollectionFile =>
+      builder.sslContext(sslContext(trustCollectionFile))
+    }
+
+    builder
+      .build()
+  }
+
+  private def sslContext(trustCollectionFile: PemFileOrString) = {
+    val certificateFactory = CertificateFactory.getInstance("X.509")
+    val certificates =
+      certificateFactory.generateCertificates(trustCollectionFile.pemStream).asScala
+
+    require(
+      certificates.nonEmpty,
+      "TLS trust collection must contain at least one X.509 certificate",
+    )
+
+    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType)
+    loadEmpty(keyStore)
+    certificates.zipWithIndex.foreach { case (certificate, index) =>
+      keyStore.setCertificateEntry(s"certificate-$index", certificate)
+    }
+
+    HttpService.buildSSLContext(keyStore)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  private def loadEmpty(keyStore: KeyStore): Unit =
+    keyStore.load(null, null)
+
+  /** Create an ExtensionServiceManager with no extensions configured. Useful for tests or when no
+    * extensions are needed.
+    */
+  def empty(
+      loggerFactory: NamedLoggerFactory,
+      timeouts: ProcessingTimeout,
+  )(implicit ec: ExecutionContext): ExtensionServiceManager =
+    new ExtensionServiceManager(
+      Map.empty,
+      loggerFactory,
+      timeouts,
+    )
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -3,18 +3,21 @@
 
 package com.digitalasset.canton.participant.extension
 
+import com.digitalasset.canton.concurrent.{ExecutorServiceExtensions, Threading}
 import com.digitalasset.canton.config.{PemFileOrString, ProcessingTimeout}
 import com.digitalasset.canton.http.HttpService
-import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown}
+import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown, LifeCycle}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.config.ExtensionServiceConfig
 import com.digitalasset.canton.tracing.TraceContext
 
 import java.net.http.HttpClient
-import java.security.cert.CertificateFactory
 import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 
 /** Manages extension service connections with per-extension pooled HTTP clients.
   *
@@ -39,16 +42,39 @@ class ExtensionServiceManager(
     extends NamedLogging
     with FlagCloseable {
 
+  private val timeoutScheduler: Option[ScheduledExecutorService] =
+    Option.when(extensionConfigs.nonEmpty) {
+      val scheduler = Threading.singleThreadScheduledExecutor(
+        loggerFactory.threadName + "-extension-service-http-timeout",
+        noTracingLogger,
+      )
+      scheduler match {
+        case executor: ScheduledThreadPoolExecutor =>
+          executor.setRemoveOnCancelPolicy(true)
+        case _ => ()
+      }
+      scheduler
+    }
+
   // Extension clients by ID
   private val clients: Map[String, HttpExtensionServiceClient] =
-    extensionConfigs.map { case (id, config) =>
-      id -> new HttpExtensionServiceClient(
-        id,
-        config,
-        ExtensionServiceManager.createHttpClient(config),
-        this,
-        loggerFactory,
-      )
+    timeoutScheduler.fold(Map.empty[String, HttpExtensionServiceClient]) { scheduler =>
+      try {
+        extensionConfigs.map { case (id, config) =>
+          id -> new HttpExtensionServiceClient(
+            id,
+            config,
+            ExtensionServiceManager.createHttpClient(config),
+            scheduler,
+            this,
+            loggerFactory,
+          )
+        }
+      } catch {
+        case NonFatal(exception) =>
+          closeTimeoutScheduler(scheduler)
+          throw exception
+      }
     }
 
   /** Get a client for the specified extension.
@@ -156,6 +182,12 @@ class ExtensionServiceManager(
 
   /** Get the list of configured extension IDs. */
   def extensionIds: Set[String] = clients.keySet
+
+  override protected def onClosed(): Unit =
+    timeoutScheduler.foreach(closeTimeoutScheduler)
+
+  private def closeTimeoutScheduler(scheduler: ScheduledExecutorService): Unit =
+    LifeCycle.close(ExecutorServiceExtensions(scheduler)(logger, timeouts))(logger)
 }
 
 object ExtensionServiceManager {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -481,12 +481,17 @@ object HttpExtensionServiceClient {
   private def isInvalidBearerTokenChar(char: Char): Boolean =
     char < 33 || char > 126
 
+  private val MaxExternalCallHeaderValueLength = 1024
+
+  private def isInvalidExternalCallHeaderValue(value: String): Boolean =
+    value.length > MaxExternalCallHeaderValueLength || value.exists(isInvalidHeaderChar)
+
   private def invalidExternalCallHeader(
       functionId: String,
       configHash: String,
   ): Option[String] =
-    if (functionId.exists(isInvalidHeaderChar)) Some("X-Daml-External-Function-Id")
-    else if (configHash.exists(isInvalidHeaderChar)) Some("X-Daml-External-Config-Hash")
+    if (isInvalidExternalCallHeaderValue(functionId)) Some("X-Daml-External-Function-Id")
+    else if (isInvalidExternalCallHeaderValue(configHash)) Some("X-Daml-External-Config-Hash")
     else None
 
   private[extension] final case class ResponseBodyTooLarge(maxResponseBodyBytes: Long)

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -94,6 +94,7 @@ class HttpExtensionServiceClient(
             Left("Bearer token file is empty")
         }
     }
+  private val maxResponseBodyBytes: Long = config.maxResponseBodyBytes.unwrap.toLong
 
   override def call(
       functionId: String,
@@ -171,7 +172,7 @@ class HttpExtensionServiceClient(
     val response = httpClient.sendAsync(
       request,
       HttpExtensionServiceClient.boundedUtf8BodyHandler(
-        HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
+        maxResponseBodyBytes
       ),
     )
     FutureUtil
@@ -436,7 +437,6 @@ class HttpExtensionServiceClient(
 }
 
 object HttpExtensionServiceClient {
-  private[extension] val DefaultMaxResponseBodyBytes: Long = 20L * 1024L * 1024L
   private val MaxDiagnosticResponseBodyChars: Int = 1024
 
   private[extension] def isRetryableHttpStatus(statusCode: Int): Boolean =

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -16,7 +16,7 @@ import com.digitalasset.canton.participant.config.{
   ExtensionServiceConfig,
 }
 import com.digitalasset.canton.tracing.TraceContext
-import com.digitalasset.canton.util.{DelayUtil, FutureUtil}
+import com.digitalasset.canton.util.TryUtil
 import com.digitalasset.canton.util.retry.{Backoff, NoExceptionRetryPolicy, Success}
 
 import java.io.ByteArrayOutputStream
@@ -27,13 +27,18 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
-import java.util.concurrent.{CompletableFuture, CompletionStage, Flow}
+import java.util.concurrent.{
+  CompletableFuture,
+  CompletionStage,
+  Flow,
+  ScheduledExecutorService,
+  TimeUnit,
+}
 import java.util.{List as JList, UUID}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.jdk.CollectionConverters.*
-import scala.jdk.javaapi.FutureConverters
-import scala.util.control.NonFatal
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /** HTTP client implementation for extension services with retry logic, bearer token authentication,
   * and TLS support.
@@ -44,6 +49,8 @@ import scala.util.Try
   *   Configuration for this extension service
   * @param httpClient
   *   HTTP client for this extension service, with connection pooling
+  * @param timeoutScheduler
+  *   Scheduler for hard per-request timeout tasks
   * @param performUnlessClosing
   *   Close context used to stop retry delays and avoid scheduling requests during shutdown
   * @param loggerFactory
@@ -53,6 +60,7 @@ class HttpExtensionServiceClient(
     override val extensionId: String,
     config: ExtensionServiceConfig,
     httpClient: HttpClient,
+    timeoutScheduler: ScheduledExecutorService,
     performUnlessClosing: PerformUnlessClosing,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit ec: ExecutionContext)
@@ -175,19 +183,26 @@ class HttpExtensionServiceClient(
         maxResponseBodyBytes
       ),
     )
-    FutureUtil
-      .unwrapCompletionException(FutureConverters.asScala(response))
-      .onComplete(result.tryComplete)
-    DelayUtil
-      .delay(scala.concurrent.duration.Duration.fromNanos(requestTimeout.toNanos))
-      .foreach { _ =>
-        result
-          .tryFailure(
+    val timeoutTask =
+      timeoutScheduler.schedule(
+        (() => {
+          val timeout =
             new java.net.http.HttpTimeoutException(s"Request timed out after $requestTimeout")
-          )
-          .discard
-        response.cancel(true).discard
-      }
+          if (result.tryFailure(timeout))
+            response.cancel(true).discard
+        }): Runnable,
+        requestTimeout.toNanos,
+        TimeUnit.NANOSECONDS,
+      )
+
+    response.whenComplete { (httpResponse: HttpResponse[String], error: Throwable) =>
+      val completion: Try[HttpResponse[String]] =
+        Option(error).fold[Try[HttpResponse[String]]](scala.util.Success(httpResponse))(error =>
+          TryUtil.unwrapCompletionException(scala.util.Failure(error))
+        )
+      result.tryComplete(completion).discard
+      timeoutTask.cancel(false).discard
+    }.discard
 
     result.future
   }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -1,0 +1,516 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.config.RequireTypes.Port
+import com.digitalasset.canton.discard.Implicits.DiscardOps
+import com.digitalasset.canton.lifecycle.{
+  FutureUnlessShutdown,
+  PerformUnlessClosing,
+  UnlessShutdown,
+}
+import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.participant.config.{
+  ExtensionServiceAuthConfig,
+  ExtensionServiceConfig,
+}
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.FutureUtil
+import com.digitalasset.canton.util.retry.{Backoff, NoExceptionRetryPolicy, Success}
+
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+import java.util.concurrent.{CompletableFuture, CompletionStage, Flow}
+import java.util.{List as JList, UUID}
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
+import scala.jdk.javaapi.FutureConverters
+import scala.util.control.NonFatal
+import scala.util.Try
+
+/** HTTP client implementation for extension services with retry logic, bearer token authentication,
+  * and TLS support.
+  *
+  * @param extensionId
+  *   The extension identifier (key from config map)
+  * @param config
+  *   Configuration for this extension service
+  * @param httpClient
+  *   HTTP client for this extension service, with connection pooling
+  * @param performUnlessClosing
+  *   Close context used to stop retry delays and avoid scheduling requests during shutdown
+  * @param loggerFactory
+  *   Logger factory
+  */
+class HttpExtensionServiceClient(
+    override val extensionId: String,
+    config: ExtensionServiceConfig,
+    httpClient: HttpClient,
+    performUnlessClosing: PerformUnlessClosing,
+    override protected val loggerFactory: NamedLoggerFactory,
+)(implicit ec: ExecutionContext)
+    extends ExtensionServiceClient
+    with NamedLogging {
+
+  // Construct the endpoint URL
+  private val scheme = if (config.tls.exists(_.enabled)) "https" else "http"
+  private val endpoint: URI =
+    HttpExtensionServiceClient.serviceUri(
+      scheme,
+      config.address,
+      config.port,
+      s"/api/${config.version}/external-call",
+    )
+  private val versionEndpoint: URI =
+    HttpExtensionServiceClient.serviceUri(
+      scheme,
+      config.address,
+      config.port,
+      s"/api/${config.version}/version",
+    )
+
+  private val authorizationHeader: Either[String, Option[String]] =
+    config.auth match {
+      case ExtensionServiceAuthConfig.None => Right(None)
+      case ExtensionServiceAuthConfig.BearerTokenFile(tokenFile) =>
+        val file = tokenFile.unwrap
+        Try(
+          HttpExtensionServiceClient.stripTrailingLineTerminators(Files.readString(file.toPath))
+        ).toEither match {
+          case Left(_) =>
+            Left("Failed to read bearer token file")
+          case Right(token) if token.exists(HttpExtensionServiceClient.isInvalidBearerTokenChar) =>
+            Left("Bearer token file contains invalid characters")
+          case Right(token) if token.nonEmpty =>
+            Right(Some(s"Bearer $token"))
+          case Right(_) =>
+            Left("Bearer token file is empty")
+        }
+    }
+
+  override def call(
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] =
+    callWithRetry(functionId, configHash, input, mode)
+
+  private[extension] def startupLocalPreflight(): Either[String, Unit] =
+    authorizationHeader match {
+      case Left(error) =>
+        Left(s"Invalid extension service authentication configuration: $error")
+      case Right(_) =>
+        Right(())
+    }
+
+  private[extension] def validateConnection()(implicit
+      tc: TraceContext
+  ): FutureUnlessShutdown[ExtensionValidationResult] =
+    startupLocalPreflight() match {
+      case Left(error) =>
+        FutureUnlessShutdown.pure(ExtensionValidationResult.Invalid(Seq(error)))
+
+      case Right(_) =>
+        validateVersionEndpoint()
+    }
+
+  private def validateVersionEndpoint()(implicit
+      tc: TraceContext
+  ): FutureUnlessShutdown[ExtensionValidationResult] = {
+    val requestId = UUID.randomUUID().toString
+    val request = HttpRequest
+      .newBuilder()
+      .uri(versionEndpoint)
+      .timeout(config.requestTimeout.asJava)
+      .header("Accept", "application/json")
+      .header("X-Request-Id", requestId)
+      .GET()
+      .build()
+
+    sendValidationRequest(request, requestId).map {
+      case Right(response) =>
+        response.statusCode() match {
+          case 200 =>
+            ExtensionValidationResult.Valid
+          case code =>
+            ExtensionValidationResult.Invalid(
+              Seq(s"Version endpoint returned HTTP $code")
+            )
+        }
+      case Left(error) =>
+        ExtensionValidationResult.Invalid(Seq(error))
+    }
+  }
+
+  private def sendValidationRequest(
+      request: HttpRequest,
+      requestId: String,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[String, HttpResponse[String]]] =
+    performUnlessClosing
+      .synchronizeWithClosingF("extension-service-startup-validation") {
+        FutureUtil.unwrapCompletionException(
+          FutureConverters.asScala(
+            httpClient.sendAsync(
+              request,
+              HttpExtensionServiceClient.boundedUtf8BodyHandler(
+                HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
+              ),
+            )
+          )
+        )
+      }
+      .map(response => Right(response))
+      .recover { case NonFatal(e) =>
+        UnlessShutdown.Outcome(Left(validationExceptionMessage(e, requestId)))
+      }
+
+  private def validationExceptionMessage(e: Throwable, requestId: String): String =
+    e match {
+      case tooLarge: HttpExtensionServiceClient.ResponseBodyTooLarge =>
+        s"Response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes"
+      case timeout: java.net.http.HttpTimeoutException =>
+        s"Request timeout during startup validation: ${exceptionMessage(timeout)}"
+      case connect: java.net.ConnectException =>
+        s"Connection failed: ${exceptionMessage(connect)}"
+      case io: java.io.IOException =>
+        s"I/O error: ${exceptionMessage(io)}"
+      case other =>
+        s"Unexpected error during startup validation: ${exceptionMessage(other)} (requestId=$requestId)"
+    }
+
+  private def exceptionMessage(e: Throwable): String =
+    Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+
+  /** Make an HTTP call with retry logic */
+  private def callWithRetry(
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] = {
+    val idempotencyKey = UUID.randomUUID().toString
+    implicit val retrySuccess: Success[Either[ExtensionCallError, String]] =
+      Success {
+        case Left(error) => !shouldRetry(error)
+        case Right(_) => true
+      }
+
+    Backoff(
+      logger = logger,
+      hasSynchronizeWithClosing = performUnlessClosing,
+      maxRetries = config.maxRetries.value,
+      initialDelay = config.retryInitialDelay.underlying,
+      maxDelay = config.retryMaxDelay.underlying,
+      operationName = "external-call-http-request",
+    ).unlessShutdown(
+      singleCall(
+        functionId,
+        configHash,
+        input,
+        mode,
+        config.requestTimeout.asJava,
+        idempotencyKey,
+      ),
+      NoExceptionRetryPolicy,
+    )
+  }
+
+  /** Make a single HTTP call without retry logic */
+  private def singleCall(
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+      requestTimeout: Duration,
+      idempotencyKey: String,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] = {
+    val requestId = UUID.randomUUID().toString
+
+    HttpExtensionServiceClient.invalidExternalCallHeader(functionId, configHash) match {
+      case Some(headerName) =>
+        FutureUnlessShutdown.pure(
+          Left(
+            ExtensionCallError(
+              400,
+              s"Invalid external-call HTTP header value for $headerName",
+              Some(requestId),
+              retryable = false,
+            )
+          )
+        )
+
+      case None =>
+        try {
+          val requestBuilder = HttpRequest
+            .newBuilder()
+            .uri(endpoint)
+            .timeout(requestTimeout)
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .header("Accept", "text/plain")
+            .header("X-Daml-External-Function-Id", functionId)
+            .header("X-Daml-External-Config-Hash", configHash)
+            .header("X-Daml-External-Mode", mode.headerValue)
+            .header("X-Request-Id", requestId)
+            .header("Idempotency-Key", idempotencyKey)
+
+          authorizationHeader match {
+            case Left(error) =>
+              FutureUnlessShutdown.pure(
+                Left(
+                  ExtensionCallError(
+                    400,
+                    s"Invalid extension service authentication configuration: $error",
+                    Some(requestId),
+                    retryable = false,
+                  )
+                )
+              )
+
+            case Right(headerO) =>
+              headerO.foreach(requestBuilder.header("Authorization", _))
+
+              val req = requestBuilder
+                .POST(HttpRequest.BodyPublishers.ofString(input))
+                .build()
+
+              logger.debug(
+                s"Making external call to extension '$extensionId': functionId=$functionId, mode=${mode.headerValue}, requestId=$requestId"
+              )
+
+              performUnlessClosing
+                .synchronizeWithClosingF("external-call-http-request") {
+                  FutureUtil.unwrapCompletionException(
+                    FutureConverters.asScala(
+                      httpClient.sendAsync(
+                        req,
+                        HttpExtensionServiceClient.boundedUtf8BodyHandler(
+                          HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
+                        ),
+                      )
+                    )
+                  )
+                }
+                .map(response => responseToResult(response, requestId))
+                .recover { case NonFatal(e) =>
+                  UnlessShutdown.Outcome(Left(exceptionToError(e, requestId)))
+                }
+          }
+        } catch {
+          case NonFatal(e) =>
+            FutureUnlessShutdown.pure(Left(exceptionToError(e, requestId)))
+        }
+    }
+  }
+
+  private def responseToResult(
+      resp: HttpResponse[String],
+      requestId: String,
+  )(implicit tc: TraceContext): Either[ExtensionCallError, String] =
+    resp.statusCode() match {
+      case 200 =>
+        logger.debug(
+          s"External call to extension '$extensionId' succeeded: requestId=$requestId"
+        )
+        Right(resp.body())
+
+      case 400 =>
+        Left(errorFromStatus(resp, requestId, "Bad Request"))
+
+      case 401 =>
+        Left(errorFromStatus(resp, requestId, "Unauthorized - check bearer token"))
+
+      case 403 =>
+        Left(errorFromStatus(resp, requestId, "Forbidden - insufficient permissions"))
+
+      case 404 =>
+        Left(errorFromStatus(resp, requestId, "Function not found"))
+
+      case 408 =>
+        Left(errorFromStatus(resp, requestId, "Request timeout"))
+
+      case 429 =>
+        Left(errorFromStatus(resp, requestId, "Rate limit exceeded"))
+
+      case 500 =>
+        Left(errorFromStatus(resp, requestId, "Internal server error"))
+
+      case 502 =>
+        Left(errorFromStatus(resp, requestId, "Bad gateway"))
+
+      case 503 =>
+        Left(errorFromStatus(resp, requestId, "Service unavailable"))
+
+      case 504 =>
+        Left(errorFromStatus(resp, requestId, "Gateway timeout"))
+
+      case code =>
+        Left(errorFromStatus(resp, requestId, s"HTTP $code"))
+    }
+
+  private def exceptionToError(
+      e: Throwable,
+      requestId: String,
+  )(implicit tc: TraceContext): ExtensionCallError =
+    e match {
+      case tooLarge: HttpExtensionServiceClient.ResponseBodyTooLarge =>
+        logger.warn(
+          s"External call to extension '$extensionId' response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes: requestId=$requestId"
+        )
+        ExtensionCallError(
+          413,
+          s"External call response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes",
+          Some(requestId),
+          retryable = false,
+        )
+
+      case timeout: java.net.http.HttpTimeoutException =>
+        logger.warn(s"External call to extension '$extensionId' timed out: requestId=$requestId")
+        ExtensionCallError(408, "Request timeout", Some(requestId), retryable = true)
+
+      case connect: java.net.ConnectException =>
+        logger.warn(
+          s"External call to extension '$extensionId' connection failed: requestId=$requestId"
+        )
+        ExtensionCallError(503, "Connection failed", Some(requestId), retryable = true)
+
+      case io: java.io.IOException =>
+        logger.warn(
+          s"External call to extension '$extensionId' I/O error: requestId=$requestId"
+        )
+        ExtensionCallError(503, "I/O error", Some(requestId), retryable = true)
+
+      case other =>
+        logger.error(
+          s"External call to extension '$extensionId' unexpected error: requestId=$requestId",
+          other,
+        )
+        ExtensionCallError(500, "Unexpected error", Some(requestId), retryable = false)
+    }
+
+  private def errorFromStatus(
+      resp: HttpResponse[String],
+      requestId: String,
+      defaultMessage: String,
+  ): ExtensionCallError =
+    ExtensionCallError(
+      resp.statusCode(),
+      defaultMessage,
+      Some(requestId),
+      retryable = HttpExtensionServiceClient.isRetryableHttpStatus(resp.statusCode()),
+    )
+
+  private def shouldRetry(error: ExtensionCallError): Boolean =
+    error.retryable
+}
+
+object HttpExtensionServiceClient {
+  private[extension] val DefaultMaxResponseBodyBytes: Long = 20L * 1024L * 1024L
+
+  private[extension] def isRetryableHttpStatus(statusCode: Int): Boolean =
+    statusCode match {
+      case 408 | 412 | 429 | 500 | 502 | 503 | 504 => true
+      case _ => false
+    }
+
+  private[extension] def serviceUri(
+      scheme: String,
+      address: String,
+      port: Port,
+      path: String,
+  ): URI = {
+    val host = renderHost(address)
+    val uri = URI.create(s"$scheme://$host:${port.unwrap}$path")
+    require(uri.getHost == host, s"Invalid extension service address '$address'")
+    uri
+  }
+
+  private def renderHost(address: String): String =
+    if (address.startsWith("[") && address.endsWith("]")) address
+    else if (address.contains(":")) s"[$address]"
+    else address
+
+  private[extension] def stripTrailingLineTerminators(value: String): String =
+    value.substring(0, value.lastIndexWhere(ch => ch != '\r' && ch != '\n') + 1)
+
+  private def isInvalidHeaderChar(char: Char): Boolean =
+    char < 32 || char > 126
+
+  private def isInvalidBearerTokenChar(char: Char): Boolean =
+    char < 33 || char > 126
+
+  private def invalidExternalCallHeader(
+      functionId: String,
+      configHash: String,
+  ): Option[String] =
+    if (functionId.exists(isInvalidHeaderChar)) Some("X-Daml-External-Function-Id")
+    else if (configHash.exists(isInvalidHeaderChar)) Some("X-Daml-External-Config-Hash")
+    else None
+
+  private[extension] final case class ResponseBodyTooLarge(maxResponseBodyBytes: Long)
+      extends RuntimeException(
+        s"External call response body exceeded maximum size of $maxResponseBodyBytes bytes"
+      )
+
+  private[extension] def boundedUtf8BodyHandler(
+      maxResponseBodyBytes: Long
+  ): HttpResponse.BodyHandler[String] =
+    _ => new BoundedUtf8BodySubscriber(maxResponseBodyBytes)
+
+  private final class BoundedUtf8BodySubscriber(maxResponseBodyBytes: Long)
+      extends HttpResponse.BodySubscriber[String] {
+    private val result = new CompletableFuture[String]
+    private val output = new ByteArrayOutputStream
+    private val subscription = new AtomicReference[Option[Flow.Subscription]](None)
+    private val receivedBytes = new AtomicLong(0L)
+    private val finished = new AtomicBoolean(false)
+
+    override def getBody: CompletionStage[String] = result
+
+    override def onSubscribe(subscription: Flow.Subscription): Unit =
+      if (this.subscription.compareAndSet(None, Some(subscription))) {
+        subscription.request(Long.MaxValue)
+      } else {
+        subscription.cancel()
+      }
+
+    override def onNext(items: JList[ByteBuffer]): Unit =
+      items.asScala.foreach(append)
+
+    override def onError(throwable: Throwable): Unit =
+      if (finished.compareAndSet(false, true)) {
+        result.completeExceptionally(throwable).discard
+      }
+
+    override def onComplete(): Unit =
+      if (finished.compareAndSet(false, true)) {
+        val body = new String(output.toByteArray, StandardCharsets.UTF_8)
+        result.complete(body).discard
+      }
+
+    private def append(buffer: ByteBuffer): Unit =
+      if (!finished.get()) {
+        appendUnlessTooLarge(buffer)
+      }
+
+    private def appendUnlessTooLarge(buffer: ByteBuffer): Unit = {
+      val length = buffer.remaining()
+      if (receivedBytes.get() + length > maxResponseBodyBytes) {
+        subscription.get().foreach(_.cancel())
+        onError(ResponseBodyTooLarge(maxResponseBodyBytes))
+      } else {
+        val bytes = new Array[Byte](length)
+        buffer.get(bytes)
+        output.write(bytes, 0, bytes.length)
+        receivedBytes.addAndGet(length.toLong).discard
+      }
+    }
+  }
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -16,7 +16,7 @@ import com.digitalasset.canton.participant.config.{
   ExtensionServiceConfig,
 }
 import com.digitalasset.canton.tracing.TraceContext
-import com.digitalasset.canton.util.FutureUtil
+import com.digitalasset.canton.util.{DelayUtil, FutureUtil}
 import com.digitalasset.canton.util.retry.{Backoff, NoExceptionRetryPolicy, Success}
 
 import java.io.ByteArrayOutputStream
@@ -29,7 +29,7 @@ import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
 import java.util.concurrent.{CompletableFuture, CompletionStage, Flow}
 import java.util.{List as JList, UUID}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.jdk.CollectionConverters.*
 import scala.jdk.javaapi.FutureConverters
 import scala.util.control.NonFatal
@@ -156,21 +156,40 @@ class HttpExtensionServiceClient(
   )(implicit tc: TraceContext): FutureUnlessShutdown[Either[String, HttpResponse[String]]] =
     performUnlessClosing
       .synchronizeWithClosingF("extension-service-startup-validation") {
-        FutureUtil.unwrapCompletionException(
-          FutureConverters.asScala(
-            httpClient.sendAsync(
-              request,
-              HttpExtensionServiceClient.boundedUtf8BodyHandler(
-                HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
-              ),
-            )
-          )
-        )
+        sendAsyncWithTimeout(request, config.requestTimeout.asJava)
       }
       .map(response => Right(response))
       .recover { case NonFatal(e) =>
         UnlessShutdown.Outcome(Left(validationExceptionMessage(e, requestId)))
       }
+
+  private def sendAsyncWithTimeout(
+      request: HttpRequest,
+      requestTimeout: Duration,
+  ): Future[HttpResponse[String]] = {
+    val result = Promise[HttpResponse[String]]()
+    val response = httpClient.sendAsync(
+      request,
+      HttpExtensionServiceClient.boundedUtf8BodyHandler(
+        HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
+      ),
+    )
+    FutureUtil
+      .unwrapCompletionException(FutureConverters.asScala(response))
+      .onComplete(result.tryComplete)
+    DelayUtil
+      .delay(scala.concurrent.duration.Duration.fromNanos(requestTimeout.toNanos))
+      .foreach { _ =>
+        result
+          .tryFailure(
+            new java.net.http.HttpTimeoutException(s"Request timed out after $requestTimeout")
+          )
+          .discard
+        response.cancel(true).discard
+      }
+
+    result.future
+  }
 
   private def validationExceptionMessage(e: Throwable, requestId: String): String =
     e match {
@@ -287,16 +306,7 @@ class HttpExtensionServiceClient(
 
               performUnlessClosing
                 .synchronizeWithClosingF("external-call-http-request") {
-                  FutureUtil.unwrapCompletionException(
-                    FutureConverters.asScala(
-                      httpClient.sendAsync(
-                        req,
-                        HttpExtensionServiceClient.boundedUtf8BodyHandler(
-                          HttpExtensionServiceClient.DefaultMaxResponseBodyBytes
-                        ),
-                      )
-                    )
-                  )
+                  sendAsyncWithTimeout(req, requestTimeout)
                 }
                 .map(response => responseToResult(response, requestId))
                 .recover { case NonFatal(e) =>

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -463,13 +463,21 @@ object HttpExtensionServiceClient {
   ): URI = {
     val host = renderHost(address)
     val uri = URI.create(s"$scheme://$host:${port.unwrap}$path")
-    require(uri.getHost == host, s"Invalid extension service address '$address'")
+    require(
+      uri.getHost == host || uri.getHost == comparisonHost(address),
+      s"Invalid extension service address '$address'",
+    )
     uri
   }
 
   private def renderHost(address: String): String =
     if (address.startsWith("[") && address.endsWith("]")) address
     else if (address.contains(":")) s"[$address]"
+    else address
+
+  private def comparisonHost(address: String): String =
+    if (address.startsWith("[") && address.endsWith("]"))
+      address.substring(1, address.length - 1)
     else address
 
   private[extension] def stripTrailingLineTerminators(value: String): String =

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -409,13 +409,27 @@ class HttpExtensionServiceClient(
       resp: HttpResponse[String],
       requestId: String,
       defaultMessage: String,
-  ): ExtensionCallError =
+  )(implicit tc: TraceContext): ExtensionCallError = {
+    debugLogErrorBody(resp, requestId)
     ExtensionCallError(
       resp.statusCode(),
       defaultMessage,
       Some(requestId),
       retryable = HttpExtensionServiceClient.isRetryableHttpStatus(resp.statusCode()),
     )
+  }
+
+  private def debugLogErrorBody(resp: HttpResponse[String], requestId: String)(implicit
+      tc: TraceContext
+  ): Unit =
+    if (logger.underlying.isDebugEnabled) {
+      val statusCode = resp.statusCode()
+      HttpExtensionServiceClient.diagnosticResponseBody(resp.body()).foreach { body =>
+        logger.debug(
+          s"External call to extension '$extensionId' returned HTTP $statusCode with response body '$body': requestId=$requestId"
+        )
+      }
+    }
 
   private def shouldRetry(error: ExtensionCallError): Boolean =
     error.retryable
@@ -423,12 +437,23 @@ class HttpExtensionServiceClient(
 
 object HttpExtensionServiceClient {
   private[extension] val DefaultMaxResponseBodyBytes: Long = 20L * 1024L * 1024L
+  private val MaxDiagnosticResponseBodyChars: Int = 1024
 
   private[extension] def isRetryableHttpStatus(statusCode: Int): Boolean =
     statusCode match {
       case 408 | 412 | 429 | 500 | 502 | 503 | 504 => true
       case _ => false
     }
+
+  private[extension] def diagnosticResponseBody(body: String): Option[String] =
+    Option.when(body.nonEmpty) {
+      val prefix = body.take(MaxDiagnosticResponseBodyChars).map(sanitizeDiagnosticChar)
+      if (body.length > MaxDiagnosticResponseBodyChars) s"$prefix..."
+      else prefix
+    }
+
+  private def sanitizeDiagnosticChar(char: Char): Char =
+    if (Character.isISOControl(char)) ' ' else char
 
   private[extension] def serviceUri(
       scheme: String,

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -133,21 +133,29 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
 
       try {
         val client = newClient(configFor(server))
+        val oversizedValue = "a" * 1025
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("bad\u0100function", "config-hash", "input", ExternalCallMode.Submission)(
-              TraceContext.empty
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
+        Seq(
+          ("X-Daml-External-Function-Id", "bad\u0100function", "config-hash", "bad"),
+          ("X-Daml-External-Function-Id", oversizedValue, "config-hash", oversizedValue),
+          ("X-Daml-External-Config-Hash", "function", oversizedValue, oversizedValue),
+        ).foreach { case (headerName, functionId, configHash, redactedValue) =>
+          val error = loggerFactory.suppressWarnings {
+            client
+              .call(functionId, configHash, "input", ExternalCallMode.Submission)(
+                TraceContext.empty
+              )
+              .failOnShutdown
+              .futureValue
+              .left
+              .value
+          }
+
+          error.statusCode shouldBe 400
+          error.message should include(headerName)
+          error.message should not include redactedValue
         }
 
-        error.statusCode shouldBe 400
-        error.message should include("X-Daml-External-Function-Id")
-        error.message should not include "bad"
         requests.get shouldBe 0
       } finally {
         server.stop(0)

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.participant.extension
 
 import com.daml.tls.{ServerAuthRequirementConfig, TlsClientConfigOnlyTrustFile, TlsServerConfig}
-import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port}
+import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port, PositiveInt}
 import com.digitalasset.canton.config.{NonNegativeFiniteDuration, PemFile, PositiveFiniteDuration}
 import com.digitalasset.canton.http.HttpService
 import com.digitalasset.canton.lifecycle.{FlagCloseable, UnlessShutdown}
@@ -420,6 +420,50 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         attempts.get() shouldBe 1
       } finally {
         server.stop(0)
+      }
+    }
+
+    "reject oversized response bodies before interpreting the HTTP status" in {
+      Seq(200, 400, 500).foreach { statusCode =>
+        withClue(s"statusCode=$statusCode") {
+          val attempts = new AtomicInteger(0)
+          val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+          server.createContext(
+            "/",
+            exchange => {
+              attempts.incrementAndGet()
+              writeResponse(exchange, statusCode, "beef00")
+            },
+          )
+          server.start()
+
+          try {
+            val client = newClient(
+              configFor(server).copy(
+                maxRetries = NonNegativeInt.tryCreate(1),
+                retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+                retryMaxDelay = NonNegativeFiniteDuration.ofMillis(10),
+                maxResponseBodyBytes = PositiveInt.tryCreate(4),
+              )
+            )
+
+            val error = loggerFactory.suppressWarnings {
+              client
+                .call("function", "config-hash", "input", ExternalCallMode.Submission)
+                .failOnShutdown
+                .futureValue
+                .left
+                .value
+            }
+
+            error.statusCode shouldBe 413
+            error.message should include("exceeded maximum size of 4 bytes")
+            error.message should not include "beef00"
+            attempts.get() shouldBe 1
+          } finally {
+            server.stop(0)
+          }
+        }
       }
     }
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -1,0 +1,881 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.daml.tls.{ServerAuthRequirementConfig, TlsClientConfigOnlyTrustFile, TlsServerConfig}
+import com.digitalasset.canton.config.RequireTypes.{ExistingFile, NonNegativeInt, Port}
+import com.digitalasset.canton.config.{NonNegativeFiniteDuration, PemFile, PositiveFiniteDuration}
+import com.digitalasset.canton.http.HttpService
+import com.digitalasset.canton.lifecycle.{FlagCloseable, UnlessShutdown}
+import com.digitalasset.canton.logging.SuppressionRule
+import com.digitalasset.canton.participant.config.{
+  ExtensionServiceAuthConfig,
+  ExtensionServiceConfig,
+}
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.JarResourceUtils
+import com.digitalasset.canton.{BaseTest, HasExecutionContext}
+import com.sun.net.httpserver.{HttpServer, HttpsConfigurator, HttpsServer}
+import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.event.Level
+
+import java.io.IOException
+import java.net.{InetSocketAddress, ServerSocket}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{CopyOnWriteArrayList, CountDownLatch, TimeUnit}
+import scala.concurrent.ExecutionContext
+
+class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasExecutionContext {
+
+  "HttpExtensionServiceClient" should {
+    "connect to an HTTPS service using the configured trust collection" in {
+      val server = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.setHttpsConfigurator(new HttpsConfigurator(testServerSslContext()))
+      server.createContext(
+        "/",
+        exchange => writeResponse(exchange, 200, "beef"),
+      )
+      server.start()
+
+      try {
+        val config = configFor(server).copy(
+          tls = Some(TlsClientConfigOnlyTrustFile(trustCollectionFile = Some(testPem("ca.crt")))),
+          connectTimeout = PositiveFiniteDuration.ofSeconds(2),
+          requestTimeout = PositiveFiniteDuration.ofSeconds(5),
+        )
+        val client = newClient(config)
+
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue shouldBe Right("beef")
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "send the expected external-call HTTP request" in {
+      val observedMethod = new AtomicReference[String]("")
+      val observedPath = new AtomicReference[String]("")
+      val observedContentType = new AtomicReference[String]("")
+      val observedFunctionId = new AtomicReference[String]("")
+      val observedConfigHash = new AtomicReference[String]("")
+      val observedMode = new AtomicReference[String]("")
+      val observedRequestId = new AtomicReference[String]("")
+      val observedIdempotencyKey = new AtomicReference[String]("")
+      val observedAccept = new AtomicReference[String]("")
+      val observedBody = new AtomicReference[String]("")
+
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          val headers = exchange.getRequestHeaders
+          observedMethod.set(exchange.getRequestMethod)
+          observedPath.set(exchange.getRequestURI.getPath)
+          observedContentType.set(headers.getFirst("Content-Type"))
+          observedFunctionId.set(headers.getFirst("X-Daml-External-Function-Id"))
+          observedConfigHash.set(headers.getFirst("X-Daml-External-Config-Hash"))
+          observedMode.set(headers.getFirst("X-Daml-External-Mode"))
+          observedRequestId.set(Option(headers.getFirst("X-Request-Id")).getOrElse(""))
+          observedIdempotencyKey.set(Option(headers.getFirst("Idempotency-Key")).getOrElse(""))
+          observedAccept.set(headers.getFirst("Accept"))
+          observedBody.set(
+            new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+          )
+          writeResponse(exchange, 200, "beef")
+        },
+      )
+      server.start()
+
+      try {
+        val config = configFor(server).copy(version = "v-test")
+        val client = newClient(config)
+
+        client
+          .call("external-function", "config-hash-123", "001122", ExternalCallMode.Validation)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue shouldBe Right("beef")
+
+        observedMethod.get shouldBe "POST"
+        observedPath.get shouldBe "/api/v-test/external-call"
+        observedContentType.get shouldBe "text/plain; charset=utf-8"
+        observedAccept.get shouldBe "text/plain"
+        observedFunctionId.get shouldBe "external-function"
+        observedConfigHash.get shouldBe "config-hash-123"
+        observedMode.get shouldBe "validation"
+        observedRequestId.get should not be empty
+        observedIdempotencyKey.get should not be empty
+        observedBody.get shouldBe "001122"
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "reject malformed outbound header values without sending a request" in {
+      val requests = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          val _ = requests.incrementAndGet()
+          writeResponse(exchange, 200, "beef")
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(configFor(server))
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("bad\u0100function", "config-hash", "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 400
+        error.message should include("X-Daml-External-Function-Id")
+        error.message should not include "bad"
+        requests.get shouldBe 0
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "send bearer token auth from the configured token file" in {
+      val observedAuthorization = new AtomicReference[Option[String]](None)
+      val tokenFile = Files.createTempFile("canton-extension-token", ".txt")
+      Files.writeString(tokenFile, "test-token\n", StandardCharsets.UTF_8)
+
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          observedAuthorization.set(
+            Option(exchange.getRequestHeaders.getFirst("Authorization"))
+          )
+          exchange.sendResponseHeaders(200, 0)
+          exchange.getResponseBody.close()
+        },
+      )
+      server.start()
+
+      try {
+        val config = ExtensionServiceConfig(
+          address = "127.0.0.1",
+          port = Port.tryCreate(server.getAddress.getPort),
+          version = "v0",
+          tls = None,
+          auth = ExtensionServiceAuthConfig.BearerTokenFile(
+            ExistingFile.tryCreate(tokenFile.toFile)
+          ),
+        )
+        val client = newClient(config)
+
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue shouldBe Right("")
+        observedAuthorization.get shouldBe Some("Bearer test-token")
+      } finally {
+        server.stop(0)
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+
+    "validate the configured API version endpoint on startup" in {
+      val observedRequests = new CopyOnWriteArrayList[String]()
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          observedRequests.add(s"${exchange.getRequestMethod} ${exchange.getRequestURI.getPath}")
+          writeResponse(exchange, 200, """{"application":"external-call-server","version":"v0"}""")
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(configFor(server))
+
+        client
+          .validateConnection()
+          .failOnShutdown
+          .futureValue shouldBe ExtensionValidationResult.Valid
+        observedRequests.size shouldBe 1
+        observedRequests.get(0) shouldBe "GET /api/v0/version"
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "retry retryable 412 responses and return the later successful response" in {
+      val attempts = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange =>
+          if (attempts.incrementAndGet() == 1) {
+            writeResponse(exchange, 412, "try again")
+          } else {
+            writeResponse(exchange, 200, "cafe")
+          },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+            retryMaxDelay = NonNegativeFiniteDuration.ofMillis(10),
+          )
+        )
+
+        loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)
+            .failOnShutdown
+            .futureValue shouldBe Right("cafe")
+        }
+        attempts.get() shouldBe 2
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "reuse the same idempotency key across retry attempts" in {
+      val attempts = new AtomicInteger(0)
+      val observedIdempotencyKeys = new CopyOnWriteArrayList[String]()
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          observedIdempotencyKeys.add(
+            Option(exchange.getRequestHeaders.getFirst("Idempotency-Key")).getOrElse("")
+          )
+          if (attempts.incrementAndGet() == 1) {
+            writeResponse(exchange, 503, "try again")
+          } else {
+            writeResponse(exchange, 200, "cafe")
+          }
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+            retryMaxDelay = NonNegativeFiniteDuration.ofMillis(10),
+          )
+        )
+
+        loggerFactory.suppressWarnings {
+          client
+            .call(
+              "function",
+              "config-hash",
+              "input",
+              ExternalCallMode.Submission,
+            )
+            .failOnShutdown
+            .futureValue shouldBe Right("cafe")
+        }
+
+        observedIdempotencyKeys.size shouldBe 2
+        observedIdempotencyKeys.get(0) should not be empty
+        observedIdempotencyKeys.get(1) shouldBe observedIdempotencyKeys.get(0)
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "retry retryable responses using Canton backoff even when Retry-After is present" in {
+      val attempts = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange =>
+          if (attempts.incrementAndGet() == 1) {
+            exchange.getResponseHeaders.add("Retry-After", "5")
+            writeResponse(exchange, 429, "retry later")
+          } else {
+            writeResponse(exchange, 200, "cafe")
+          },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            connectTimeout = PositiveFiniteDuration.ofMillis(10),
+            requestTimeout = PositiveFiniteDuration.ofMillis(50),
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+            retryMaxDelay = NonNegativeFiniteDuration.ofMillis(1),
+          )
+        )
+
+        loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)
+            .failOnShutdown
+            .futureValue shouldBe Right("cafe")
+        }
+
+        attempts.get() shouldBe 2
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "stop after maxRetries and return the last retryable error" in {
+      val attempts = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          attempts.incrementAndGet()
+          writeResponse(exchange, 503, "still unavailable")
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+            retryMaxDelay = NonNegativeFiniteDuration.ofMillis(10),
+          )
+        )
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 503
+        error.message should include("Service unavailable")
+        error.message should not include "still unavailable"
+        attempts.get() shouldBe 2
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "not retry non-retryable HTTP errors" in {
+      val attempts = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          attempts.incrementAndGet()
+          writeResponse(exchange, 401, "missing token")
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1),
+            retryMaxDelay = NonNegativeFiniteDuration.ofMillis(10),
+          )
+        )
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 401
+        error.message should include("Unauthorized - check bearer token")
+        error.message should not include "missing token"
+        attempts.get() shouldBe 1
+      } finally {
+        server.stop(0)
+      }
+    }
+
+    "map request timeout failures to 408" in {
+      val releaseResponse = new CountDownLatch(1)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          releaseResponse.await(5, TimeUnit.SECONDS)
+          try {
+            writeResponse(exchange, 200, "too late")
+          } catch {
+            case _: IOException => ()
+          }
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(
+          configFor(server).copy(
+            requestTimeout = PositiveFiniteDuration.ofMillis(100),
+            maxRetries = NonNegativeInt.tryCreate(0),
+          )
+        )
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 408
+      } finally {
+        releaseResponse.countDown()
+        server.stop(0)
+      }
+    }
+
+    "map connection failures to 503" in {
+      val client = newClient(
+        configForUnusedPort()
+      )
+
+      val error = loggerFactory.suppressWarnings {
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
+      }
+
+      error.statusCode shouldBe 503
+    }
+
+    "abort retry delay when the extension manager is closing" in {
+      val firstResponseReturned = new CountDownLatch(1)
+      val attempts = new AtomicInteger(0)
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          attempts.incrementAndGet()
+          writeResponse(exchange, 503, "try again")
+          firstResponseReturned.countDown()
+        },
+      )
+      server.start()
+
+      val manager = new ExtensionServiceManager(
+        Map(
+          "test-extension" -> configFor(
+            server
+          ).copy(
+            maxRetries = NonNegativeInt.tryCreate(1),
+            retryInitialDelay = NonNegativeFiniteDuration.ofSeconds(2),
+            retryMaxDelay = NonNegativeFiniteDuration.ofSeconds(2),
+          )
+        ),
+        loggerFactory,
+        timeouts,
+      )
+
+      try {
+        loggerFactory.suppressWarnings {
+          val resultF =
+            manager.handleExternalCall(
+              "test-extension",
+              "function",
+              "config-hash",
+              "input",
+              ExternalCallMode.Submission,
+            )
+          firstResponseReturned.await(5, TimeUnit.SECONDS) shouldBe true
+
+          manager.close()
+
+          resultF.unwrap.futureValue shouldBe UnlessShutdown.AbortedDueToShutdown
+        }
+        attempts.get() shouldBe 1
+      } finally {
+        manager.close()
+        server.stop(0)
+      }
+    }
+
+    "treat invalid bearer token auth as a non-retryable configuration error" in {
+      val tokenFile = Files.createTempFile("canton-extension-empty-token", ".txt")
+
+      try {
+        val config = ExtensionServiceConfig(
+          address = "127.0.0.1",
+          port = Port.tryCreate(12345),
+          version = "v0",
+          tls = None,
+          auth = ExtensionServiceAuthConfig.BearerTokenFile(
+            ExistingFile.tryCreate(tokenFile.toFile)
+          ),
+          maxRetries = NonNegativeInt.tryCreate(0),
+        )
+        val client = newClient(config)
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 400
+        error.message should include("Bearer token file is empty")
+        error.message should not include tokenFile.toString
+      } finally {
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+
+    "not expose the bearer token file path when the token file cannot be read" in {
+      val tokenFile = Files.createTempFile("canton-extension-missing-token", ".txt")
+      val existingTokenFile = ExistingFile.tryCreate(tokenFile.toFile)
+      Files.deleteIfExists(tokenFile)
+
+      val config = ExtensionServiceConfig(
+        address = "127.0.0.1",
+        port = Port.tryCreate(12345),
+        version = "v0",
+        tls = None,
+        auth = ExtensionServiceAuthConfig.BearerTokenFile(existingTokenFile),
+        maxRetries = NonNegativeInt.tryCreate(0),
+      )
+      val client = newClient(config)
+
+      val error = loggerFactory.suppressWarnings {
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
+      }
+
+      error.statusCode shouldBe 400
+      error.message should include("Failed to read bearer token file")
+      error.message should not include tokenFile.toString
+    }
+
+    "reject malformed bearer token contents without exposing the token" in {
+      val tokenFile = Files.createTempFile("canton-extension-malformed-token", ".txt")
+      Files.writeString(tokenFile, "secret-token\nInjected: value", StandardCharsets.UTF_8)
+
+      try {
+        val config = ExtensionServiceConfig(
+          address = "127.0.0.1",
+          port = Port.tryCreate(12345),
+          version = "v0",
+          tls = None,
+          auth = ExtensionServiceAuthConfig.BearerTokenFile(
+            ExistingFile.tryCreate(tokenFile.toFile)
+          ),
+          maxRetries = NonNegativeInt.tryCreate(0),
+        )
+        val client = newClient(config)
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 400
+        error.message should include("Bearer token file contains invalid characters")
+        error.message should not include "secret-token"
+        error.message should not include tokenFile.toString
+      } finally {
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+
+    "reject bearer token contents with surrounding whitespace" in {
+      val tokenFile = Files.createTempFile("canton-extension-whitespace-token", ".txt")
+      Files.writeString(tokenFile, " secret-token\n", StandardCharsets.UTF_8)
+
+      try {
+        val config = configForPort(12345).copy(
+          auth = ExtensionServiceAuthConfig.BearerTokenFile(
+            ExistingFile.tryCreate(tokenFile.toFile)
+          ),
+          maxRetries = NonNegativeInt.tryCreate(0),
+        )
+        val client = newClient(config)
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 400
+        error.message should include("Bearer token file contains invalid characters")
+        error.message should not include "secret-token"
+        error.message should not include tokenFile.toString
+      } finally {
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+
+    "reject non-ASCII bearer token contents without exposing the token" in {
+      val tokenFile = Files.createTempFile("canton-extension-non-ascii-token", ".txt")
+      Files.writeString(tokenFile, "secret-token\u0100", StandardCharsets.UTF_8)
+
+      try {
+        val config = ExtensionServiceConfig(
+          address = "127.0.0.1",
+          port = Port.tryCreate(12345),
+          version = "v0",
+          tls = None,
+          auth = ExtensionServiceAuthConfig.BearerTokenFile(
+            ExistingFile.tryCreate(tokenFile.toFile)
+          ),
+          maxRetries = NonNegativeInt.tryCreate(0),
+        )
+        val client = newClient(config)
+
+        val error = loggerFactory.suppressWarnings {
+          client
+            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+        }
+
+        error.statusCode shouldBe 400
+        error.message should include("Bearer token file contains invalid characters")
+        error.message should not include "secret-token"
+        error.message should not include tokenFile.toString
+      } finally {
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+  }
+
+  "ExtensionServiceManager" should {
+    "return a helpful 404 when an extension id is not configured" in {
+      val manager = new ExtensionServiceManager(
+        Map(
+          "first-extension" -> configForUnusedPort(),
+          "second-extension" -> configForUnusedPort(),
+        ),
+        loggerFactory,
+        timeouts,
+      )
+
+      try {
+        val error = manager
+          .handleExternalCall(
+            "missing-extension",
+            "function",
+            "config-hash",
+            "input",
+            ExternalCallMode.Submission,
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
+
+        error.statusCode shouldBe 404
+        error.requestId shouldBe None
+        error.message should include("Extension 'missing-extension' not configured")
+        error.message should not include "first-extension"
+        error.message should not include "second-extension"
+      } finally {
+        manager.close()
+      }
+    }
+
+    "skip remote startup validation by default" in {
+      val manager = new ExtensionServiceManager(
+        Map("test-extension" -> configForUnusedPort()),
+        loggerFactory,
+        timeouts,
+      )
+
+      try {
+        manager.initializeOnStartup().failOnShutdown.futureValue shouldBe Right(())
+      } finally {
+        manager.close()
+      }
+    }
+
+    "fail local startup preflight before remote validation" in {
+      val tokenFile = Files.createTempFile("canton-extension-empty-token", ".txt")
+
+      try {
+        val manager = new ExtensionServiceManager(
+          Map(
+            "test-extension" -> configForUnusedPort().copy(
+              auth = ExtensionServiceAuthConfig.BearerTokenFile(
+                ExistingFile.tryCreate(tokenFile.toFile)
+              )
+            )
+          ),
+          loggerFactory,
+          timeouts,
+        )
+
+        try {
+          loggerFactory.assertLogsSeq(SuppressionRule.LevelAndAbove(Level.ERROR))(
+            inside(manager.initializeOnStartup().failOnShutdown.futureValue) { case Left(error) =>
+              error should include("Bearer token file is empty")
+              error should not include tokenFile.toString
+            },
+            entries =>
+              inside(entries) { case Seq(entry) =>
+                entry.errorMessage should include("Extension startup local preflight failed")
+                entry.errorMessage should include("Bearer token file is empty")
+                entry.errorMessage should not include tokenFile.toString
+              },
+          )
+        } finally {
+          manager.close()
+        }
+      } finally {
+        Files.deleteIfExists(tokenFile)
+      }
+    }
+
+    "fail startup when enabled remote validation cannot reach the extension service" in {
+      val manager = new ExtensionServiceManager(
+        Map("test-extension" -> configForUnusedPort().copy(validateOnStartup = true)),
+        loggerFactory,
+        timeouts,
+      )
+
+      try {
+        loggerFactory.assertLogsSeq(SuppressionRule.LevelAndAbove(Level.ERROR))(
+          inside(manager.initializeOnStartup().failOnShutdown.futureValue) { case Left(error) =>
+            error should include("Extension startup validation failed")
+            error should include("test-extension")
+          },
+          entries =>
+            inside(entries) { case Seq(entry) =>
+              entry.errorMessage should include("Extension startup validation failed")
+              entry.errorMessage should include("test-extension")
+            },
+        )
+      } finally {
+        manager.close()
+      }
+    }
+  }
+
+  private def newClient(config: ExtensionServiceConfig)(implicit
+      ec: ExecutionContext
+  ): HttpExtensionServiceClient =
+    new HttpExtensionServiceClient(
+      extensionId = "test-extension",
+      config = config,
+      httpClient = ExtensionServiceManager.createHttpClient(config),
+      performUnlessClosing = FlagCloseable(logger, timeouts),
+      loggerFactory = loggerFactory,
+    )(ec)
+
+  private def configFor(server: HttpServer): ExtensionServiceConfig =
+    configForPort(server.getAddress.getPort)
+
+  private def configForPort(port: Int): ExtensionServiceConfig =
+    ExtensionServiceConfig(
+      address = "127.0.0.1",
+      port = Port.tryCreate(port),
+      version = "v0",
+      auth = ExtensionServiceAuthConfig.None,
+      connectTimeout = PositiveFiniteDuration.ofMillis(100),
+      requestTimeout = PositiveFiniteDuration.ofSeconds(1),
+      maxRetries = NonNegativeInt.tryCreate(0),
+      retryInitialDelay = NonNegativeFiniteDuration.ofMillis(1000),
+      retryMaxDelay = NonNegativeFiniteDuration.ofSeconds(1),
+    )
+
+  private def configForUnusedPort(): ExtensionServiceConfig =
+    configForPort(unusedPort()).copy(
+      requestTimeout = PositiveFiniteDuration.ofMillis(500)
+    )
+
+  private def testPem(fileName: String): PemFile =
+    PemFile(ExistingFile.tryCreate(JarResourceUtils.resourceFile(s"test-certificates/$fileName")))
+
+  private def testServerSslContext(): javax.net.ssl.SSLContext =
+    HttpService.buildSSLContext(
+      TlsServerConfig(
+        certChainFile = testPem("server.crt"),
+        privateKeyFile = testPem("server.pem"),
+        trustCollectionFile = Some(testPem("ca.crt")),
+        clientAuth = ServerAuthRequirementConfig.None,
+      )
+    )
+
+  private def writeResponse(
+      exchange: com.sun.net.httpserver.HttpExchange,
+      statusCode: Int,
+      body: String,
+  ): Unit = {
+    val bytes = body.getBytes(StandardCharsets.UTF_8)
+    exchange.sendResponseHeaders(statusCode, bytes.length.toLong)
+    val responseBody = exchange.getResponseBody
+    try responseBody.write(bytes)
+    finally responseBody.close()
+  }
+
+  private def unusedPort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -119,6 +119,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       }
     }
 
+    "build service URIs for IPv6 literals" in {
+      val uri = HttpExtensionServiceClient.serviceUri(
+        scheme = "http",
+        address = "::1",
+        port = Port.tryCreate(8080),
+        path = "/api/v0/external-call",
+      )
+
+      uri.toString shouldBe "http://[::1]:8080/api/v0/external-call"
+      Set("::1", "[::1]") should contain(uri.getHost)
+    }
+
     "reject malformed outbound header values without sending a request" in {
       val requests = new AtomicInteger(0)
       val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -423,17 +423,26 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       }
     }
 
-    "map request timeout failures to 408" in {
+    "map stalled response body timeout failures to 408" in {
       val releaseResponse = new CountDownLatch(1)
       val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
       server.createContext(
         "/",
         exchange => {
-          releaseResponse.await(5, TimeUnit.SECONDS)
+          val body = "too late".getBytes(StandardCharsets.UTF_8)
+          exchange.sendResponseHeaders(200, body.length.toLong)
+          val responseBody = exchange.getResponseBody
           try {
-            writeResponse(exchange, 200, "too late")
+            responseBody.flush()
+            releaseResponse.await(5, TimeUnit.SECONDS)
+            responseBody.write(body)
           } catch {
             case _: IOException => ()
+          } finally {
+            try responseBody.close()
+            catch {
+              case _: IOException => ()
+            }
           }
         },
       )

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -896,6 +896,7 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       extensionId = "test-extension",
       config = config,
       httpClient = ExtensionServiceManager.createHttpClient(config),
+      timeoutScheduler = scheduledExecutor(),
       performUnlessClosing = FlagCloseable(logger, timeouts),
       loggerFactory = loggerFactory,
     )(ec)

--- a/project/BuildCommon.scala
+++ b/project/BuildCommon.scala
@@ -1232,6 +1232,7 @@ object BuildCommon {
         DamlProjects.`test-evidence-generator` % "test->test",
         DamlProjects.`test-evidence-tag` % "test->test",
         `community-common` % "test->test",
+        `daml-tls` % "test->test",
         `ledger-json-api` % "compile->compile;test->test",
       )
       .enablePlugins(DamlPlugin)


### PR DESCRIPTION
## Summary

This is the next small PR in the external-call stack tracked in #513.

#506 added the transaction-side representation for recording external call results. #514 added the LF `EXTERNAL_CALL` builtin surface. #518 wired the builtin into Speedy and the LF engine. #522 added transaction protobuf encoding and decoding. #526 added Canton protocol serialization support for recorded external call results.

This PR adds the participant-side extension-service client layer that later runtime integration will use to execute external calls against configured external services.

## Scope

This PR adds:

- extension-service configuration data types for participant-side clients
- an `ExtensionServiceClient` abstraction and manager for configured extension services
- an HTTP implementation for `POST /api/<version>/external-call`
- startup reachability/version checks via `GET /api/<version>/version`
- bearer-token authentication support
- Canton TLS client config support for extension-service HTTP calls
- request IDs, idempotency keys, and external-call mode headers
- bounded response handling, retry handling, and sanitized client errors
- focused participant tests for HTTP client behavior, retries, auth, TLS, startup checks, and response validation

## Out of scope

Runtime wiring into command interpretation and participant validation is intentionally left for the next PR in the stack.

This PR also does not change LF semantics, Canton protocol serialization, confirmation-response behavior, or the external-call server API.

Refs #513.