### PR TITLE
feat(external-call): command-execution errors, rejection and handler SPI

### DIFF
--- a/.circleci/branches_to_be_fully_recompiled_in_ci.txt
+++ b/.circleci/branches_to_be_fully_recompiled_in_ci.txt
@@ -1,0 +1,5 @@
+^main$
+zenith-network:angelol/external-call-06-split-pr3-interp
+fork/zenith-network/angelol/external-call-06-split-pr3-interp
+zenith-network/angelol/external-call-06-split-pr3-interp
+pull/551/head

--- a/base/errors/src/main/scala/com/digitalasset/base/error/ErrorResource.scala
+++ b/base/errors/src/main/scala/com/digitalasset/base/error/ErrorResource.scala
@@ -35,6 +35,8 @@ object ErrorResource {
   lazy val ExceptionValue: ErrorResource = ErrorResource("EXCEPTION_VALUE")
   lazy val ExceptionType: ErrorResource = ErrorResource("EXCEPTION_TYPE")
   lazy val ExceptionText: ErrorResource = ErrorResource("EXCEPTION_TEXT")
+  lazy val ExternalCallExtensionId: ErrorResource = ErrorResource("EXTERNAL_CALL_EXTENSION_ID")
+  lazy val ExternalCallFunctionId: ErrorResource = ErrorResource("EXTERNAL_CALL_FUNCTION_ID")
   lazy val DevErrorType: ErrorResource = ErrorResource("DEV_ERROR_TYPE")
   lazy val SynchronizerId: ErrorResource = ErrorResource("SYNCHRONIZER_ID")
   lazy val SynchronizerAlias: ErrorResource = ErrorResource("SYNCHRONIZER_ALIAS")
@@ -56,6 +58,8 @@ object ErrorResource {
     ExceptionType,
     ExceptionValue,
     ExpectedType,
+    ExternalCallExtensionId,
+    ExternalCallFunctionId,
     FieldIndex,
     IdentityProviderConfig,
     InterfaceId,

--- a/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
+++ b/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
@@ -80,55 +80,34 @@ class ExternalCallEngineTest extends AnyWordSpec with Matchers with Inside with 
   )
 
   "Engine.submit" should {
-    "emit ResultNeedExternalCall with the expected payload and continuation" in {
-      val result = submit(newEngine())
+    Seq(
+      ("populated", "Call", "0a0b", "c0ff", "beef"),
+      ("empty", "CallEmptyPayloads", "", "", ""),
+    ).foreach { case (label, choice, expectedConfig, expectedInput, expectedOutput) =>
+      s"emit ResultNeedExternalCall and record the result for $label payloads" in {
+        val result = submit(newEngine(), choice)
 
-      inside(result) {
-        case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
-          extensionId shouldBe "ext"
-          functionId shouldBe "fun"
-          configHash shouldBe "0a0b"
-          input shouldBe "c0ff"
+        inside(result) {
+          case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
+            extensionId shouldBe "ext"
+            functionId shouldBe "fun"
+            configHash shouldBe expectedConfig
+            input shouldBe expectedInput
 
-          inside(resume(Right("beef")).consume()) { case Right((tx, _)) =>
-            val exerciseNodes = tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
-            exerciseNodes should have size 1
-            exerciseNodes.head.externalCallResults shouldBe ImmArray(
-              ExternalCallResult(
-                extensionId = "ext",
-                functionId = "fun",
-                config = data.Bytes.assertFromString("0a0b"),
-                input = data.Bytes.assertFromString("c0ff"),
-                output = data.Bytes.assertFromString("beef"),
+            inside(resume(Right(expectedOutput)).consume()) { case Right((tx, _)) =>
+              val exerciseNodes = tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+              exerciseNodes should have size 1
+              exerciseNodes.head.externalCallResults shouldBe ImmArray(
+                ExternalCallResult(
+                  extensionId = "ext",
+                  functionId = "fun",
+                  config = data.Bytes.assertFromString(expectedConfig),
+                  input = data.Bytes.assertFromString(expectedInput),
+                  output = data.Bytes.assertFromString(expectedOutput),
+                )
               )
-            )
-          }
-      }
-    }
-
-    "accept empty config, input, and output hex payloads" in {
-      val result = submit(newEngine(), "CallEmptyPayloads")
-
-      inside(result) {
-        case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
-          extensionId shouldBe "ext"
-          functionId shouldBe "fun"
-          configHash shouldBe ""
-          input shouldBe ""
-
-          inside(resume(Right("")).consume()) { case Right((tx, _)) =>
-            val exerciseNodes = tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
-            exerciseNodes should have size 1
-            exerciseNodes.head.externalCallResults shouldBe ImmArray(
-              ExternalCallResult(
-                extensionId = "ext",
-                functionId = "fun",
-                config = data.Bytes.assertFromString(""),
-                input = data.Bytes.assertFromString(""),
-                output = data.Bytes.assertFromString(""),
-              )
-            )
-          }
+            }
+        }
       }
     }
 

--- a/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
+++ b/community/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ExternalCallEngineTest.scala
@@ -41,6 +41,10 @@ class ExternalCallEngineTest extends AnyWordSpec with Matchers with Inside with 
         choice Call (self) (arg: Unit) : Text,
           controllers Cons @Party [M:T {party} this] (Nil @Party)
           to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
+
+        choice CallEmptyPayloads (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "" "";
       };
     }
   """
@@ -51,11 +55,11 @@ class ExternalCallEngineTest extends AnyWordSpec with Matchers with Inside with 
     engine
   }
 
-  def submit(engine: Engine) =
+  def submit(engine: Engine, choiceName: String = "Call") =
     engine.submit(
       submitters = Set(alice),
       readAs = Set.empty,
-      cmds = ApiCommands(ImmArray(command), let, "external-call-engine-test"),
+      cmds = ApiCommands(ImmArray(command(choiceName)), let, "external-call-engine-test"),
       participantId = participantId,
       submissionSeed = submissionSeed,
       contractIdVersion = ContractIdVersion.V1,
@@ -68,10 +72,10 @@ class ExternalCallEngineTest extends AnyWordSpec with Matchers with Inside with 
   private val submissionSeed = Hash.hashPrivateKey("ExternalCallEngineTest")
   private val let = Time.Timestamp.now()
   private val templateId = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("M:T"))
-  private val command = ApiCommand.CreateAndExercise(
+  private def command(choiceName: String) = ApiCommand.CreateAndExercise(
     templateId.toRef,
     Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(alice))),
-    Ref.ChoiceName.assertFromString("Call"),
+    Ref.ChoiceName.assertFromString(choiceName),
     Value.ValueUnit,
   )
 
@@ -96,6 +100,32 @@ class ExternalCallEngineTest extends AnyWordSpec with Matchers with Inside with 
                 config = data.Bytes.assertFromString("0a0b"),
                 input = data.Bytes.assertFromString("c0ff"),
                 output = data.Bytes.assertFromString("beef"),
+              )
+            )
+          }
+      }
+    }
+
+    "accept empty config, input, and output hex payloads" in {
+      val result = submit(newEngine(), "CallEmptyPayloads")
+
+      inside(result) {
+        case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
+          extensionId shouldBe "ext"
+          functionId shouldBe "fun"
+          configHash shouldBe ""
+          input shouldBe ""
+
+          inside(resume(Right("")).consume()) { case Right((tx, _)) =>
+            val exerciseNodes = tx.nodes.collect { case (_, exercise: Node.Exercise) => exercise }
+            exerciseNodes should have size 1
+            exerciseNodes.head.externalCallResults shouldBe ImmArray(
+              ExternalCallResult(
+                extensionId = "ext",
+                functionId = "fun",
+                config = data.Bytes.assertFromString(""),
+                input = data.Bytes.assertFromString(""),
+                output = data.Bytes.assertFromString(""),
               )
             )
           }

--- a/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
+++ b/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
@@ -48,6 +48,10 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
           controllers Cons @Party [M:T {party} this] (Nil @Party)
           to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
 
+        choice CallEmptyPayloads (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "" "";
+
         choice CallBadConfig (self) (arg: Unit) : Text,
           controllers Cons @Party [M:T {party} this] (Nil @Party)
           to EXTERNAL_CALL "ext" "fun" "zzzz" "c0ff";
@@ -55,6 +59,10 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
         choice CallBadInput (self) (arg: Unit) : Text,
           controllers Cons @Party [M:T {party} this] (Nil @Party)
           to EXTERNAL_CALL "ext" "fun" "0a0b" "nope";
+
+        choice CallOddLengthInput (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "0";
 
         choice CallUppercaseConfig (self) (arg: Unit) : Text,
           controllers Cons @Party [M:T {party} this] (Nil @Party)
@@ -91,6 +99,10 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
         ubind cid: ContractId M:T <- create @M:T M:T { party = party }
         in exercise @M:T Call cid ();
 
+      val runEmptyPayloads : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallEmptyPayloads cid ();
+
       val runBadConfig : Party -> Update Text = \(party: Party) ->
         ubind cid: ContractId M:T <- create @M:T M:T { party = party }
         in exercise @M:T CallBadConfig cid ();
@@ -98,6 +110,10 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
       val runBadInput : Party -> Update Text = \(party: Party) ->
         ubind cid: ContractId M:T <- create @M:T M:T { party = party }
         in exercise @M:T CallBadInput cid ();
+
+      val runOddLengthInput : Party -> Update Text = \(party: Party) ->
+        ubind cid: ContractId M:T <- create @M:T M:T { party = party }
+        in exercise @M:T CallOddLengthInput cid ();
 
       val runUppercaseConfig : Party -> Update Text = \(party: Party) ->
         ubind cid: ContractId M:T <- create @M:T M:T { party = party }
@@ -245,6 +261,47 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
             config = Bytes.assertFromString("0a0b"),
             input = Bytes.assertFromString("c0ff"),
             output = Bytes.assertFromString("beef"),
+          )
+        )
+      }
+    }
+
+    "accept empty config, input, and output hex payloads" in {
+      val machine = machineForRun(pkgs.compiler.unsafeCompile(e"M:runEmptyPayloads"))
+
+      var questions = 0
+      val result = SpeedyTestLib.runTxQ[Question.Update](
+        {
+          case Question.Update
+                .NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+            questions += 1
+            extensionId shouldBe "ext"
+            functionId shouldBe "fun"
+            configHash shouldBe ""
+            input shouldBe ""
+            callback(Right(""))
+          case other =>
+            fail(s"Unexpected question: $other")
+        },
+        machine,
+      )
+
+      result shouldBe Right(SText(""))
+      questions shouldBe 1
+
+      inside(machine.finish) { case Right(commit) =>
+        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) =>
+          exercise
+        }
+        exerciseNodes should have size 1
+        exerciseNodes.head.version shouldBe SerializationVersion.minExternalCallResults
+        exerciseNodes.head.externalCallResults shouldBe ImmArray(
+          ExternalCallResult(
+            extensionId = "ext",
+            functionId = "fun",
+            config = Bytes.assertFromString(""),
+            input = Bytes.assertFromString(""),
+            output = Bytes.assertFromString(""),
           )
         )
       }
@@ -439,6 +496,7 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
         "padded config" -> pkgs.compiler.unsafeCompile(e"M:runPaddedConfig"),
         "uppercase input" -> pkgs.compiler.unsafeCompile(e"M:runUppercaseInput"),
         "padded input" -> pkgs.compiler.unsafeCompile(e"M:runPaddedInput"),
+        "odd-length input" -> pkgs.compiler.unsafeCompile(e"M:runOddLengthInput"),
       ).foreach { case (label, run) =>
         withClue(label) {
           rejectConfigOrInputBeforeExternalCall(run)

--- a/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
+++ b/community/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExternalCallTest.scala
@@ -219,91 +219,49 @@ class ExternalCallTest extends AnyWordSpec with Matchers with Inside with Suppre
     )
 
   "SBExternalCall" should {
-    "resume through NeedExternalCall and record the result on the exercise node" in {
-      val machine = Speedy.Machine.fromUpdateSExpr(
-        pkgs,
-        transactionSeed,
-        SEApp(pkgs.compiler.unsafeCompile(e"M:run"), ArraySeq(SParty(alice))),
-        Set(alice),
-        MachineLogger(),
-      )
+    Seq(
+      ("populated", e"M:run", "0a0b", "c0ff", "beef"),
+      ("empty", e"M:runEmptyPayloads", "", "", ""),
+    ).foreach { case (label, expr, expectedConfig, expectedInput, expectedOutput) =>
+      s"resume NeedExternalCall and record the result on the exercise node ($label payloads)" in {
+        val machine = machineForRun(pkgs.compiler.unsafeCompile(expr))
 
-      var questions = 0
-      val result = SpeedyTestLib.runTxQ[Question.Update](
-        {
-          case Question.Update
-                .NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
-            questions += 1
-            extensionId shouldBe "ext"
-            functionId shouldBe "fun"
-            configHash shouldBe "0a0b"
-            input shouldBe "c0ff"
-            callback(Right("beef"))
-          case other =>
-            fail(s"Unexpected question: $other")
-        },
-        machine,
-      )
-
-      result shouldBe Right(SText("beef"))
-      questions shouldBe 1
-
-      inside(machine.finish) { case Right(commit) =>
-        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) =>
-          exercise
-        }
-        exerciseNodes should have size 1
-        exerciseNodes.head.version shouldBe SerializationVersion.minExternalCallResults
-        exerciseNodes.head.externalCallResults shouldBe ImmArray(
-          ExternalCallResult(
-            extensionId = "ext",
-            functionId = "fun",
-            config = Bytes.assertFromString("0a0b"),
-            input = Bytes.assertFromString("c0ff"),
-            output = Bytes.assertFromString("beef"),
-          )
+        var questions = 0
+        val result = SpeedyTestLib.runTxQ[Question.Update](
+          {
+            case Question.Update
+                  .NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
+              questions += 1
+              extensionId shouldBe "ext"
+              functionId shouldBe "fun"
+              configHash shouldBe expectedConfig
+              input shouldBe expectedInput
+              callback(Right(expectedOutput))
+            case other =>
+              fail(s"Unexpected question: $other")
+          },
+          machine,
         )
-      }
-    }
 
-    "accept empty config, input, and output hex payloads" in {
-      val machine = machineForRun(pkgs.compiler.unsafeCompile(e"M:runEmptyPayloads"))
+        result shouldBe Right(SText(expectedOutput))
+        questions shouldBe 1
 
-      var questions = 0
-      val result = SpeedyTestLib.runTxQ[Question.Update](
-        {
-          case Question.Update
-                .NeedExternalCall(extensionId, functionId, configHash, input, callback) =>
-            questions += 1
-            extensionId shouldBe "ext"
-            functionId shouldBe "fun"
-            configHash shouldBe ""
-            input shouldBe ""
-            callback(Right(""))
-          case other =>
-            fail(s"Unexpected question: $other")
-        },
-        machine,
-      )
-
-      result shouldBe Right(SText(""))
-      questions shouldBe 1
-
-      inside(machine.finish) { case Right(commit) =>
-        val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) =>
-          exercise
-        }
-        exerciseNodes should have size 1
-        exerciseNodes.head.version shouldBe SerializationVersion.minExternalCallResults
-        exerciseNodes.head.externalCallResults shouldBe ImmArray(
-          ExternalCallResult(
-            extensionId = "ext",
-            functionId = "fun",
-            config = Bytes.assertFromString(""),
-            input = Bytes.assertFromString(""),
-            output = Bytes.assertFromString(""),
+        inside(machine.finish) { case Right(commit) =>
+          val exerciseNodes = commit.tx.nodes.collect { case (_, exercise: Node.Exercise) =>
+            exercise
+          }
+          exerciseNodes should have size 1
+          exerciseNodes.head.version shouldBe SerializationVersion.minExternalCallResults
+          exerciseNodes.head.externalCallResults shouldBe ImmArray(
+            ExternalCallResult(
+              extensionId = "ext",
+              functionId = "fun",
+              config = Bytes.assertFromString(expectedConfig),
+              input = Bytes.assertFromString(expectedInput),
+              output = Bytes.assertFromString(expectedOutput),
+            )
           )
-        )
+        }
       }
     }
 

--- a/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
+++ b/community/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/interpretation/Error.scala
@@ -213,7 +213,9 @@ object Error {
     ) extends Error
 
     object ExecutionFailed {
-      sealed abstract class Error extends Serializable with Product
+      sealed abstract class Error extends Serializable with Product {
+        def message: String
+      }
 
       final case class CallFailed(message: String) extends Error
 

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -1099,6 +1099,92 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
       }
     }
 
+    @Explanation("Errors that occur when evaluating external-call primitives")
+    object ExternalCallError extends ErrorGroup {
+      private def externalCallResources(
+          extensionId: String,
+          functionId: String,
+          message: String,
+      ): Seq[(ErrorResource, String)] =
+        Seq(
+          ErrorResource.ExternalCallExtensionId -> extensionId,
+          ErrorResource.ExternalCallFunctionId -> functionId,
+          ErrorResource.ExceptionText -> message,
+        )
+
+      private def externalCallResources(
+          err: LfInterpretationError.ExternalCall.PreparationFailed
+      ): Seq[(ErrorResource, String)] =
+        externalCallResources(err.extensionId, err.functionId, err.message)
+
+      private def externalCallResources(
+          err: LfInterpretationError.ExternalCall.ExecutionFailed
+      ): Seq[(ErrorResource, String)] = {
+        val message = err.error match {
+          case LfInterpretationError.ExternalCall.ExecutionFailed.CallFailed(message) => message
+          case LfInterpretationError.ExternalCall.ExecutionFailed.InvalidOutput(message) => message
+        }
+        externalCallResources(err.extensionId, err.functionId, message)
+      }
+
+      @Explanation(
+        "External-call preparation failed before the participant issued the external call."
+      )
+      @Resolution(
+        "Check the external-call extension id, function id, config hash bytes, and input bytes."
+      )
+      object PreparationFailed
+          extends ErrorCode(
+            id = "INTERPRETATION_EXTERNAL_CALL_ERROR_PREPARATION_FAILED",
+            ErrorCategory.InvalidGivenCurrentSystemStateOther,
+          ) {
+        final case class Reject(
+            override val cause: String,
+            err: LfInterpretationError.ExternalCall.PreparationFailed,
+        )(implicit loggingContext: ErrorLoggingContext)
+            extends DamlErrorWithDefiniteAnswer(cause = cause) {
+          override def resources: Seq[(ErrorResource, String)] =
+            externalCallResources(err)
+        }
+      }
+
+      @Explanation("The external-call handler or service returned a failure.")
+      @Resolution(
+        "Check participant external-call configuration and the external service response."
+      )
+      object ExecutionFailed
+          extends ErrorCode(
+            id = "INTERPRETATION_EXTERNAL_CALL_ERROR_EXECUTION_FAILED",
+            ErrorCategory.InvalidGivenCurrentSystemStateOther,
+          ) {
+        final case class Reject(
+            override val cause: String,
+            err: LfInterpretationError.ExternalCall.ExecutionFailed,
+        )(implicit loggingContext: ErrorLoggingContext)
+            extends DamlErrorWithDefiniteAnswer(cause = cause) {
+          override def resources: Seq[(ErrorResource, String)] =
+            externalCallResources(err)
+        }
+      }
+
+      @Explanation("The external-call service returned output that is not valid canonical hex.")
+      @Resolution("Fix the external service to return canonical lowercase hex output.")
+      object InvalidOutput
+          extends ErrorCode(
+            id = "INTERPRETATION_EXTERNAL_CALL_ERROR_INVALID_OUTPUT",
+            ErrorCategory.InvalidGivenCurrentSystemStateOther,
+          ) {
+        final case class Reject(
+            override val cause: String,
+            err: LfInterpretationError.ExternalCall.ExecutionFailed,
+        )(implicit loggingContext: ErrorLoggingContext)
+            extends DamlErrorWithDefiniteAnswer(cause = cause) {
+          override def resources: Seq[(ErrorResource, String)] =
+            externalCallResources(err)
+        }
+      }
+    }
+
     @Explanation(
       """This error is a catch-all for errors thrown by in-development features, and should never be thrown in production."""
     )

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/error/groups/CommandExecutionErrors.scala
@@ -1119,13 +1119,8 @@ object CommandExecutionErrors extends CommandExecutionErrorGroup {
 
       private def externalCallResources(
           err: LfInterpretationError.ExternalCall.ExecutionFailed
-      ): Seq[(ErrorResource, String)] = {
-        val message = err.error match {
-          case LfInterpretationError.ExternalCall.ExecutionFailed.CallFailed(message) => message
-          case LfInterpretationError.ExternalCall.ExecutionFailed.InvalidOutput(message) => message
-        }
-        externalCallResources(err.extensionId, err.functionId, message)
-      }
+      ): Seq[(ErrorResource, String)] =
+        externalCallResources(err.extensionId, err.functionId, err.error.message)
 
       @Explanation(
         "External-call preparation failed before the participant issued the external call."

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGenerators.scala
@@ -200,9 +200,29 @@ object RejectionGenerators {
             ) =>
           CommandExecutionErrors.Interpreter.CryptoError.MalformedSignature
             .Reject(renderedMessage, error)
-        case LfInterpretationError.ExternalCall(_) =>
-          CommandExecutionErrors.Interpreter.GenericInterpretationError
-            .Error(renderedMessage)
+        case LfInterpretationError.ExternalCall(
+              error: LfInterpretationError.ExternalCall.PreparationFailed
+            ) =>
+          CommandExecutionErrors.Interpreter.ExternalCallError.PreparationFailed
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.ExternalCall(
+              error @ LfInterpretationError.ExternalCall.ExecutionFailed(
+                _,
+                _,
+                LfInterpretationError.ExternalCall.ExecutionFailed.CallFailed(_),
+              )
+            ) =>
+          CommandExecutionErrors.Interpreter.ExternalCallError.ExecutionFailed
+            .Reject(renderedMessage, error)
+        case LfInterpretationError.ExternalCall(
+              error @ LfInterpretationError.ExternalCall.ExecutionFailed(
+                _,
+                _,
+                LfInterpretationError.ExternalCall.ExecutionFailed.InvalidOutput(_),
+              )
+            ) =>
+          CommandExecutionErrors.Interpreter.ExternalCallError.InvalidOutput
+            .Reject(renderedMessage, error)
         case LfInterpretationError.Dev(_, err) =>
           CommandExecutionErrors.Interpreter.InterpretationDevError
             .Reject(renderedMessage, err)

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/execution/ExternalCallHandler.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/execution/ExternalCallHandler.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.platform.execution
+
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.daml.lf.engine.ResultNeedExternalCall
+
+/** Handler for external calls made during Daml contract execution. External calls are deterministic
+  * extension-service calls that are recorded in the transaction for replay during validation.
+  */
+trait ExternalCallHandler {
+  def handleExternalCall(
+      extensionId: String,
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ResultNeedExternalCall.Error, String]]
+}
+
+object ExternalCallHandler {
+  val Unsupported: ExternalCallHandler = new ExternalCallHandler {
+    override def handleExternalCall(
+        extensionId: String,
+        functionId: String,
+        configHash: String,
+        input: String,
+        mode: ExternalCallMode,
+    )(implicit
+        tc: TraceContext
+    ): FutureUnlessShutdown[Either[ResultNeedExternalCall.Error, String]] =
+      FutureUnlessShutdown.pure(Left(ResultNeedExternalCall.Error("External calls not supported")))
+  }
+}

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/execution/ExternalCallMode.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/execution/ExternalCallMode.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.platform.execution
+
+/** Execution modes for external calls. */
+sealed abstract class ExternalCallMode(val wireValue: String) extends Product with Serializable
+
+object ExternalCallMode {
+  case object Submission extends ExternalCallMode("submission")
+  case object Validation extends ExternalCallMode("validation")
+}

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -6,6 +6,10 @@ package com.digitalasset.canton.ledger.api.validation
 import com.daml.ledger.api.v2.command_service.SubmitAndWaitForTransactionRequest
 import com.daml.ledger.api.v2.commands.Commands.DeduplicationPeriod as DeduplicationPeriodProto
 import com.daml.ledger.api.v2.commands.{Command, Commands, CreateCommand, PrefetchContractKey}
+import com.daml.ledger.api.v2.interactive.interactive_submission_service.{
+  HashingSchemeVersion as ApiHashingSchemeVersion,
+  PrepareSubmissionRequest,
+}
 import com.daml.ledger.api.v2.transaction_filter.TransactionShape.TRANSACTION_SHAPE_ACS_DELTA
 import com.daml.ledger.api.v2.transaction_filter.{EventFormat, Filters, TransactionFormat}
 import com.daml.ledger.api.v2.value.Value.Sum
@@ -22,6 +26,7 @@ import com.digitalasset.canton.ledger.api.{ApiMocks, Commands as ApiCommands, Di
 import com.digitalasset.canton.ledger.error.groups.RequestValidationErrors
 import com.digitalasset.canton.logging.{ErrorLoggingContext, NoLogging}
 import com.digitalasset.canton.topology.SynchronizerId
+import com.digitalasset.canton.version.HashingSchemeVersion
 import com.digitalasset.daml.lf.command.{
   ApiCommand as LfCommand,
   ApiCommands as LfCommands,
@@ -212,6 +217,12 @@ class SubmitRequestValidatorTest
 
     when(validateDisclosedContractsMock.validateCommands(any[Commands])(any[ErrorLoggingContext]))
       .thenReturn(Right(internal.disclosedContracts))
+    when(
+      validateDisclosedContractsMock.validateDisclosedContracts(
+        any[Seq[com.daml.ledger.api.v2.commands.DisclosedContract]]
+      )(any[ErrorLoggingContext])
+    )
+      .thenReturn(Right(ImmArray.Empty))
 
     new CommandsValidator(
       validateUpgradingPackageResolutions = ValidateUpgradingPackageResolutions.Empty,
@@ -222,6 +233,8 @@ class SubmitRequestValidatorTest
   private val testedSubmitAndWaitRequestValidator = new SubmitAndWaitRequestValidator(
     testedCommandValidator
   )
+
+  private val testedSubmitRequestValidator = new SubmitRequestValidator(testedCommandValidator)
 
   private val testedValueValidator = ValueValidator
 
@@ -284,6 +297,36 @@ class SubmitRequestValidatorTest
             "MISSING_FIELD(8,0): The submitted command is missing a mandatory field: transaction_format",
           metadata = Map.empty,
         )
+      }
+    }
+
+    "validating interactive submission requests" should {
+      "accept HASHING_SCHEME_VERSION_V4 for prepare requests" in {
+        val result = testedSubmitRequestValidator.validatePrepare(
+          req = PrepareSubmissionRequest(
+            userId = userId,
+            commandId = commandId.unwrap,
+            commands = Seq(api.command),
+            minLedgerTime = None,
+            actAs = Seq(api.submitter),
+            readAs = Seq.empty,
+            disclosedContracts = Seq.empty,
+            synchronizerId = api.synchronizerId,
+            packageIdSelectionPreference = Seq.empty,
+            verboseHashing = false,
+            prefetchContractKeys = Seq.empty,
+            maxRecordTime = None,
+            estimateTrafficCost = None,
+            tapsMaxPasses = None,
+            hashingSchemeVersion = Some(ApiHashingSchemeVersion.HASHING_SCHEME_VERSION_V4),
+          ),
+          currentLedgerTime = internal.ledgerTime,
+          currentUtcTime = internal.submittedAt,
+        )
+
+        inside(result) { case Right(validated) =>
+          validated.hashingSchemeVersion shouldBe HashingSchemeVersion.V4
+        }
       }
     }
 

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGeneratorsExternalCallSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/RejectionGeneratorsExternalCallSpec.scala
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.platform.apiserver.services
+
+import com.digitalasset.base.error.ErrorResource
+import com.digitalasset.base.error.utils.ErrorDetails
+import com.digitalasset.canton.ledger.error.groups.CommandExecutionErrors
+import com.digitalasset.canton.logging.{ErrorLoggingContext, NoLogging}
+import com.digitalasset.daml.lf.engine.Error as LfError
+import com.digitalasset.daml.lf.interpretation.Error as LfInterpretationError
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RejectionGeneratorsExternalCallSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  private implicit val loggingContext: ErrorLoggingContext = NoLogging
+
+  behavior of "RejectionGenerators external-call interpretation errors"
+
+  it should "emit preparation-failed metadata" in {
+    assertExternalCallMetadata(
+      LfInterpretationError.ExternalCall.PreparationFailed(
+        extensionId = "test-extension",
+        functionId = "test-function",
+        message = "bad config",
+      ),
+      CommandExecutionErrors.Interpreter.ExternalCallError.PreparationFailed.id,
+      "bad config",
+    )
+  }
+
+  it should "emit execution-failed metadata" in {
+    assertExternalCallMetadata(
+      LfInterpretationError.ExternalCall.ExecutionFailed(
+        extensionId = "test-extension",
+        functionId = "test-function",
+        error = LfInterpretationError.ExternalCall.ExecutionFailed.CallFailed("call failed"),
+      ),
+      CommandExecutionErrors.Interpreter.ExternalCallError.ExecutionFailed.id,
+      "call failed",
+    )
+  }
+
+  it should "emit invalid-output metadata" in {
+    assertExternalCallMetadata(
+      LfInterpretationError.ExternalCall.ExecutionFailed(
+        extensionId = "test-extension",
+        functionId = "test-function",
+        error = LfInterpretationError.ExternalCall.ExecutionFailed.InvalidOutput("bad output"),
+      ),
+      CommandExecutionErrors.Interpreter.ExternalCallError.InvalidOutput.id,
+      "bad output",
+    )
+  }
+
+  private def assertExternalCallMetadata(
+      externalCallError: LfInterpretationError.ExternalCall.Error,
+      expectedErrorCodeId: String,
+      expectedMessage: String,
+  ): Unit = {
+    val grpcError =
+      RejectionGenerators
+        .commandExecutorError(
+          ErrorCause.DamlLf(
+            LfError.Interpretation(
+              LfError.Interpretation.DamlException(
+                LfInterpretationError.ExternalCall(externalCallError)
+              ),
+              None,
+            )
+          )
+        )
+        .asGrpcError
+
+    val details = ErrorDetails.from(grpcError)
+    details.collectFirst { case ErrorDetails.ErrorInfoDetail(errorCodeId, _) =>
+      errorCodeId
+    }.value shouldBe expectedErrorCodeId
+
+    details.collect { case ErrorDetails.ResourceInfoDetail(name, typ) =>
+      typ -> name
+    } shouldBe Seq(
+      ErrorResource.ExternalCallExtensionId.asString -> "test-extension",
+      ErrorResource.ExternalCallFunctionId.asString -> "test-function",
+      ErrorResource.ExceptionText.asString -> expectedMessage,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

This is PR 3 of 8 in the external-call runtime-integration series tracked in #513, stacked on PR 2.

The external-call stack (#513): #506 added the transaction-side representation for recording external-call results; #514 added the LF `EXTERNAL_CALL` builtin surface; #518 wired it into Speedy and the LF engine; #522 added transaction protobuf encoding/decoding; #526 added Canton protocol serialization for recorded results; #537 added the participant-side extension-service client. #541 implemented the remaining runtime integration as one PR; this series splits #541 into 8 independently reviewable PRs (each < 1000 lines) and supersedes it.

This PR adds the command-execution error surface and the handler service-provider interface (SPI) that later PRs implement and wire in.

## Scope

This PR adds:

- external-call-aware command-execution errors (`CommandExecutionErrors`) and the `ErrorResource` metadata for them
- rejection generators for external-call failures (`RejectionGenerators`)
- the external-call handler SPI (`ExternalCallHandler`, `ExternalCallMode`) — the interface used by command interpretation to dispatch engine external-call questions
- tests for rejection generation, request validation, and the LF/Speedy external-call surface

## Out of scope

The concrete extension-service handler implementation and its wiring into command execution (PR 5), engine replay (PR 4), and validation/routing/factory (PR 6–8). The SPI ships with a no-op `Unsupported` handler; nothing dispatches to a real service yet.

## Stacking & review

This PR is stacked on PR 2, so its diff against `main` is **cumulative**. The incremental change for this PR alone:
https://github.com/digital-asset/canton/compare/zenith-network:angelol/external-call-06-split-pr2-codec...zenith-network:angelol/external-call-06-split-pr3-interp

Refs #513.
