### PR TITLE
feat(external-call): extension-service handler, config and command-execution wiring

### DIFF
--- a/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
+++ b/community/app-base/src/main/scala/com/digitalasset/canton/config/CantonConfig.scala
@@ -1380,6 +1380,19 @@ object CantonConfig {
       implicit val cantonEngineConfigReader: ConfigReader[CantonEngineConfig] = {
         implicit val engineLoggingConfigReader: ConfigReader[EngineLoggingConfig] =
           deriveReader[EngineLoggingConfig]
+        implicit val extensionServiceAuthConfigNoneReader
+            : ConfigReader[ExtensionServiceAuthConfig.None.type] =
+          deriveReader[ExtensionServiceAuthConfig.None.type]
+        implicit val extensionServiceAuthConfigBearerTokenFileReader
+            : ConfigReader[ExtensionServiceAuthConfig.BearerTokenFile] =
+          deriveReader[ExtensionServiceAuthConfig.BearerTokenFile]
+        implicit val extensionServiceAuthConfigReader: ConfigReader[ExtensionServiceAuthConfig] =
+          deriveReader[ExtensionServiceAuthConfig]
+        implicit val tlsClientConfigOnlyTrustFileReader
+            : ConfigReader[TlsClientConfigOnlyTrustFile] =
+          deriveReader[TlsClientConfigOnlyTrustFile]
+        implicit val extensionServiceConfigReader: ConfigReader[ExtensionServiceConfig] =
+          deriveReader[ExtensionServiceConfig]
         deriveReader[CantonEngineConfig]
       }
       implicit val participantStoreConfigReader: ConfigReader[ParticipantStoreConfig] = {
@@ -2105,6 +2118,19 @@ object CantonConfig {
       implicit val cantonEngineConfigWriter: ConfigWriter[CantonEngineConfig] = {
         implicit val engineLoggingConfigWriter: ConfigWriter[EngineLoggingConfig] =
           deriveWriter[EngineLoggingConfig]
+        implicit val extensionServiceAuthConfigNoneWriter
+            : ConfigWriter[ExtensionServiceAuthConfig.None.type] =
+          deriveWriter[ExtensionServiceAuthConfig.None.type]
+        implicit val extensionServiceAuthConfigBearerTokenFileWriter
+            : ConfigWriter[ExtensionServiceAuthConfig.BearerTokenFile] =
+          deriveWriter[ExtensionServiceAuthConfig.BearerTokenFile]
+        implicit val extensionServiceAuthConfigWriter: ConfigWriter[ExtensionServiceAuthConfig] =
+          deriveWriter[ExtensionServiceAuthConfig]
+        implicit val tlsClientConfigOnlyTrustFileWriter
+            : ConfigWriter[TlsClientConfigOnlyTrustFile] =
+          deriveWriter[TlsClientConfigOnlyTrustFile]
+        implicit val extensionServiceConfigWriter: ConfigWriter[ExtensionServiceConfig] =
+          deriveWriter[ExtensionServiceConfig]
         deriveWriter[CantonEngineConfig]
       }
       implicit val participantStoreConfigWriter: ConfigWriter[ParticipantStoreConfig] = {

--- a/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
+++ b/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
@@ -9,8 +9,9 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.functorFilter.*
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
+import com.digitalasset.canton.config.RequireTypes.Port
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
-import com.digitalasset.canton.participant.config.ParticipantNodeConfig
+import com.digitalasset.canton.participant.config.{ExtensionServiceConfig, ParticipantNodeConfig}
 import com.digitalasset.canton.sequencing.client.SequencerClientConfig
 import com.digitalasset.canton.synchronizer.mediator.MediatorNodeConfig
 import com.digitalasset.canton.synchronizer.sequencer.SequencerConfig
@@ -33,6 +34,10 @@ object ConfigValidations extends NamedLogging {
   type Validation = CantonConfig => Validated[NonEmpty[Seq[String]], Unit]
 
   private val Valid: Validated[NonEmpty[Seq[String]], Unit] = Validated.valid(())
+  private val EngineExtensionVersionPathSegmentPattern = "[A-Za-z0-9._~-]+".r
+  private val EngineExtensionVersionPathSegmentDescription =
+    "a non-empty URI path segment containing only unreserved characters [A-Za-z0-9._~-], excluding '.' and '..'"
+  private val EngineExtensionTargetPortDescription = s"between 1 and ${Port.maxValidPort}"
 
   private def toValidated(errors: Seq[String]): Validated[NonEmpty[Seq[String]], Unit] = NonEmpty
     .from(errors)
@@ -82,6 +87,9 @@ object ConfigValidations extends NamedLogging {
       adminTokenConfigsMatchOnParticipants,
       topologyAwarePackageSelectionCheckParticipants,
       eitherUserListsOrPrivilegedTokensOnParticipants,
+      engineExtensionApiVersionPathSegmentsParticipants,
+      engineExtensionTargetPortsParticipants,
+      engineExtensionRetryDelaysParticipants,
       validateSelectedSchemes,
       sessionSigningKeysOnlyWithKmsAndSchemesAreSupported,
       sessionSigningKeysParamsValidation,
@@ -421,6 +429,59 @@ object ConfigValidations extends NamedLogging {
         participantConfig.parameters.engine.enableAdditionalConsistencyChecks && !config.parameters.nonStandardConfig
       )(
         s"Enabling additional consistency checks on the Daml Engine for participant ${name.unwrap} requires to explicitly set canton.parameters.non-standard-config = true"
+      )
+    }
+    toValidated(errors)
+  }
+
+  private def engineExtensionErrors(
+      config: CantonConfig
+  )(
+      validate: (InstanceName, String, ExtensionServiceConfig) => Option[String]
+  ): Seq[String] =
+    config.participants.toSeq.flatMap { case (name, participantConfig) =>
+      participantConfig.parameters.engine.extensions.toSeq.mapFilter {
+        case (extensionId, extensionConfig) => validate(name, extensionId, extensionConfig)
+      }
+    }
+
+  private def engineExtensionApiVersionPathSegmentsParticipants(
+      config: CantonConfig
+  ): Validated[NonEmpty[Seq[String]], Unit] = {
+    val errors = engineExtensionErrors(config) { case (name, extensionId, extensionConfig) =>
+      Option.when(
+        extensionConfig.version == "." ||
+          extensionConfig.version == ".." ||
+          !EngineExtensionVersionPathSegmentPattern.pattern
+            .matcher(extensionConfig.version)
+            .matches()
+      )(
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId.version must be $EngineExtensionVersionPathSegmentDescription, but found '${extensionConfig.version}'"
+      )
+    }
+    toValidated(errors)
+  }
+
+  private def engineExtensionTargetPortsParticipants(
+      config: CantonConfig
+  ): Validated[NonEmpty[Seq[String]], Unit] = {
+    val errors = engineExtensionErrors(config) { case (name, extensionId, extensionConfig) =>
+      Option.when(extensionConfig.port == Port.Dynamic)(
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId.port must be $EngineExtensionTargetPortDescription, but found '${extensionConfig.port}'"
+      )
+    }
+    toValidated(errors)
+  }
+
+  private def engineExtensionRetryDelaysParticipants(
+      config: CantonConfig
+  ): Validated[NonEmpty[Seq[String]], Unit] = {
+    val errors = engineExtensionErrors(config) { case (name, extensionId, extensionConfig) =>
+      Option.when(
+        extensionConfig.retryInitialDelay.underlying > extensionConfig.retryMaxDelay.underlying
+      )(
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId retry delays must satisfy retry-initial-delay <= retry-max-delay; " +
+          s"respective values are (${extensionConfig.retryInitialDelay.underlying}, ${extensionConfig.retryMaxDelay.underlying})"
       )
     }
     toValidated(errors)

--- a/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
+++ b/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
@@ -34,10 +34,6 @@ object ConfigValidations extends NamedLogging {
   type Validation = CantonConfig => Validated[NonEmpty[Seq[String]], Unit]
 
   private val Valid: Validated[NonEmpty[Seq[String]], Unit] = Validated.valid(())
-  private val EngineExtensionVersionPathSegmentPattern = "[A-Za-z0-9._~-]+".r
-  private val EngineExtensionVersionPathSegmentDescription =
-    "a non-empty URI path segment containing only unreserved characters [A-Za-z0-9._~-], excluding '.' and '..'"
-  private val EngineExtensionTargetPortDescription = s"between 1 and ${Port.maxValidPort}"
 
   private def toValidated(errors: Seq[String]): Validated[NonEmpty[Seq[String]], Unit] = NonEmpty
     .from(errors)
@@ -452,11 +448,11 @@ object ConfigValidations extends NamedLogging {
       Option.when(
         extensionConfig.version == "." ||
           extensionConfig.version == ".." ||
-          !EngineExtensionVersionPathSegmentPattern.pattern
-            .matcher(extensionConfig.version)
-            .matches()
+          !extensionConfig.version.matches("[A-Za-z0-9._~-]+")
       )(
-        s"For participant ${name.unwrap}, engine.extensions.$extensionId.version must be $EngineExtensionVersionPathSegmentDescription, but found '${extensionConfig.version}'"
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId.version must be " +
+          "a non-empty URI path segment containing only unreserved characters [A-Za-z0-9._~-], " +
+          s"excluding '.' and '..', but found '${extensionConfig.version}'"
       )
     }
     toValidated(errors)
@@ -467,7 +463,8 @@ object ConfigValidations extends NamedLogging {
   ): Validated[NonEmpty[Seq[String]], Unit] = {
     val errors = engineExtensionErrors(config) { case (name, extensionId, extensionConfig) =>
       Option.when(extensionConfig.port == Port.Dynamic)(
-        s"For participant ${name.unwrap}, engine.extensions.$extensionId.port must be $EngineExtensionTargetPortDescription, but found '${extensionConfig.port}'"
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId.port must be " +
+          s"between 1 and ${Port.maxValidPort}, but found '${extensionConfig.port}'"
       )
     }
     toValidated(errors)

--- a/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
@@ -19,6 +19,7 @@ import com.digitalasset.canton.config.InitConfigBase.NodeIdentifierConfig
 import com.digitalasset.canton.config.StartupMemoryCheckConfig.ReportingLevel
 import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
 import com.digitalasset.canton.logging.{LogEntry, SuppressionRule}
+import com.digitalasset.canton.participant.config.ExtensionServiceAuthConfig
 import com.digitalasset.canton.version.HandshakeErrors.DeprecatedProtocolVersion
 import com.digitalasset.canton.version.{ProtocolVersionCompatibility, ReleaseVersion}
 import com.digitalasset.nonempty.NonEmpty
@@ -490,6 +491,46 @@ class CantonConfigTest extends AnyWordSpec with BaseTest {
       }
     }
 
+    "load bearer token file auth for participant engine extensions" in {
+      File.usingTemporaryFile("extension-token", ".txt") { tokenFile =>
+        tokenFile.writeText("test-token")
+
+        File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
+          overrideFile.writeText(
+            s"""
+               |canton.participants.participant1.parameters.engine.extensions.external-call-test {
+               |  address = "127.0.0.1"
+               |  port = 12345
+               |  version = "v-test"
+               |  tls.enabled = false
+               |
+               |  auth {
+               |    type = bearer-token-file
+               |    token-file = "${tokenFile.pathAsString}"
+               |  }
+               |}
+               |""".stripMargin
+          )
+
+          val config = CantonConfig.parseAndLoadOrExit(
+            Seq(simpleConf.toJava, overrideFile.toJava),
+            defaultPorts = None,
+          )
+
+          val extension = config
+            .participantsByString("participant1")
+            .parameters
+            .engine
+            .extensions("external-call-test")
+          extension.version shouldBe "v-test"
+
+          inside(extension.auth) { case ExtensionServiceAuthConfig.BearerTokenFile(file) =>
+            file.unwrap.getAbsolutePath shouldBe tokenFile.toJava.getAbsolutePath
+          }
+        }
+      }
+    }
+
     "remote sequencer ha onboarding config" in {
       val configE =
         CantonConfig.parseAndLoad(
@@ -538,6 +579,91 @@ class CantonConfigTest extends AnyWordSpec with BaseTest {
           .init
           .identity should matchPattern { case IdentityConfig.Auto(`expectedConfig`) => }
 
+      }
+    }
+  }
+
+  "config validation on engine extensions" should {
+    "reject API versions that are not single path segments" in {
+      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
+        overrideFile.writeText(
+          """
+             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
+             |  address = "127.0.0.1"
+             |  port = 12345
+             |  version = "v1/internal"
+             |  tls.enabled = false
+             |}
+             |""".stripMargin
+        )
+
+        val result = loggerFactory.assertLogs(
+          CantonConfig.parseAndLoad(
+            Seq(simpleConf.toJava, overrideFile.toJava),
+            defaultPorts = None,
+          ),
+          _.errorMessage should (include("external-call-test") and include(
+            "version"
+          ) and include("URI path segment")),
+        )
+
+        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
+      }
+    }
+
+    "reject extension service port 0" in {
+      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
+        overrideFile.writeText(
+          """
+             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
+             |  address = "127.0.0.1"
+             |  port = 0
+             |  version = "v1"
+             |  tls.enabled = false
+             |}
+             |""".stripMargin
+        )
+
+        val result = loggerFactory.assertLogs(
+          CantonConfig.parseAndLoad(
+            Seq(simpleConf.toJava, overrideFile.toJava),
+            defaultPorts = None,
+          ),
+          _.errorMessage should (include("external-call-test") and include("port") and include(
+            "between 1"
+          )),
+        )
+
+        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
+      }
+    }
+
+    "reject retry delays where the initial delay exceeds the maximum delay" in {
+      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
+        overrideFile.writeText(
+          """
+             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
+             |  address = "127.0.0.1"
+             |  port = 12345
+             |  version = "v1"
+             |  tls.enabled = false
+             |  retry-initial-delay = 2s
+             |  retry-max-delay = 1s
+             |}
+             |""".stripMargin
+        )
+
+        val result = loggerFactory.assertLogs(
+          CantonConfig.parseAndLoad(
+            Seq(simpleConf.toJava, overrideFile.toJava),
+            defaultPorts = None,
+          ),
+          _.errorMessage should (include("external-call-test") and include(
+            "retry-initial-delay <= retry-max-delay"
+          )),
+        )
+
+        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
       }
     }
   }

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/ApiServiceOwner.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/ApiServiceOwner.scala
@@ -40,6 +40,7 @@ import com.digitalasset.canton.platform.config.{
   UpdateServiceConfig,
   UserManagementServiceConfig,
 }
+import com.digitalasset.canton.platform.execution.ExternalCallHandler
 import com.digitalasset.canton.scheduler.SafeToPruneCommitmentState
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.user.IdentityProviderConfig
@@ -116,6 +117,7 @@ object ApiServiceOwner {
       apiContractService: ApiContractService,
       safeToPruneCommitmentState: Option[SafeToPruneCommitmentState],
       trafficEnforcementBackendO: Option[TrafficEnforcementBackend],
+      externalCallHandler: ExternalCallHandler,
   )(implicit
       actorSystem: ActorSystem,
       materializer: Materializer,
@@ -213,6 +215,7 @@ object ApiServiceOwner {
         apiContractService = apiContractService,
         partyReplicationEndpointsO = partyReplicationEndpointsO,
         trafficEnforcementBackendO = trafficEnforcementBackendO,
+        externalCallHandler = externalCallHandler,
       )(materializer, executionSequencerFactory, tracer).withServices(otherServices)
       // for all the top level gRPC servicing apparatus we use the writeApiServicesExecutionContext
       apiService <- LedgerApiService(

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/ApiServices.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/ApiServices.scala
@@ -33,6 +33,7 @@ import com.digitalasset.canton.platform.apiserver.services.command.{
 import com.digitalasset.canton.platform.apiserver.services.tracking.SubmissionTracker
 import com.digitalasset.canton.platform.apiserver.services.traffic.ApiTrafficService
 import com.digitalasset.canton.platform.config.*
+import com.digitalasset.canton.platform.execution.ExternalCallHandler
 import com.digitalasset.canton.platform.packages.DeduplicatingPackageLoader
 import com.digitalasset.canton.scheduler.SafeToPruneCommitmentState
 import com.digitalasset.canton.tracing.TraceContext
@@ -124,6 +125,7 @@ object ApiServices {
       apiContractService: ApiContractService,
       safeToPruneCommitmentState: Option[SafeToPruneCommitmentState],
       trafficEnforcementBackendO: Option[TrafficEnforcementBackend],
+      externalCallHandler: ExternalCallHandler,
   )(implicit
       materializer: Materializer,
       esf: ExecutionSequencerFactory,
@@ -285,6 +287,7 @@ object ApiServices {
           loggerFactory = loggerFactory,
           dynParamGetter = dynParamGetter,
           timeProvider = timeProvider,
+          externalCallHandler = externalCallHandler,
         )
 
       val commandExecutor =

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreter.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreter.scala
@@ -23,6 +23,7 @@ import com.digitalasset.canton.logging.{
 import com.digitalasset.canton.metrics.LedgerApiServerMetrics
 import com.digitalasset.canton.platform.*
 import com.digitalasset.canton.platform.apiserver.services.ErrorCause
+import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
 import com.digitalasset.canton.protocol.{
   CantonContractIdVersion,
   LfFatContractInst,
@@ -81,6 +82,7 @@ final class StoreBackedCommandInterpreter(
     val loggerFactory: NamedLoggerFactory,
     dynParamGetter: DynamicSynchronizerParameterGetter,
     timeProvider: TimeProvider,
+    externalCallHandler: ExternalCallHandler,
 )(implicit
     ec: ExecutionContext
 ) extends CommandInterpreter
@@ -462,23 +464,23 @@ final class StoreBackedCommandInterpreter(
             .outcomeF(loadContractsF)
             .flatMap(_ => resolveStep(resume()))
 
-        // TODO(https://github.com/digital-asset/canton/issues/513): Replace this fail-fast once command submission is wired to external calls.
-        case ResultNeedExternalCall(extensionId, functionId, _, _, _) =>
-          FutureUnlessShutdown.pure(
-            Left(
-              ErrorCause.DamlLf(
-                Error.Interpretation(
-                  Error.Interpretation.Internal(
-                    "StoreBackedCommandInterpreter",
-                    s"External calls are not supported during ledger-api command submission " +
-                      s"(extensionId=$extensionId, functionId=$functionId)",
-                    None,
-                  ),
-                  None,
+        case ResultNeedExternalCall(extensionId, functionId, configHash, input, resume) =>
+          externalCallHandler
+            .handleExternalCall(
+              extensionId,
+              functionId,
+              configHash,
+              input,
+              ExternalCallMode.Submission,
+            )
+            .flatMap { result =>
+              resolveStep(
+                Tracked.value(
+                  metrics.execution.engineRunning,
+                  trackSyncExecution(interpretationTimeNanos)(resume(result)),
                 )
               )
-            )
-          )
+            }
       }
 
     resolveStep(result).thereafter { _ =>

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreterSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/execution/StoreBackedCommandInterpreterSpec.scala
@@ -5,6 +5,7 @@ package com.digitalasset.canton.platform.apiserver.execution
 
 import cats.syntax.either.*
 import com.digitalasset.canton.crypto.TestSalt
+import com.digitalasset.canton.data.DeduplicationPeriod
 import com.digitalasset.canton.examples.java.cycle.Cycle
 import com.digitalasset.canton.ledger.api.Commands
 import com.digitalasset.canton.ledger.api.util.TimeProvider
@@ -21,22 +22,29 @@ import com.digitalasset.canton.platform.apiserver.execution.StoreBackedCommandIn
 import com.digitalasset.canton.platform.apiserver.services.ErrorCause
 import com.digitalasset.canton.platform.apiserver.services.ErrorCause.InterpretationTimeExceeded
 import com.digitalasset.canton.platform.config.CommandServiceConfig
+import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.time.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.SynchronizerId
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ContractValidator.ContractAuthenticatorFn
+import com.digitalasset.canton.util.PackageConsumer.PackageResolver
 import com.digitalasset.canton.util.TestEngine
 import com.digitalasset.canton.{BaseTest, FailOnShutdown, HasExecutionContext, LfPartyId, LfValue}
+import com.digitalasset.daml.lf.command.{ApiCommand, ApiCommands}
 import com.digitalasset.daml.lf.crypto.Hash
 import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.daml.lf.data.{Bytes, ImmArray, Ref, Time}
 import com.digitalasset.daml.lf.engine.*
 import com.digitalasset.daml.lf.interpretation.Error.UnsupportedContractId
 import com.digitalasset.daml.lf.interpretation.InterpretationConfig
+import com.digitalasset.daml.lf.language.{Ast, LanguageVersion}
+import com.digitalasset.daml.lf.testing.parser.Implicits.SyntaxHelper
+import com.digitalasset.daml.lf.testing.parser.ParserParameters
 import com.digitalasset.daml.lf.transaction.test.TransactionBuilder
 import com.digitalasset.daml.lf.transaction.{
   CreationTime,
+  ExternalCallResult,
   FatContractInstance,
   GlobalKey,
   NeedKeyProgression,
@@ -50,7 +58,7 @@ import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.wordspec.AsyncWordSpec
 
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.concurrent.Future
 
 class StoreBackedCommandInterpreterSpec
@@ -68,6 +76,69 @@ class StoreBackedCommandInterpreterSpec
       loggerFactory = loggerFactory,
     )
   private val alice = LfPartyId.assertFromString("Alice")
+  private val externalCallPackageId = Ref.PackageId.assertFromString("-external-call-test-")
+
+  implicit private val parserParameters: ParserParameters[this.type] =
+    ParserParameters(
+      defaultPackageId = externalCallPackageId,
+      languageVersion = LanguageVersion.v2_dev,
+    )
+
+  private val externalCallPackage: Ast.Package = p"""
+    metadata ( '-external-call-test-' : '1.0.0' )
+
+    module M {
+      record @serializable T = { party: Party };
+
+      template (this: T) = {
+        precondition True;
+        signatories Cons @Party [M:T {party} this] (Nil @Party);
+        observers Nil @Party;
+
+        choice Call (self) (arg: Unit) : Text,
+          controllers Cons @Party [M:T {party} this] (Nil @Party)
+          to EXTERNAL_CALL "ext" "fun" "0a0b" "c0ff";
+      };
+    }
+  """
+  private val externalCallPackageResolver: PackageResolver = new PackageResolver {
+    override protected def resolveInternal(packageId: Ref.PackageId)(implicit
+        traceContext: TraceContext
+    ): FutureUnlessShutdown[Option[Ast.Package]] =
+      FutureUnlessShutdown.pure(
+        Option.when(packageId == externalCallPackageId)(externalCallPackage)
+      )
+  }
+  private val externalCallTemplateId =
+    Ref.Identifier(externalCallPackageId, Ref.QualifiedName.assertFromString("M:T"))
+  private val externalCallApiCommands: Commands = Commands(
+    workflowId = None,
+    userId = Ref.UserId.assertFromString("external-call-user"),
+    commandId = com.digitalasset.canton.ledger.api.CommandId(
+      Ref.CommandId.assertFromString("external-call-command")
+    ),
+    submissionId = None,
+    actAs = Set(alice),
+    readAs = Set.empty,
+    submittedAt = Time.Timestamp.now(),
+    deduplicationPeriod = DeduplicationPeriod.DeduplicationOffset(None),
+    commands = ApiCommands(
+      commands = ImmArray(
+        ApiCommand.CreateAndExercise(
+          externalCallTemplateId.toRef,
+          Value.ValueRecord(None, ImmArray(None -> Value.ValueParty(alice))),
+          Ref.ChoiceName.assertFromString("Call"),
+          Value.ValueUnit,
+        )
+      ),
+      ledgerEffectiveTime = Time.Timestamp.now(),
+      commandsReference = "external-call-command",
+    ),
+    disclosedContracts = ImmArray.empty,
+    synchronizerId = None,
+    prefetchKeys = Seq.empty,
+    tapsMaxPasses = None,
+  )
 
   private val createCycleApiCommand: Commands =
     testEngine.validateCommand(new Cycle("id", alice).create().commands.loneElement, alice)
@@ -139,12 +210,14 @@ class StoreBackedCommandInterpreterSpec
       engine: Engine,
       contractStore: ContractStore = mock[ContractStore],
       contractAuthenticator: ContractAuthenticatorFn = (_, _) => Left("Not authorized"),
+      packageResolver: PackageResolver = testEngine.packageResolver,
       tolerance: NonNegativeFiniteDuration = NonNegativeFiniteDuration.tryOfSeconds(60),
+      externalCallHandler: ExternalCallHandler = ExternalCallHandler.Unsupported,
   ) =
     new StoreBackedCommandInterpreter(
       engine = engine,
       participant = Ref.ParticipantId.assertFromString("anId"),
-      packageResolver = testEngine.packageResolver,
+      packageResolver = packageResolver,
       contractStore = contractStore,
       contractAuthenticator = contractAuthenticator,
       metrics = LedgerApiServerMetrics.ForTesting,
@@ -152,12 +225,16 @@ class StoreBackedCommandInterpreterSpec
       loggerFactory = loggerFactory,
       dynParamGetter = new TestDynamicSynchronizerParameterGetter(tolerance),
       timeProvider = TimeProvider.UTC,
+      externalCallHandler = externalCallHandler,
     )
 
   "StoreBackedCommandExecutor" should {
     "add interpretation time and used disclosed contracts to result" in {
 
-      val sut = mkSut(testEngine.engine, tolerance = NonNegativeFiniteDuration.Zero)
+      val sut = mkSut(
+        testEngine.engine,
+        tolerance = NonNegativeFiniteDuration.Zero,
+      )
 
       sut
         .interpret(createCycleApiCommand, interpretationConfig, submissionSeed)(
@@ -175,7 +252,10 @@ class StoreBackedCommandInterpreterSpec
 
     "interpret successfully if time limit is not exceeded" in {
       val tolerance = NonNegativeFiniteDuration.tryOfSeconds(60)
-      val sut = mkSut(testEngine.engine, tolerance = tolerance)
+      val sut = mkSut(
+        testEngine.engine,
+        tolerance = tolerance,
+      )
 
       val commands =
         createCycleApiCommand.focus(_.commands.ledgerEffectiveTime).replace(Time.Timestamp.now())
@@ -194,7 +274,10 @@ class StoreBackedCommandInterpreterSpec
       val tolerance = NonNegativeFiniteDuration.tryOfSeconds(10)
       val let = Time.Timestamp.now().subtract(Duration.ofSeconds(20))
       val commands = createCycleApiCommand.focus(_.commands.ledgerEffectiveTime).replace(let)
-      val sut = mkSut(testEngine.engine, tolerance = tolerance)
+      val sut = mkSut(
+        testEngine.engine,
+        tolerance = tolerance,
+      )
       sut
         .interpret(commands, interpretationConfig, submissionSeed)(
           LoggingContextWithTrace(loggerFactory),
@@ -203,6 +286,67 @@ class StoreBackedCommandInterpreterSpec
         .map {
           case Left(InterpretationTimeExceeded(`let`, `tolerance`, _)) => succeed
           case other => fail(s"Did not expect: $other")
+        }
+    }
+
+    "dispatch external calls to the handler in submission mode" in {
+      val externalCallEngine = new Engine(Engine.DevConfig, loggerFactory)
+      inside(externalCallEngine.preloadPackage(externalCallPackageId, externalCallPackage)) {
+        case ResultDone(()) => succeed
+      }
+
+      val observedCall =
+        new AtomicReference[Option[(String, String, String, String, ExternalCallMode)]](None)
+      val handler = new ExternalCallHandler {
+        override def handleExternalCall(
+            extensionId: String,
+            functionId: String,
+            configHash: String,
+            input: String,
+            mode: ExternalCallMode,
+        )(implicit
+            tc: TraceContext
+        ): FutureUnlessShutdown[Either[ResultNeedExternalCall.Error, String]] = {
+          observedCall.set(Some((extensionId, functionId, configHash, input, mode)))
+          FutureUnlessShutdown.pure(Right("beef"))
+        }
+      }
+
+      val sut = mkSut(
+        externalCallEngine,
+        packageResolver = externalCallPackageResolver,
+        externalCallHandler = handler,
+      )
+
+      sut
+        .interpret(
+          externalCallApiCommands,
+          InterpretationConfig.Dev,
+          submissionSeed,
+        )(
+          LoggingContextWithTrace(loggerFactory),
+          executionContext,
+        )
+        .map {
+          case Right(result) =>
+            observedCall.get() shouldBe Some(
+              ("ext", "fun", "0a0b", "c0ff", ExternalCallMode.Submission)
+            )
+
+            val exerciseNodes = result.transaction.nodes.collect {
+              case (_, exercise: LfNode.Exercise) => exercise
+            }
+            exerciseNodes should have size 1
+            exerciseNodes.head.externalCallResults shouldBe ImmArray(
+              ExternalCallResult(
+                extensionId = "ext",
+                functionId = "fun",
+                config = Bytes.assertFromString("0a0b"),
+                input = Bytes.assertFromString("c0ff"),
+                output = Bytes.assertFromString("beef"),
+              )
+            )
+          case other => fail(s"Expected successful interpretation, got $other")
         }
     }
   }
@@ -316,7 +460,10 @@ class StoreBackedCommandInterpreterSpec
 
       val commands = repeatCycleApiCommand(invalidCid)
 
-      val sut = mkSut(testEngine.engine, contractStore = contractStore)
+      val sut = mkSut(
+        testEngine.engine,
+        contractStore = contractStore,
+      )
       sut
         .interpret(commands, interpretationConfig, submissionSeed)(
           LoggingContextWithTrace(loggerFactory),

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -58,7 +58,7 @@ class ExternalTransactionProcessorSpec
       transaction: VersionedTransaction,
       protocolVersion: ProtocolVersion,
       submissionSeed: String,
-      nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
+      nodeSeeds: ImmArray[(NodeId, LfHash)],
   ): (CommandExecutionResult, Commands) = {
     val physicalSynchronizerId =
       DefaultTestIdentities.physicalSynchronizerId.copy(protocolVersion = protocolVersion)
@@ -137,6 +137,47 @@ class ExternalTransactionProcessorSpec
     )
   }
 
+  private def vDevCreateTransaction(seed: String): (NodeId, VersionedTransaction) = {
+    val nodeId = NodeId(0)
+    val signatory = Ref.Party.assertFromString("Alice")
+    val createNode = Node.Create(
+      coid = Value.ContractId.V1(LfHash.hashPrivateKey(seed)),
+      packageName = Ref.PackageName.assertFromString("pkg"),
+      templateId = Ref.Identifier.assertFromString("pkgid:Mod:Template"),
+      arg = Value.ValueUnit,
+      signatories = Set(signatory),
+      stakeholders = Set(signatory),
+      keyOpt = None,
+      version = LfSerializationVersion.VDev,
+    )
+    val transaction = VersionedTransaction(
+      LfSerializationVersion.VDev,
+      Map(nodeId -> createNode),
+      ImmArray(nodeId),
+    )
+    (nodeId, transaction)
+  }
+
+  private def prepare(
+      transaction: VersionedTransaction,
+      protocolVersion: ProtocolVersion,
+      submissionSeed: String,
+      hashingSchemeVersion: HashingSchemeVersion,
+      nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
+  ) = {
+    val (commandExecutionResult, commands) =
+      commandExecutionResultFor(transaction, protocolVersion, submissionSeed, nodeSeeds)
+    val processor = processorFor(transaction)
+    processor.processPrepare(
+      commandExecutionResult,
+      commands,
+      PositiveInt.one,
+      HashTracer.NoOp,
+      maxRecordTime = None,
+      hashingSchemeVersion = hashingSchemeVersion,
+    )
+  }
+
   "ExternalTransactionProcessor" should {
     "honor the requested hashing scheme for non-dev prepared transactions" in {
       val transaction = VersionedTransaction(
@@ -144,107 +185,40 @@ class ExternalTransactionProcessorSpec
         Map.empty,
         ImmArray.Empty,
       )
-      val (commandExecutionResult, commands) = commandExecutionResultFor(
+      val result = prepare(
         transaction,
         ProtocolVersion.v35,
         "prepared-requested-hash-version-test",
-      )
-      val processor = processorFor(transaction)
-
-      val result = processor
-        .processPrepare(
-          commandExecutionResult,
-          commands,
-          PositiveInt.one,
-          HashTracer.NoOp,
-          maxRecordTime = None,
-          hashingSchemeVersion = HashingSchemeVersion.V3,
-        )
-        .valueOrFailShutdown("prepare transaction")
-        .futureValue
+        HashingSchemeVersion.V3,
+      ).valueOrFailShutdown("prepare transaction").futureValue
 
       result.hashVersion shouldBe HashingSchemeVersion.V3
     }
 
     "reject VDev prepared transactions when the requested hashing scheme is V2" in {
-      val nodeId = NodeId(0)
-      val signatory = Ref.Party.assertFromString("Alice")
-      val createNode = Node.Create(
-        coid = Value.ContractId.V1(LfHash.hashPrivateKey("prepared-vdev-requested-v2-contract")),
-        packageName = Ref.PackageName.assertFromString("pkg"),
-        templateId = Ref.Identifier.assertFromString("pkgid:Mod:Template"),
-        arg = Value.ValueUnit,
-        signatories = Set(signatory),
-        stakeholders = Set(signatory),
-        keyOpt = None,
-        version = LfSerializationVersion.VDev,
-      )
-      val transaction = VersionedTransaction(
-        LfSerializationVersion.VDev,
-        Map(nodeId -> createNode),
-        ImmArray(nodeId),
-      )
-      val (commandExecutionResult, commands) = commandExecutionResultFor(
+      val (nodeId, transaction) = vDevCreateTransaction("prepared-vdev-requested-v2-contract")
+
+      val result = prepare(
         transaction,
         ProtocolVersion.dev,
         "prepared-vdev-requested-v2-test",
+        HashingSchemeVersion.V2,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
-      )
-      val processor = processorFor(transaction)
-
-      val result = processor
-        .processPrepare(
-          commandExecutionResult,
-          commands,
-          PositiveInt.one,
-          HashTracer.NoOp,
-          maxRecordTime = None,
-          hashingSchemeVersion = HashingSchemeVersion.V2,
-        )
-        .value
-        .failOnShutdown("prepare transaction")
-        .futureValue
+      ).value.failOnShutdown("prepare transaction").futureValue
 
       result.left.value.reason should include("Cannot hash node with LF serialization version VDev")
     }
 
     "honor the requested hashing scheme for dev prepared transactions" in {
-      val nodeId = NodeId(0)
-      val signatory = Ref.Party.assertFromString("Alice")
-      val createNode = Node.Create(
-        coid = Value.ContractId.V1(LfHash.hashPrivateKey("prepared-vdev-requested-v4-contract")),
-        packageName = Ref.PackageName.assertFromString("pkg"),
-        templateId = Ref.Identifier.assertFromString("pkgid:Mod:Template"),
-        arg = Value.ValueUnit,
-        signatories = Set(signatory),
-        stakeholders = Set(signatory),
-        keyOpt = None,
-        version = LfSerializationVersion.VDev,
-      )
-      val transaction = VersionedTransaction(
-        LfSerializationVersion.VDev,
-        Map(nodeId -> createNode),
-        ImmArray(nodeId),
-      )
-      val (commandExecutionResult, commands) = commandExecutionResultFor(
+      val (nodeId, transaction) = vDevCreateTransaction("prepared-vdev-requested-v4-contract")
+
+      val result = prepare(
         transaction,
         ProtocolVersion.dev,
         "prepared-vdev-requested-v4-test",
+        HashingSchemeVersion.V4,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v4-node")),
-      )
-      val processor = processorFor(transaction)
-
-      val result = processor
-        .processPrepare(
-          commandExecutionResult,
-          commands,
-          PositiveInt.one,
-          HashTracer.NoOp,
-          maxRecordTime = None,
-          hashingSchemeVersion = HashingSchemeVersion.V4,
-        )
-        .valueOrFailShutdown("prepare transaction")
-        .futureValue
+      ).valueOrFailShutdown("prepare transaction").futureValue
 
       result.hashVersion shouldBe HashingSchemeVersion.V4
     }
@@ -255,25 +229,12 @@ class ExternalTransactionProcessorSpec
         Map.empty,
         ImmArray.Empty,
       )
-      val (commandExecutionResult, commands) = commandExecutionResultFor(
+      val result = prepare(
         transaction,
         ProtocolVersion.v35,
         "prepared-pv35-requested-v4-test",
-      )
-      val processor = processorFor(transaction)
-
-      val result = processor
-        .processPrepare(
-          commandExecutionResult,
-          commands,
-          PositiveInt.one,
-          HashTracer.NoOp,
-          maxRecordTime = None,
-          hashingSchemeVersion = HashingSchemeVersion.V4,
-        )
-        .value
-        .failOnShutdown("prepare transaction")
-        .futureValue
+        HashingSchemeVersion.V4,
+      ).value.failOnShutdown("prepare transaction").futureValue
 
       result.left.value.reason should include(
         "Hashing scheme version V4 is not supported on protocol version"

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -206,7 +206,9 @@ class ExternalTransactionProcessorSpec
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
       ).value.failOnShutdown("prepare transaction").futureValue
 
-      result.left.value.reason should include("Cannot hash node with LF serialization version VDev")
+      result.left.value.reason shouldBe
+        "Cannot hash node with LF serialization version VDev using hashing scheme V2." +
+        " Please use hashing scheme V4 or higher."
     }
 
     "honor the requested hashing scheme for dev prepared transactions" in {
@@ -236,9 +238,10 @@ class ExternalTransactionProcessorSpec
         HashingSchemeVersion.V4,
       ).value.failOnShutdown("prepare transaction").futureValue
 
-      result.left.value.reason should include(
-        "Hashing scheme version V4 is not supported on protocol version"
-      )
+      result.left.value.reason shouldBe
+        "Hashing scheme version V4 is not supported on protocol version 35." +
+        " Minimum protocol version for hashing version V4: dev." +
+        " Supported hashing version on protocol version 35: V2, V3"
     }
   }
 }

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.platform.apiserver.services.command.interactive.codec
+
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.DeduplicationPeriod.DeduplicationOffset
+import com.digitalasset.canton.data.LedgerTimeBoundaries
+import com.digitalasset.canton.interactive.InteractiveSubmissionEnricher
+import com.digitalasset.canton.ledger.api.{CommandId, Commands}
+import com.digitalasset.canton.ledger.participant.state.index.ContractStore
+import com.digitalasset.canton.ledger.participant.state.{
+  RoutingSynchronizerState,
+  SubmitterInfo,
+  SyncService,
+  SynchronizerRank,
+  TransactionMeta,
+}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.LoggingContextWithTrace
+import com.digitalasset.canton.platform.apiserver.execution.{
+  CommandExecutionResult,
+  CommandInterpretationResult,
+}
+import com.digitalasset.canton.platform.config.InteractiveSubmissionServiceConfig
+import com.digitalasset.canton.protocol.hash.HashTracer
+import com.digitalasset.canton.topology.DefaultTestIdentities
+import com.digitalasset.canton.version.{HashingSchemeVersion, ProtocolVersion}
+import com.digitalasset.canton.{BaseTest, HasExecutionContext, LedgerUserId, LfTimestamp}
+import com.digitalasset.daml.lf.command.ApiCommands
+import com.digitalasset.daml.lf.crypto.Hash as LfHash
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
+import com.digitalasset.daml.lf.transaction.{
+  Node,
+  NodeId,
+  SerializationVersion as LfSerializationVersion,
+  SubmittedTransaction,
+  VersionedTransaction,
+}
+import com.digitalasset.daml.lf.value.Value
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.ExecutionContext
+
+class ExternalTransactionProcessorSpec
+    extends AnyWordSpec
+    with Matchers
+    with BaseTest
+    with HasExecutionContext
+    with MockitoSugar
+    with ArgumentMatchersSugar {
+
+  private implicit val loggingContext: LoggingContextWithTrace = LoggingContextWithTrace.ForTesting
+
+  private def commandExecutionResultFor(
+      transaction: VersionedTransaction,
+      protocolVersion: ProtocolVersion,
+      submissionSeed: String,
+      nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
+  ): (CommandExecutionResult, Commands) = {
+    val physicalSynchronizerId =
+      DefaultTestIdentities.physicalSynchronizerId.copy(protocolVersion = protocolVersion)
+    val commandId = Ref.CommandId.assertFromString("command")
+    val submitterInfo = SubmitterInfo(
+      actAs = List.empty,
+      readAs = List.empty,
+      userId = LedgerUserId.assertFromString("app"),
+      commandId = commandId,
+      deduplicationPeriod = DeduplicationOffset(None),
+      submissionId = None,
+      externallySignedSubmission = None,
+      // transactionHash is computed later from the verified signature during execution
+      // (see EnrichedTransactionData / ExternalTransactionProcessor); unknown at this point.
+      transactionHash = None,
+    )
+    val transactionMeta = TransactionMeta(
+      ledgerEffectiveTime = LfTimestamp.Epoch,
+      workflowId = None,
+      preparationTime = LfTimestamp.Epoch,
+      submissionSeed = LfHash.hashPrivateKey(submissionSeed),
+      timeBoundaries = LedgerTimeBoundaries.unconstrained,
+      optUsedPackages = None,
+      optNodeSeeds = Some(nodeSeeds),
+      optByKeyNodes = None,
+    )
+    val commandExecutionResult = CommandExecutionResult(
+      commandInterpretationResult = CommandInterpretationResult(
+        submitterInfo = submitterInfo,
+        optSynchronizerId = None,
+        transactionMeta = transactionMeta,
+        transaction = SubmittedTransaction(transaction),
+        dependsOnLedgerTime = false,
+        interpretationTimeNanos = 0L,
+        processedDisclosedContracts = ImmArray.Empty,
+      ),
+      synchronizerRank = SynchronizerRank.single(physicalSynchronizerId),
+      routingSynchronizerState = mock[RoutingSynchronizerState],
+    )
+    val commands = Commands(
+      workflowId = None,
+      userId = submitterInfo.userId,
+      commandId = CommandId(commandId),
+      submissionId = None,
+      actAs = Set.empty,
+      readAs = Set.empty,
+      submittedAt = LfTimestamp.Epoch,
+      deduplicationPeriod = DeduplicationOffset(None),
+      commands = ApiCommands(
+        commands = ImmArray.Empty,
+        ledgerEffectiveTime = LfTimestamp.Epoch,
+        commandsReference = "command",
+      ),
+      disclosedContracts = ImmArray.Empty,
+      synchronizerId = None,
+      prefetchKeys = Seq.empty,
+      tapsMaxPasses = None,
+    )
+    (commandExecutionResult, commands)
+  }
+
+  private def processorFor(transaction: VersionedTransaction): ExternalTransactionProcessor = {
+    val enricher = mock[InteractiveSubmissionEnricher]
+    when(
+      enricher.enrichVersionedTransaction(any[VersionedTransaction])(
+        any[ExecutionContext],
+        anyTraceContext,
+      )
+    ).thenReturn(FutureUnlessShutdown.pure(transaction))
+    new ExternalTransactionProcessor(
+      enricher = enricher,
+      contractStore = mock[ContractStore],
+      syncService = mock[SyncService],
+      config = InteractiveSubmissionServiceConfig.Default,
+      loggerFactory = loggerFactory,
+    )
+  }
+
+  "ExternalTransactionProcessor" should {
+    "honor the requested hashing scheme for non-dev prepared transactions" in {
+      val transaction = VersionedTransaction(
+        LfSerializationVersion.V2,
+        Map.empty,
+        ImmArray.Empty,
+      )
+      val (commandExecutionResult, commands) = commandExecutionResultFor(
+        transaction,
+        ProtocolVersion.v35,
+        "prepared-requested-hash-version-test",
+      )
+      val processor = processorFor(transaction)
+
+      val result = processor
+        .processPrepare(
+          commandExecutionResult,
+          commands,
+          PositiveInt.one,
+          HashTracer.NoOp,
+          maxRecordTime = None,
+          hashingSchemeVersion = HashingSchemeVersion.V3,
+        )
+        .valueOrFailShutdown("prepare transaction")
+        .futureValue
+
+      result.hashVersion shouldBe HashingSchemeVersion.V3
+    }
+
+    "reject VDev prepared transactions when the requested hashing scheme is V2" in {
+      val nodeId = NodeId(0)
+      val signatory = Ref.Party.assertFromString("Alice")
+      val createNode = Node.Create(
+        coid = Value.ContractId.V1(LfHash.hashPrivateKey("prepared-vdev-requested-v2-contract")),
+        packageName = Ref.PackageName.assertFromString("pkg"),
+        templateId = Ref.Identifier.assertFromString("pkgid:Mod:Template"),
+        arg = Value.ValueUnit,
+        signatories = Set(signatory),
+        stakeholders = Set(signatory),
+        keyOpt = None,
+        version = LfSerializationVersion.VDev,
+      )
+      val transaction = VersionedTransaction(
+        LfSerializationVersion.VDev,
+        Map(nodeId -> createNode),
+        ImmArray(nodeId),
+      )
+      val (commandExecutionResult, commands) = commandExecutionResultFor(
+        transaction,
+        ProtocolVersion.dev,
+        "prepared-vdev-requested-v2-test",
+        ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
+      )
+      val processor = processorFor(transaction)
+
+      val result = processor
+        .processPrepare(
+          commandExecutionResult,
+          commands,
+          PositiveInt.one,
+          HashTracer.NoOp,
+          maxRecordTime = None,
+          hashingSchemeVersion = HashingSchemeVersion.V2,
+        )
+        .value
+        .failOnShutdown("prepare transaction")
+        .futureValue
+
+      result.left.value.reason should include("Cannot hash node with LF serialization version VDev")
+    }
+
+    "honor the requested hashing scheme for dev prepared transactions" in {
+      val nodeId = NodeId(0)
+      val signatory = Ref.Party.assertFromString("Alice")
+      val createNode = Node.Create(
+        coid = Value.ContractId.V1(LfHash.hashPrivateKey("prepared-vdev-requested-v4-contract")),
+        packageName = Ref.PackageName.assertFromString("pkg"),
+        templateId = Ref.Identifier.assertFromString("pkgid:Mod:Template"),
+        arg = Value.ValueUnit,
+        signatories = Set(signatory),
+        stakeholders = Set(signatory),
+        keyOpt = None,
+        version = LfSerializationVersion.VDev,
+      )
+      val transaction = VersionedTransaction(
+        LfSerializationVersion.VDev,
+        Map(nodeId -> createNode),
+        ImmArray(nodeId),
+      )
+      val (commandExecutionResult, commands) = commandExecutionResultFor(
+        transaction,
+        ProtocolVersion.dev,
+        "prepared-vdev-requested-v4-test",
+        ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v4-node")),
+      )
+      val processor = processorFor(transaction)
+
+      val result = processor
+        .processPrepare(
+          commandExecutionResult,
+          commands,
+          PositiveInt.one,
+          HashTracer.NoOp,
+          maxRecordTime = None,
+          hashingSchemeVersion = HashingSchemeVersion.V4,
+        )
+        .valueOrFailShutdown("prepare transaction")
+        .futureValue
+
+      result.hashVersion shouldBe HashingSchemeVersion.V4
+    }
+
+    "reject stable prepared transactions when the requested hashing scheme is V4" in {
+      val transaction = VersionedTransaction(
+        LfSerializationVersion.V2,
+        Map.empty,
+        ImmArray.Empty,
+      )
+      val (commandExecutionResult, commands) = commandExecutionResultFor(
+        transaction,
+        ProtocolVersion.v35,
+        "prepared-pv35-requested-v4-test",
+      )
+      val processor = processorFor(transaction)
+
+      val result = processor
+        .processPrepare(
+          commandExecutionResult,
+          commands,
+          PositiveInt.one,
+          HashTracer.NoOp,
+          maxRecordTime = None,
+          hashingSchemeVersion = HashingSchemeVersion.V4,
+        )
+        .value
+        .failOnShutdown("prepare transaction")
+        .futureValue
+
+      result.left.value.reason should include(
+        "Hashing scheme version V4 is not supported on protocol version"
+      )
+    }
+  }
+}

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -223,7 +223,7 @@ class ExternalTransactionProcessorSpec
       result.hashVersion shouldBe HashingSchemeVersion.V4
     }
 
-    "reject stable prepared transactions when the requested hashing scheme is V4" in {
+    "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is stable" in {
       val transaction = VersionedTransaction(
         LfSerializationVersion.V2,
         Map.empty,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
@@ -35,6 +35,7 @@ import com.digitalasset.canton.participant.admin.*
 import com.digitalasset.canton.participant.admin.grpc.*
 import com.digitalasset.canton.participant.admin.party.{PartyReplicationEndpoints, PartyReplicator}
 import com.digitalasset.canton.participant.config.*
+import com.digitalasset.canton.participant.extension.ExtensionServiceManager
 import com.digitalasset.canton.participant.health.admin.ParticipantStatus
 import com.digitalasset.canton.participant.ledger.api.{
   AcsCommitmentPublicationPostProcessor,
@@ -731,6 +732,33 @@ class ParticipantNodeBootstrap(
             )
             .mapK(FutureUnlessShutdown.outcomeK)
 
+        // Create extension service manager early so it can be shared with both CantonSyncService and LedgerApiServer
+        extensionServiceManagerO: Option[ExtensionServiceManager] =
+          Option.when(parameters.engine.extensions.nonEmpty) {
+            val manager = new ExtensionServiceManager(
+              extensionConfigs = parameters.engine.extensions,
+              loggerFactory = loggerFactory,
+              timeouts = timeouts,
+            )
+            logger.info(
+              s"Extension service manager initialized with ${parameters.engine.extensions.size} extension(s): " +
+                s"${parameters.engine.extensions.keys.mkString(", ")}"
+            )
+            manager
+          }
+
+        // Register before startup validation so failures close the manager's lifecycle context.
+        // The manager is shared by sync and the Ledger API; registering it before consumers keeps
+        // reverse close order closing consumers first.
+        _ = extensionServiceManagerO.foreach(addCloseable)
+
+        _ <- EitherT(
+          extensionServiceManagerO
+            .fold(FutureUnlessShutdown.pure[Either[String, Unit]](Right(())))(
+              _.initializeOnStartup()
+            )
+        )
+
         // Sync Service
         sync = CantonSyncService.create(
           participantId,
@@ -843,6 +871,7 @@ class ParticipantNodeBootstrap(
                 tracerProvider = tracerProvider,
                 updateServiceConfig = arguments.config.ledgerApi.updateService,
                 warnOnJwtScopeUsage = arguments.testingConfig.warnOnJwtScopeUsage,
+                extensionServiceManagerO = extensionServiceManagerO,
               )
             ),
           loggerFactory = loggerFactory,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/config/CantonEngineConfig.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/config/CantonEngineConfig.scala
@@ -30,6 +30,9 @@ import java.nio.file.Path
   * security consequences.
   * @param snapshotDir
   *   path to the directory used for saving transaction tree snapshots
+  * @param extensions
+  *   Configuration for external extension services that can be called from Daml contracts. Map from
+  *   extension ID to extension service configuration.
   */
 final case class CantonEngineConfig(
     enableEngineStackTraces: Boolean = false,
@@ -40,4 +43,5 @@ final case class CantonEngineConfig(
     enableAdditionalConsistencyChecks: Boolean = false,
     profileDir: Option[Path] = None,
     snapshotDir: Option[Path] = None,
+    extensions: Map[String, ExtensionServiceConfig] = Map.empty,
 )

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.canton.participant.extension
 
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 
 /** Error information from external call failures. */
@@ -21,14 +22,6 @@ object ExtensionValidationResult {
   case object Valid extends ExtensionValidationResult
 
   final case class Invalid(errors: Seq[String]) extends ExtensionValidationResult
-}
-
-/** Execution modes Canton currently emits for external calls. */
-sealed abstract class ExternalCallMode(val headerValue: String) extends Product with Serializable
-
-object ExternalCallMode {
-  case object Submission extends ExternalCallMode("submission")
-  case object Validation extends ExternalCallMode("validation")
 }
 
 /** Trait for extension service clients.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.daml.lf.engine.ResultNeedExternalCall
+
+import scala.concurrent.ExecutionContext
+
+/** ExternalCallHandler implementation that delegates to ExtensionServiceManager.
+  *
+  * This bridges the platform ExternalCallHandler interface with the participant's
+  * ExtensionServiceManager for handling external calls during command submission.
+  */
+class ExtensionServiceExternalCallHandler(
+    extensionServiceManager: ExtensionServiceManager
+)(implicit ec: ExecutionContext)
+    extends ExternalCallHandler {
+
+  override def handleExternalCall(
+      extensionId: String,
+      functionId: String,
+      configHash: String,
+      input: String,
+      mode: ExternalCallMode,
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ResultNeedExternalCall.Error, String]] =
+    extensionServiceManager
+      .handleExternalCall(
+        extensionId = extensionId,
+        functionId = functionId,
+        configHash = configHash,
+        input = input,
+        mode = mode,
+      )
+      .map(_.left.map { extensionError =>
+        ResultNeedExternalCall.Error(sanitizedEngineError(extensionError))
+      })
+
+  private def sanitizedEngineError(extensionError: ExtensionCallError): String = {
+    val requestId = extensionError.requestId.fold("")(id => s", requestId=$id")
+    s"External call failed with status ${extensionError.statusCode}$requestId"
+  }
+}
+
+object ExtensionServiceExternalCallHandler {
+
+  /** Create an ExternalCallHandler from an optional ExtensionServiceManager.
+    *
+    * @param extensionServiceManagerO
+    *   Optional ExtensionServiceManager
+    * @return
+    *   ExternalCallHandler that delegates to the manager, or Unsupported if None
+    */
+  def create(
+      extensionServiceManagerO: Option[ExtensionServiceManager]
+  )(implicit ec: ExecutionContext): ExternalCallHandler =
+    extensionServiceManagerO match {
+      case Some(manager) => new ExtensionServiceExternalCallHandler(manager)
+      case None => ExternalCallHandler.Unsupported
+    }
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -9,6 +9,7 @@ import com.digitalasset.canton.http.HttpService
 import com.digitalasset.canton.lifecycle.{FlagCloseable, FutureUnlessShutdown, LifeCycle}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.config.ExtensionServiceConfig
+import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 
 import java.net.http.HttpClient

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -11,6 +11,7 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.config.ExtensionServiceConfig
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.EitherUtil.*
 
 import java.net.http.HttpClient
 import java.security.KeyStore
@@ -111,8 +112,8 @@ class ExtensionServiceManager(
       configHash: String,
       input: String,
       mode: ExternalCallMode,
-  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] =
-    clients.get(extensionId) match {
+  )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] = {
+    val result = clients.get(extensionId) match {
       case Some(client) =>
         client.call(functionId, configHash, input, mode)
       case None =>
@@ -127,6 +128,15 @@ class ExtensionServiceManager(
           )
         )
     }
+    // Log the full error here, at the last common point before the per-consumer
+    // sanitization drops the message.
+    result.map(_.tapLeft { error =>
+      val requestId = error.requestId.fold("")(id => s", requestId=$id")
+      logger.warn(
+        s"External call to extension '$extensionId' (function '$functionId') failed: status=${error.statusCode}, retryable=${error.retryable}$requestId, message=${error.message}"
+      )
+    })
+  }
 
   def initializeOnStartup()(implicit
       tc: TraceContext

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -15,6 +15,7 @@ import com.digitalasset.canton.participant.config.{
   ExtensionServiceAuthConfig,
   ExtensionServiceConfig,
 }
+import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.TryUtil
 import com.digitalasset.canton.util.retry.{Backoff, NoExceptionRetryPolicy, Success}
@@ -292,7 +293,7 @@ class HttpExtensionServiceClient(
             .header("Accept", "text/plain")
             .header("X-Daml-External-Function-Id", functionId)
             .header("X-Daml-External-Config-Hash", configHash)
-            .header("X-Daml-External-Mode", mode.headerValue)
+            .header("X-Daml-External-Mode", mode.wireValue)
             .header("X-Request-Id", requestId)
             .header("Idempotency-Key", idempotencyKey)
 
@@ -317,7 +318,7 @@ class HttpExtensionServiceClient(
                 .build()
 
               logger.debug(
-                s"Making external call to extension '$extensionId': functionId=$functionId, mode=${mode.headerValue}, requestId=$requestId"
+                s"Making external call to extension '$extensionId': functionId=$functionId, mode=${mode.wireValue}, requestId=$requestId"
               )
 
               performUnlessClosing
@@ -426,7 +427,7 @@ class HttpExtensionServiceClient(
       requestId: String,
       defaultMessage: String,
   )(implicit tc: TraceContext): ExtensionCallError = {
-    debugLogErrorBody(resp, requestId)
+    logErrorBody(resp, requestId)
     ExtensionCallError(
       resp.statusCode(),
       defaultMessage,
@@ -435,13 +436,13 @@ class HttpExtensionServiceClient(
     )
   }
 
-  private def debugLogErrorBody(resp: HttpResponse[String], requestId: String)(implicit
+  private def logErrorBody(resp: HttpResponse[String], requestId: String)(implicit
       tc: TraceContext
   ): Unit =
-    if (logger.underlying.isDebugEnabled) {
+    if (logger.underlying.isInfoEnabled) {
       val statusCode = resp.statusCode()
       HttpExtensionServiceClient.diagnosticResponseBody(resp.body()).foreach { body =>
-        logger.debug(
+        logger.info(
           s"External call to extension '$extensionId' returned HTTP $statusCode with response body '$body': requestId=$requestId"
         )
       }
@@ -452,7 +453,7 @@ class HttpExtensionServiceClient(
 }
 
 object HttpExtensionServiceClient {
-  private val MaxDiagnosticResponseBodyChars: Int = 1024
+  private val MaxDiagnosticResponseBodyChars: Int = 8192
 
   private[extension] def isRetryableHttpStatus(statusCode: Int): Boolean =
     statusCode match {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/ledger/api/LedgerApiServer.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/ledger/api/LedgerApiServer.scala
@@ -39,6 +39,10 @@ import com.digitalasset.canton.participant.config.{
   ParticipantStoreConfig,
   TestingTimeServiceConfig,
 }
+import com.digitalasset.canton.participant.extension.{
+  ExtensionServiceExternalCallHandler,
+  ExtensionServiceManager,
+}
 import com.digitalasset.canton.participant.store.ParticipantNodePersistentState
 import com.digitalasset.canton.participant.sync.CantonSyncService
 import com.digitalasset.canton.participant.{
@@ -121,6 +125,7 @@ class LedgerApiServer(
     trafficEnforcementBackendO: Option[Eval[TrafficEnforcementBackend]],
     warnOnJwtScopeUsage: Boolean,
     val loggerFactory: NamedLoggerFactory,
+    extensionServiceManagerO: Option[ExtensionServiceManager],
 )(implicit
     executionContext: ExecutionContextIdlenessExecutorService,
     actorSystem: ActorSystem,
@@ -313,6 +318,7 @@ class LedgerApiServer(
         lfValueTranslation = lfValueTranslation,
         loggerFactory = loggerFactory,
       )
+      externalCallHandler = ExtensionServiceExternalCallHandler.create(extensionServiceManagerO)
       (_, authInterceptor) <- ApiServiceOwner(
         indexService = indexService,
         transactionSubmissionTracker = inMemoryState.transactionSubmissionTracker,
@@ -373,6 +379,7 @@ class LedgerApiServer(
         apiContractService = apiContractService,
         safeToPruneCommitmentState = pruningConfig.safeToPruneCommitmentState,
         trafficEnforcementBackendO = trafficEnforcementBackendO.map(_.value),
+        externalCallHandler = externalCallHandler,
       )
       _ <- startHttpApiIfEnabled(
         timedSyncService,
@@ -541,6 +548,7 @@ object LedgerApiServer {
       tracerProvider: TracerProvider,
       updateServiceConfig: UpdateServiceConfig,
       warnOnJwtScopeUsage: Boolean,
+      extensionServiceManagerO: Option[ExtensionServiceManager],
   )(implicit
       actorSystem: ActorSystem,
       executionContext: ExecutionContextIdlenessExecutorService,
@@ -597,6 +605,7 @@ object LedgerApiServer {
       updateServiceConfig = updateServiceConfig,
       trafficEnforcementBackendO = trafficEnforcementBackendO,
       warnOnJwtScopeUsage = warnOnJwtScopeUsage,
+      extensionServiceManagerO = extensionServiceManagerO,
     ).owner()
     new ResourceOwnerFlagCloseableOps(ledgerApiServerOwner)
       .acquireFlagCloseable("Ledger API Server")

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.BaseTest
+import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.platform.execution.ExternalCallMode
+import com.digitalasset.canton.util.Thereafter.syntax.*
+import org.scalatest.wordspec.AsyncWordSpec
+
+class ExtensionServiceExternalCallHandlerTest extends AsyncWordSpec with BaseTest {
+
+  private def emptyManager: ExtensionServiceManager =
+    ExtensionServiceManager.empty(loggerFactory, ProcessingTimeout())
+
+  "ExtensionServiceExternalCallHandler.create" should {
+
+    "use provided manager when manager is provided" in {
+      val manager = emptyManager
+      val handler = ExtensionServiceExternalCallHandler.create(Some(manager))
+
+      handler
+        .handleExternalCall(
+          "unknown-ext",
+          "test-func",
+          "00000000",
+          "deadbeef",
+          ExternalCallMode.Submission,
+        )
+        .failOnShutdown
+        .map { result =>
+          result.left.value.message should include("status 404")
+        }
+        .thereafter(_ => manager.close())
+    }
+
+    "return Unsupported when manager is None" in {
+      val handler = ExtensionServiceExternalCallHandler.create(None)
+
+      handler
+        .handleExternalCall(
+          "any-ext",
+          "any-func",
+          "00000000",
+          "deadbeef",
+          ExternalCallMode.Submission,
+        )
+        .failOnShutdown
+        .map { result =>
+          result.left.value.message should include(
+            "External calls not supported"
+          )
+        }
+    }
+  }
+
+  "ExtensionServiceExternalCallHandler" should {
+
+    "map manager errors to sanitized engine external-call errors" in {
+      val manager = emptyManager
+      val handler = new ExtensionServiceExternalCallHandler(manager)
+
+      handler
+        .handleExternalCall(
+          "unknown-ext",
+          "test-func",
+          "00000000",
+          "deadbeef",
+          ExternalCallMode.Submission,
+        )
+        .failOnShutdown
+        .map { result =>
+          val error = result.left.value
+          error.message should include("status 404")
+          error.message should not include "unknown-ext"
+          error.message should not include "not configured"
+          error.message should not include "Available extensions"
+        }
+        .thereafter(_ => manager.close())
+    }
+
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -3,13 +3,15 @@
 
 package com.digitalasset.canton.participant.extension
 
-import com.digitalasset.canton.BaseTest
 import com.digitalasset.canton.config.ProcessingTimeout
 import com.digitalasset.canton.platform.execution.ExternalCallMode
-import com.digitalasset.canton.util.Thereafter.syntax.*
-import org.scalatest.wordspec.AsyncWordSpec
+import com.digitalasset.canton.{BaseTest, HasExecutionContext}
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExtensionServiceExternalCallHandlerTest extends AsyncWordSpec with BaseTest {
+class ExtensionServiceExternalCallHandlerTest
+    extends AnyWordSpec
+    with BaseTest
+    with HasExecutionContext {
 
   private def emptyManager: ExtensionServiceManager =
     ExtensionServiceManager.empty(loggerFactory, ProcessingTimeout())
@@ -20,25 +22,32 @@ class ExtensionServiceExternalCallHandlerTest extends AsyncWordSpec with BaseTes
       val manager = emptyManager
       val handler = ExtensionServiceExternalCallHandler.create(Some(manager))
 
-      handler
-        .handleExternalCall(
-          "unknown-ext",
-          "test-func",
-          "00000000",
-          "deadbeef",
-          ExternalCallMode.Submission,
+      try {
+        loggerFactory.assertLogs(
+          {
+            val result = handler
+              .handleExternalCall(
+                "unknown-ext",
+                "test-func",
+                "00000000",
+                "deadbeef",
+                ExternalCallMode.Submission,
+              )
+              .failOnShutdown
+              .futureValue
+            result.left.value.message should include("status 404")
+          },
+          _.warningMessage shouldBe
+            "External call to extension 'unknown-ext' (function 'test-func') failed: " +
+            "status=404, retryable=false, message=Extension 'unknown-ext' not configured",
         )
-        .failOnShutdown
-        .map { result =>
-          result.left.value.message should include("status 404")
-        }
-        .thereafter(_ => manager.close())
+      } finally manager.close()
     }
 
     "return Unsupported when manager is None" in {
       val handler = ExtensionServiceExternalCallHandler.create(None)
 
-      handler
+      val result = handler
         .handleExternalCall(
           "any-ext",
           "any-func",
@@ -47,11 +56,9 @@ class ExtensionServiceExternalCallHandlerTest extends AsyncWordSpec with BaseTes
           ExternalCallMode.Submission,
         )
         .failOnShutdown
-        .map { result =>
-          result.left.value.message should include(
-            "External calls not supported"
-          )
-        }
+        .futureValue
+
+      result.left.value.message should include("External calls not supported")
     }
   }
 
@@ -61,23 +68,31 @@ class ExtensionServiceExternalCallHandlerTest extends AsyncWordSpec with BaseTes
       val manager = emptyManager
       val handler = new ExtensionServiceExternalCallHandler(manager)
 
-      handler
-        .handleExternalCall(
-          "unknown-ext",
-          "test-func",
-          "00000000",
-          "deadbeef",
-          ExternalCallMode.Submission,
+      try {
+        loggerFactory.assertLogs(
+          {
+            val error = handler
+              .handleExternalCall(
+                "unknown-ext",
+                "test-func",
+                "00000000",
+                "deadbeef",
+                ExternalCallMode.Submission,
+              )
+              .failOnShutdown
+              .futureValue
+              .left
+              .value
+            error.message should include("status 404")
+            error.message should not include "unknown-ext"
+            error.message should not include "not configured"
+            error.message should not include "Available extensions"
+          },
+          _.warningMessage shouldBe
+            "External call to extension 'unknown-ext' (function 'test-func') failed: " +
+            "status=404, retryable=false, message=Extension 'unknown-ext' not configured",
         )
-        .failOnShutdown
-        .map { result =>
-          val error = result.left.value
-          error.message should include("status 404")
-          error.message should not include "unknown-ext"
-          error.message should not include "not configured"
-          error.message should not include "Available extensions"
-        }
-        .thereafter(_ => manager.close())
+      } finally manager.close()
     }
 
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -13,6 +13,7 @@ import com.digitalasset.canton.participant.config.{
   ExtensionServiceAuthConfig,
   ExtensionServiceConfig,
 }
+import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.JarResourceUtils
 import com.digitalasset.canton.{BaseTest, HasExecutionContext}
@@ -129,6 +130,39 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
 
       uri.toString shouldBe "http://[::1]:8080/api/v0/external-call"
       Set("::1", "[::1]") should contain(uri.getHost)
+    }
+
+    "send empty config hash and input as an empty HTTP header and body" in {
+      val observedConfigHash = new AtomicReference[String]("not observed")
+      val observedBody = new AtomicReference[String]("not observed")
+
+      val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext(
+        "/",
+        exchange => {
+          val headers = exchange.getRequestHeaders
+          observedConfigHash.set(headers.getFirst("X-Daml-External-Config-Hash"))
+          observedBody.set(
+            new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+          )
+          writeResponse(exchange, 200, "beef")
+        },
+      )
+      server.start()
+
+      try {
+        val client = newClient(configFor(server))
+
+        client
+          .call("external-function", "", "", ExternalCallMode.Validation)(TraceContext.empty)
+          .failOnShutdown
+          .futureValue shouldBe Right("beef")
+
+        observedConfigHash.get shouldBe ""
+        observedBody.get shouldBe ""
+      } finally {
+        server.stop(0)
+      }
     }
 
     "reject malformed outbound header values without sending a request" in {

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -824,24 +824,31 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       )
 
       try {
-        val error = manager
-          .handleExternalCall(
-            "missing-extension",
-            "function",
-            "config-hash",
-            "input",
-            ExternalCallMode.Submission,
-          )
-          .failOnShutdown
-          .futureValue
-          .left
-          .value
+        loggerFactory.assertLogs(
+          {
+            val error = manager
+              .handleExternalCall(
+                "missing-extension",
+                "function",
+                "config-hash",
+                "input",
+                ExternalCallMode.Submission,
+              )
+              .failOnShutdown
+              .futureValue
+              .left
+              .value
 
-        error.statusCode shouldBe 404
-        error.requestId shouldBe None
-        error.message should include("Extension 'missing-extension' not configured")
-        error.message should not include "first-extension"
-        error.message should not include "second-extension"
+            error.statusCode shouldBe 404
+            error.requestId shouldBe None
+            error.message should include("Extension 'missing-extension' not configured")
+            error.message should not include "first-extension"
+            error.message should not include "second-extension"
+          },
+          _.warningMessage shouldBe
+            "External call to extension 'missing-extension' (function 'function') failed: " +
+            "status=404, retryable=false, message=Extension 'missing-extension' not configured",
+        )
       } finally {
         manager.close()
       }

--- a/community/upgrading-integration-tests/src/test/scala/com/digitalasset/canton/integration/tests/upgrading/DisclosedContractNormalizationTest.scala
+++ b/community/upgrading-integration-tests/src/test/scala/com/digitalasset/canton/integration/tests/upgrading/DisclosedContractNormalizationTest.scala
@@ -13,6 +13,7 @@ import com.digitalasset.canton.platform.apiserver.execution.{
   TestDynamicSynchronizerParameterGetter,
 }
 import com.digitalasset.canton.platform.config.CommandServiceConfig
+import com.digitalasset.canton.platform.execution.ExternalCallHandler
 import com.digitalasset.canton.protocol.{AuthenticatedContractIdVersionV10, LfFatContractInst}
 import com.digitalasset.canton.time.NonNegativeFiniteDuration
 import com.digitalasset.canton.util.{ContractValidator, TestEngine}
@@ -121,6 +122,7 @@ class DisclosedContractNormalizationTest
         dynParamGetter =
           new TestDynamicSynchronizerParameterGetter(NonNegativeFiniteDuration.Zero)(ec),
         timeProvider = TimeProvider.UTC,
+        externalCallHandler = ExternalCallHandler.Unsupported,
       )(ec)
 
     def interpretDisclosure(cId: Upgrading.ContractId, fat: LfFatContractInst): Assertion = {


### PR DESCRIPTION
## Summary

This is PR 5 of 8 in the external-call runtime-integration series tracked in #513, stacked on PR 4.

The external-call stack (#513): #506 added the transaction-side representation for recording external-call results; #514 added the LF `EXTERNAL_CALL` builtin surface; #518 wired it into Speedy and the LF engine; #522 added transaction protobuf encoding/decoding; #526 added Canton protocol serialization for recorded results; #537 added the participant-side extension-service client. #541 implemented the remaining runtime integration as one PR; this series splits #541 into 8 independently reviewable PRs (each < 1000 lines) and supersedes it.

This PR connects the #537 extension-service client to command execution: it adds the handler that routes engine external-call questions to configured extension services, the participant configuration that keys services by extension id, and the node wiring.

## Scope

This PR adds:

- the `ExtensionServiceExternalCallHandler` implementation of the PR 3 handler SPI, dispatching engine external-call questions to the #537 extension-service client (`ExtensionServiceManager` / `HttpExtensionServiceClient` / `ExtensionServiceClient` glue)
- participant extension-service configuration keyed by extension id (`CantonConfig`, `ConfigValidations`, `CantonEngineConfig`)
- handler wiring through command execution (`ApiServiceOwner`, `ApiServices`, `StoreBackedCommandInterpreter`) and node startup (`LedgerApiServer`, `ParticipantNode`)
- configuration, HTTP-handler and command-interpreter tests

## Out of scope

Recorded-result consistency checking and the extension-service validator implementation (PR 6), response routing (PR 7), and activation of validation in transaction processing (PR 8). The handler is dev-gated and off unless an extension service is configured, so the intermediate state is dormant.

## Stacking & review

This PR is stacked on PR 4, so its diff against `main` is **cumulative**. The incremental change for this PR alone (it depends on PR 3's handler SPI, not PR 4):
https://github.com/digital-asset/canton/compare/zenith-network:angelol/external-call-06-split-pr4-damle-mcc...zenith-network:angelol/external-call-06-split-pr5-extension

Refs #513.
