### PR TITLE
feat(external-call): recorded-result consistency checker and extension-service validator

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.platform.execution.ExternalCallMode
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.daml.lf.data.Bytes
+
+import scala.concurrent.ExecutionContext
+
+class ExtensionServiceExternalCallValidator(
+    extensionServiceManager: ExtensionServiceManager
+)(implicit ec: ExecutionContext)
+    extends ExternalCallValidator {
+
+  override def validate(
+      key: DAMLe.ExternalCallKey,
+      recordedOutput: Bytes,
+  )(implicit traceContext: TraceContext): FutureUnlessShutdown[ExternalCallValidator.Result] =
+    extensionServiceManager
+      .handleExternalCall(
+        extensionId = key.extensionId,
+        functionId = key.functionId,
+        configHash = key.config,
+        input = key.input,
+        mode = ExternalCallMode.Validation,
+      )
+      .map {
+        case Left(error) =>
+          val requestId = error.requestId.fold("")(id => s", requestId=$id")
+          ExternalCallValidator.UnableToValidate(
+            s"external-call validation failed with status ${error.statusCode}$requestId"
+          )
+
+        case Right(output) =>
+          Bytes.fromString(output) match {
+            case Left(_) =>
+              ExternalCallValidator.UnableToValidate(
+                "external-call validation returned non-canonical output"
+              )
+            case Right(computedOutput) if computedOutput == recordedOutput =>
+              ExternalCallValidator.Matched
+            case Right(computedOutput) =>
+              ExternalCallValidator.Mismatched(
+                computedOutput = computedOutput,
+                recordedOutput = recordedOutput,
+              )
+          }
+      }
+}
+
+object ExtensionServiceExternalCallValidator {
+  def create(
+      extensionServiceManagerO: Option[ExtensionServiceManager]
+  )(implicit ec: ExecutionContext): ExternalCallValidator =
+    extensionServiceManagerO match {
+      case Some(manager) => new ExtensionServiceExternalCallValidator(manager)
+      case None => unconfigured
+    }
+
+  private val unconfigured: ExternalCallValidator =
+    new ExternalCallValidator {
+      override def validate(
+          key: DAMLe.ExternalCallKey,
+          recordedOutput: Bytes,
+      )(implicit traceContext: TraceContext): FutureUnlessShutdown[ExternalCallValidator.Result] =
+        FutureUnlessShutdown.pure(
+          ExternalCallValidator.UnableToValidate("extension service is not configured")
+        )
+    }
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -21,10 +21,10 @@ import com.google.protobuf.ByteString
   *
   * An external-call result is ''visible'' to this participant if it is recorded in one of the
   * (unblinded) views that this participant has received for validation. External-call results are
-  * replay data that participate in validation. If two visible occurrences of the same external
-  * call record different outputs, a hosted confirming party must reject the transaction locally
-  * instead of approving an ambiguous result. Visible disagreements are also retained independently
-  * of hosted-party routing so callers can report suspicious recorded data.
+  * replay data that participate in validation. If two visible occurrences of the same external call
+  * record different outputs, a hosted confirming party must reject the transaction locally instead
+  * of approving an ambiguous result. Visible disagreements are also retained independently of
+  * hosted-party routing so callers can report suspicious recorded data.
   */
 object ExternalCallConsistencyChecker {
 
@@ -102,8 +102,8 @@ object ExternalCallConsistencyChecker {
   /** An external-call result recorded in a view that this participant has received.
     *
     * @param checkingParties
-    *   The node-level confirming parties responsible for checking this result: the signatories
-    *   and acting parties of the exercise node that recorded the call, as determined at
+    *   The node-level confirming parties responsible for checking this result: the signatories and
+    *   acting parties of the exercise node that recorded the call, as determined at
     *   transaction-tree construction. See
     *   [[com.digitalasset.canton.data.ViewParticipantData.ViewExternalCallResult]].
     */
@@ -199,9 +199,9 @@ object ExternalCallConsistencyChecker {
       .mapValues(_.sorted(orderInconsistency))
       .toMap
 
-  /** Returns per-party inconsistencies for hosted confirming parties that check disagreeing
-    * outputs for the same external call, as well as the disagreements across all visible
-    * occurrences. See [[Result]] for how the two differ.
+  /** Returns per-party inconsistencies for hosted confirming parties that check disagreeing outputs
+    * for the same external call, as well as the disagreements across all visible occurrences. See
+    * [[Result]] for how the two differ.
     */
   def check(
       viewValidationResults: Map[ViewPosition, ViewValidationResult],

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -19,10 +19,12 @@ import com.google.protobuf.ByteString
 
 /** Checks whether visible external-call results agree.
   *
-  * External-call results are replay data that participate in validation. If two visible occurrences
-  * of the same external call record different outputs, a hosted confirming party must reject the
-  * transaction locally instead of approving an ambiguous result. Visible disagreements are also
-  * retained independently of hosted-party routing so callers can report suspicious recorded data.
+  * An external-call result is ''visible'' to this participant if it is recorded in one of the
+  * (unblinded) views that this participant has received for validation. External-call results are
+  * replay data that participate in validation. If two visible occurrences of the same external
+  * call record different outputs, a hosted confirming party must reject the transaction locally
+  * instead of approving an ambiguous result. Visible disagreements are also retained independently
+  * of hosted-party routing so callers can report suspicious recorded data.
   */
 object ExternalCallConsistencyChecker {
 
@@ -69,14 +71,26 @@ object ExternalCallConsistencyChecker {
       )
   }
 
+  /** Outcome of [[check]].
+    *
+    * @param hostedInconsistencies
+    *   Inconsistencies grouped by hosted confirming party, restricted for each party to the
+    *   occurrences that the party is responsible for checking. Grouped by party because
+    *   confirmation responses are issued on behalf of individual confirming parties: each hosted
+    *   confirming party must reject exactly the disagreements among its own occurrences.
+    * @param visibleInconsistencies
+    *   Inconsistencies across all occurrences visible to this participant, irrespective of which
+    *   parties it hosts. Used to alarm on suspicious recorded data even if this participant hosts
+    *   no affected checking party.
+    */
   final case class Result(
-      inconsistencies: Map[LfPartyId, Seq[Inconsistency]],
+      hostedInconsistencies: Map[LfPartyId, Seq[Inconsistency]],
       visibleInconsistencies: Seq[Inconsistency],
   ) extends PrettyPrinting {
-    def inconsistentParties: Set[LfPartyId] = inconsistencies.keySet
+    def inconsistentParties: Set[LfPartyId] = hostedInconsistencies.keySet
 
     override protected def pretty: Pretty[Result] = prettyOfClass(
-      param("inconsistencies", _.inconsistencies),
+      param("hostedInconsistencies", _.hostedInconsistencies),
       param("visibleInconsistencies", _.visibleInconsistencies),
     )
   }
@@ -85,6 +99,14 @@ object ExternalCallConsistencyChecker {
     val empty: Result = Result(Map.empty, Seq.empty)
   }
 
+  /** An external-call result recorded in a view that this participant has received.
+    *
+    * @param checkingParties
+    *   The node-level confirming parties responsible for checking this result: the signatories
+    *   and acting parties of the exercise node that recorded the call, as determined at
+    *   transaction-tree construction. See
+    *   [[com.digitalasset.canton.data.ViewParticipantData.ViewExternalCallResult]].
+    */
   private final case class VisibleExternalCallOccurrence(
       key: DAMLe.ExternalCallKey,
       output: Bytes,
@@ -177,9 +199,9 @@ object ExternalCallConsistencyChecker {
       .mapValues(_.sorted(orderInconsistency))
       .toMap
 
-  /** Returns per-party inconsistencies for hosted confirming parties that can see disagreeing
-    * outputs for the same external call. Also records visible disagreements that should be alarmed
-    * even if this participant does not host an affected checking party.
+  /** Returns per-party inconsistencies for hosted confirming parties that check disagreeing
+    * outputs for the same external call, as well as the disagreements across all visible
+    * occurrences. See [[Result]] for how the two differ.
     */
   def check(
       viewValidationResults: Map[ViewPosition, ViewValidationResult],
@@ -187,7 +209,7 @@ object ExternalCallConsistencyChecker {
   ): Result = {
     val occurrences = visibleOccurrences(viewValidationResults)
     Result(
-      inconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
+      hostedInconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
       visibleInconsistencies = visibleInconsistencies(occurrences),
     )
   }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -130,12 +130,8 @@ object ExternalCallConsistencyChecker {
     viewValidationResults.toSeq
       .sortBy(_._1)(ViewPosition.orderViewPosition.toOrdering)
       .flatMap { case (viewPosition, viewValidationResult) =>
-        val viewParticipantData = viewValidationResult.view.viewParticipantData
-        if (
-          viewParticipantData.supportsExternalCallResults &&
-          viewParticipantData.externalCallResults.nonEmpty
-        ) {
-          viewParticipantData.externalCallResults.map { externalCallResult =>
+        viewValidationResult.view.viewParticipantData.externalCallResults.map {
+          externalCallResult =>
             val occurrence = ExternalCallOccurrence(
               viewPosition,
               externalCallResult.exerciseIndex,
@@ -147,8 +143,7 @@ object ExternalCallConsistencyChecker {
               occurrence,
               externalCallResult.checkingParties,
             )
-          }
-        } else Seq.empty
+        }
       }
 
   private def visibleInconsistencies(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -186,13 +186,9 @@ object ExternalCallConsistencyChecker {
       hostedConfirmingParties: Set[LfPartyId],
   ): Result = {
     val occurrences = visibleOccurrences(viewValidationResults)
-    if (occurrences.isEmpty) Result.empty
-    else {
-      val visible = visibleInconsistencies(occurrences)
-      Result(
-        inconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
-        visibleInconsistencies = visible,
-      )
-    }
+    Result(
+      inconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
+      visibleInconsistencies = visibleInconsistencies(occurrences),
+    )
   }
 }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import cats.Order
+import com.digitalasset.canton.LfPartyId
+import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
+import com.digitalasset.canton.data.ViewPosition
+import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.participant.util.ExternalCallPayloadDescription.{
+  byteCount,
+  hexPayloadSize,
+}
+import com.digitalasset.canton.util.ByteStringUtil
+import com.digitalasset.daml.lf.data.Bytes
+import com.google.protobuf.ByteString
+
+/** Checks whether visible external-call results agree.
+  *
+  * External-call results are replay data that participate in validation. If two visible occurrences
+  * of the same external call record different outputs, a hosted confirming party must reject the
+  * transaction locally instead of approving an ambiguous result. Visible disagreements are also
+  * retained independently of hosted-party routing so callers can report suspicious recorded data.
+  */
+object ExternalCallConsistencyChecker {
+
+  final case class ExternalCallOccurrence(
+      viewPosition: ViewPosition,
+      exerciseIndex: NonNegativeInt,
+      callIndex: NonNegativeInt,
+  ) extends PrettyPrinting {
+    override protected def pretty: Pretty[ExternalCallOccurrence] = prettyOfClass(
+      param("viewPosition", _.viewPosition),
+      param("exerciseIndex", _.exerciseIndex),
+      param("callIndex", _.callIndex),
+    )
+  }
+
+  private val orderExternalCallOccurrence: Ordering[ExternalCallOccurrence] =
+    Ordering
+      .by[ExternalCallOccurrence, ViewPosition](_.viewPosition)(
+        ViewPosition.orderViewPosition.toOrdering
+      )
+      .orElseBy(_.exerciseIndex.unwrap)
+      .orElseBy(_.callIndex.unwrap)
+
+  final case class Inconsistency(
+      key: DAMLe.ExternalCallKey,
+      outputs: Set[Bytes],
+      occurrences: Set[ExternalCallOccurrence],
+  ) extends PrettyPrinting {
+    def description: String = toString
+
+    private def outputByteSizes: Seq[Int] = outputs.toSeq.map(byteCount).sorted
+
+    private def orderedOccurrences: Seq[ExternalCallOccurrence] =
+      occurrences.toSeq.sorted(orderExternalCallOccurrence)
+
+    override protected def pretty: Pretty[Inconsistency] =
+      prettyOfClass(
+        param("extensionId", _.key.extensionId.unquoted),
+        param("functionId", _.key.functionId.unquoted),
+        param("config", inconsistency => hexPayloadSize(inconsistency.key.config).unquoted),
+        param("input", inconsistency => hexPayloadSize(inconsistency.key.input).unquoted),
+        param("outputByteSizes", _.outputByteSizes),
+        param("occurrences", _.orderedOccurrences),
+      )
+  }
+
+  final case class Result(
+      inconsistencies: Map[LfPartyId, Seq[Inconsistency]],
+      visibleInconsistencies: Seq[Inconsistency],
+  ) extends PrettyPrinting {
+    def inconsistentParties: Set[LfPartyId] = inconsistencies.keySet
+
+    override protected def pretty: Pretty[Result] = prettyOfClass(
+      param("inconsistencies", _.inconsistencies),
+      param("visibleInconsistencies", _.visibleInconsistencies),
+    )
+  }
+
+  object Result {
+    val empty: Result = Result(Map.empty, Seq.empty)
+  }
+
+  private final case class VisibleExternalCallOccurrence(
+      key: DAMLe.ExternalCallKey,
+      output: Bytes,
+      occurrence: ExternalCallOccurrence,
+      checkingParties: Set[LfPartyId],
+  )
+
+  private implicit val orderBytes: Order[Bytes] =
+    Order.by[Bytes, ByteString](_.toByteString)(ByteStringUtil.orderByteString)
+
+  private def orderedOutputs(outputs: Set[Bytes]): List[Bytes] =
+    outputs.toList.sorted(orderBytes.toOrdering)
+
+  private[validation] val orderOutputSets: Ordering[Set[Bytes]] =
+    Order.by[Set[Bytes], List[Bytes]](orderedOutputs).toOrdering
+
+  private[validation] val orderInconsistency: Ordering[Inconsistency] = {
+    import scala.math.Ordering.Implicits.seqOrdering
+    implicit val occurrenceOrdering: Ordering[ExternalCallOccurrence] = orderExternalCallOccurrence
+    Ordering
+      .by[Inconsistency, DAMLe.ExternalCallKey](_.key)
+      .orElseBy(_.outputs)(orderOutputSets)
+      .orElseBy(_.occurrences.toSeq.sorted)
+  }
+
+  private def inconsistencyFor(
+      key: DAMLe.ExternalCallKey,
+      outputsAndOccurrences: Seq[(Bytes, ExternalCallOccurrence)],
+  ): Option[Inconsistency] = {
+    val occurrencesByOutput = outputsAndOccurrences.groupMap(_._1)(_._2)
+    Option.when(occurrencesByOutput.sizeCompare(1) > 0)(
+      Inconsistency(
+        key,
+        occurrencesByOutput.keySet,
+        occurrencesByOutput.valuesIterator.flatten.toSet,
+      )
+    )
+  }
+
+  private def visibleOccurrences(
+      viewValidationResults: Map[ViewPosition, ViewValidationResult]
+  ): Seq[VisibleExternalCallOccurrence] =
+    viewValidationResults.toSeq
+      .sortBy(_._1)(ViewPosition.orderViewPosition.toOrdering)
+      .flatMap { case (viewPosition, viewValidationResult) =>
+        val viewParticipantData = viewValidationResult.view.viewParticipantData
+        if (
+          viewParticipantData.supportsExternalCallResults &&
+          viewParticipantData.externalCallResults.nonEmpty
+        ) {
+          viewParticipantData.externalCallResults.map { externalCallResult =>
+            val occurrence = ExternalCallOccurrence(
+              viewPosition,
+              externalCallResult.exerciseIndex,
+              externalCallResult.callIndex,
+            )
+            VisibleExternalCallOccurrence(
+              DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
+              externalCallResult.result.output,
+              occurrence,
+              externalCallResult.checkingParties,
+            )
+          }
+        } else Seq.empty
+      }
+
+  private def visibleInconsistencies(
+      occurrences: Seq[VisibleExternalCallOccurrence]
+  ): Seq[Inconsistency] =
+    occurrences
+      .groupMap(_.key)(occurrence => occurrence.output -> occurrence.occurrence)
+      .toSeq
+      .flatMap { case (key, outputsAndOccurrences) =>
+        inconsistencyFor(key, outputsAndOccurrences)
+      }
+      .sorted(orderInconsistency)
+
+  private def hostedInconsistencies(
+      occurrences: Seq[VisibleExternalCallOccurrence],
+      hostedConfirmingParties: Set[LfPartyId],
+  ): Map[LfPartyId, Seq[Inconsistency]] =
+    occurrences
+      .flatMap { occurrence =>
+        occurrence.checkingParties.intersect(hostedConfirmingParties).toSeq.map { party =>
+          (party, occurrence.key) -> (occurrence.output -> occurrence.occurrence)
+        }
+      }
+      .groupMap(_._1)(_._2)
+      .toSeq
+      .flatMap { case ((party, key), outputsAndOccurrences) =>
+        inconsistencyFor(key, outputsAndOccurrences).map(party -> _)
+      }
+      .groupMap(_._1)(_._2)
+      .view
+      .mapValues(_.sorted(orderInconsistency))
+      .toMap
+
+  /** Returns per-party inconsistencies for hosted confirming parties that can see disagreeing
+    * outputs for the same external call. Also records visible disagreements that should be alarmed
+    * even if this participant does not host an affected checking party.
+    */
+  def check(
+      viewValidationResults: Map[ViewPosition, ViewValidationResult],
+      hostedConfirmingParties: Set[LfPartyId],
+  ): Result = {
+    val occurrences = visibleOccurrences(viewValidationResults)
+    if (occurrences.isEmpty) Result.empty
+    else {
+      val visible = visibleInconsistencies(occurrences)
+      Result(
+        inconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
+        visibleInconsistencies = visible,
+      )
+    }
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.extension
+
+import com.digitalasset.canton.BaseTest
+import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.platform.execution.ExternalCallMode
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.Thereafter.syntax.*
+import com.digitalasset.daml.lf.data.Bytes
+import org.scalatest.wordspec.AsyncWordSpec
+
+import java.util.concurrent.atomic.AtomicReference
+
+class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseTest {
+
+  private val externalCallKey =
+    DAMLe.ExternalCallKey(
+      extensionId = "extension-id",
+      functionId = "function-id",
+      config = "00010203",
+      input = "deadbeef",
+    )
+
+  private val recordedOutput = Bytes.assertFromString("01020304")
+
+  private def emptyManager: ExtensionServiceManager =
+    ExtensionServiceManager.empty(loggerFactory, ProcessingTimeout())
+
+  private final class StubExtensionServiceManager(
+      result: Either[ExtensionCallError, String]
+  ) extends ExtensionServiceManager(
+        Map.empty,
+        loggerFactory,
+        ProcessingTimeout(),
+      ) {
+
+    private val observedCall =
+      new AtomicReference[Option[(String, String, String, String, ExternalCallMode)]](None)
+
+    def observed: Option[(String, String, String, String, ExternalCallMode)] =
+      observedCall.get()
+
+    override def handleExternalCall(
+        extensionId: String,
+        functionId: String,
+        configHash: String,
+        input: String,
+        mode: ExternalCallMode,
+    )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] = {
+      observedCall.set(Some((extensionId, functionId, configHash, input, mode)))
+      FutureUnlessShutdown.pure(result)
+    }
+  }
+
+  "ExtensionServiceExternalCallValidator.create" should {
+
+    "return UnableToValidate when the extension service is not configured" in {
+      val validator = ExtensionServiceExternalCallValidator.create(None)
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result shouldBe ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        }
+    }
+
+    "return UnableToValidate for an unconfigured extension" in {
+      val manager = emptyManager
+      val validator = ExtensionServiceExternalCallValidator.create(Some(manager))
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result shouldBe ExternalCallValidator.UnableToValidate(
+            "external-call validation failed with status 404"
+          )
+        }
+        .thereafter(_ => manager.close())
+    }
+  }
+
+  "ExtensionServiceExternalCallValidator" should {
+
+    "sanitize manager errors" in {
+      val manager =
+        new StubExtensionServiceManager(
+          Left(
+            ExtensionCallError(
+              statusCode = 503,
+              message = "internal detail",
+              requestId = Some("request-1"),
+              retryable = true,
+            )
+          )
+        )
+      val validator = new ExtensionServiceExternalCallValidator(manager)
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result match {
+            case ExternalCallValidator.UnableToValidate(reason) =>
+              reason shouldBe
+                "external-call validation failed with status 503, requestId=request-1"
+              reason should not include externalCallKey.extensionId
+              reason should not include "internal detail"
+
+            case other => fail(s"Expected UnableToValidate, got $other")
+          }
+        }
+        .thereafter(_ => manager.close())
+    }
+
+    "return UnableToValidate when the manager returns non-canonical output" in {
+      val manager = new StubExtensionServiceManager(Right("not-hex"))
+      val validator = new ExtensionServiceExternalCallValidator(manager)
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result shouldBe ExternalCallValidator.UnableToValidate(
+            "external-call validation returned non-canonical output"
+          )
+        }
+        .thereafter(_ => manager.close())
+    }
+
+    "return Matched when computed output matches recorded output" in {
+      val manager = new StubExtensionServiceManager(Right(recordedOutput.toHexString))
+      val validator = new ExtensionServiceExternalCallValidator(manager)
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result shouldBe ExternalCallValidator.Matched
+          manager.observed shouldBe Some(
+            (
+              externalCallKey.extensionId,
+              externalCallKey.functionId,
+              externalCallKey.config,
+              externalCallKey.input,
+              ExternalCallMode.Validation,
+            )
+          )
+        }
+        .thereafter(_ => manager.close())
+    }
+
+    "return Mismatched when computed output differs from recorded output" in {
+      val computedOutput = Bytes.assertFromString("05060708")
+      val manager = new StubExtensionServiceManager(Right(computedOutput.toHexString))
+      val validator = new ExtensionServiceExternalCallValidator(manager)
+
+      validator
+        .validate(externalCallKey, recordedOutput)
+        .failOnShutdown
+        .map { result =>
+          result shouldBe ExternalCallValidator.Mismatched(
+            computedOutput = computedOutput,
+            recordedOutput = recordedOutput,
+          )
+        }
+        .thereafter(_ => manager.close())
+    }
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -76,14 +76,20 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
       val manager = emptyManager
       val validator = ExtensionServiceExternalCallValidator.create(Some(manager))
 
-      validator
-        .validate(externalCallKey, recordedOutput)
-        .failOnShutdown
-        .map { result =>
-          result shouldBe ExternalCallValidator.UnableToValidate(
-            "external-call validation failed with status 404"
-          )
-        }
+      loggerFactory
+        .assertLogs(
+          validator
+            .validate(externalCallKey, recordedOutput)
+            .failOnShutdown
+            .map { result =>
+              result shouldBe ExternalCallValidator.UnableToValidate(
+                "external-call validation failed with status 404"
+              )
+            },
+          _.warningMessage shouldBe
+            "External call to extension 'extension-id' (function 'function-id') failed: " +
+            "status=404, retryable=false, message=Extension 'extension-id' not configured",
+        )
         .thereafter(_ => manager.close())
     }
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -154,7 +154,7 @@ class ExternalCallConsistencyCheckerTest
       )
 
       result.inconsistentParties shouldBe Set(partyA)
-      val inconsistency = result.inconsistencies(partyA).loneElement
+      val inconsistency = result.hostedInconsistencies(partyA).loneElement
       inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
       inconsistency.occurrences.map(occurrence =>
         occurrence.exerciseIndex -> occurrence.callIndex
@@ -211,7 +211,7 @@ class ExternalCallConsistencyCheckerTest
       )
 
       result.inconsistentParties shouldBe Set(partyA)
-      result.inconsistencies(partyA).map(_.key.functionId).toSet shouldBe Set(
+      result.hostedInconsistencies(partyA).map(_.key.functionId).toSet shouldBe Set(
         "function-a",
         "function-b",
       )

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
+import com.digitalasset.canton.data.ViewPosition
+import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.canton.{BaseTest, LfPartyId}
+import com.digitalasset.daml.lf.data.Bytes
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.ExecutionContext
+
+class ExternalCallConsistencyCheckerTest
+    extends AnyWordSpec
+    with BaseTest
+    with ExternalCallValidationTestUtil {
+
+  implicit val ec: ExecutionContext = directExecutionContext
+
+  protected val factory =
+    new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
+
+  private val partyA = ExampleTransactionFactory.signatory
+  private val partyB = ExampleTransactionFactory.submitter
+  private val partyC = ExampleTransactionFactory.observer
+
+  private def check(
+      leftCheckingParties: Set[LfPartyId],
+      rightCheckingParties: Set[LfPartyId],
+      hostedParties: Set[LfPartyId],
+      rightResult: ExternalCallResult = otherExternalCallOutput,
+  ): ExternalCallConsistencyChecker.Result = {
+    val example = factory.MultipleRoots
+    val left = withExternalCallResults(
+      example.rootViews(4),
+      Seq(
+        externalCallViewResult(
+          exerciseIndex = 0,
+          result = externalCallResult,
+          checkingParties = leftCheckingParties,
+        )
+      ),
+    )
+    val right = withExternalCallResults(
+      example.rootViews(5),
+      Seq(
+        externalCallViewResult(
+          exerciseIndex = 0,
+          result = rightResult,
+          checkingParties = rightCheckingParties,
+        )
+      ),
+    )
+
+    ExternalCallConsistencyChecker.check(
+      Map(
+        ViewPosition.root -> validationResult(left),
+        ViewPosition(
+          List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+        ) ->
+          validationResult(right),
+      ),
+      hostedParties,
+    )
+  }
+
+  "ExternalCallConsistencyChecker" should {
+    "report only hosted parties that check conflicting outputs" in {
+      val result = check(
+        leftCheckingParties = Set(partyA),
+        rightCheckingParties = Set(partyA),
+        hostedParties = Set(partyA, partyB),
+      )
+
+      result.inconsistentParties shouldBe Set(partyA)
+    }
+
+    "not report conflicting outputs for disjoint checking parties" in {
+      val result = check(
+        leftCheckingParties = Set(partyA),
+        rightCheckingParties = Set(partyB),
+        hostedParties = Set(partyA, partyB),
+      )
+
+      result.inconsistentParties shouldBe Set.empty
+      result.visibleInconsistencies should have size 1
+    }
+
+    "record visible disagreements without reporting non-hosted checking parties" in {
+      val result = check(
+        leftCheckingParties = Set(partyC),
+        rightCheckingParties = Set(partyC),
+        hostedParties = Set(partyA, partyB),
+      )
+
+      result.inconsistentParties shouldBe Set.empty
+      result.visibleInconsistencies should have size 1
+      val visibleInconsistency = result.visibleInconsistencies.loneElement
+      visibleInconsistency.outputs shouldBe Set(
+        externalCallResult.output,
+        otherExternalCallOutput.output,
+      )
+    }
+
+    "not report identical outputs" in {
+      val result = check(
+        leftCheckingParties = Set(partyA),
+        rightCheckingParties = Set(partyA),
+        hostedParties = Set(partyA),
+        rightResult = externalCallResult,
+      )
+
+      result.inconsistentParties shouldBe Set.empty
+    }
+
+    "not report different semantic calls with different outputs" in {
+      val result = check(
+        leftCheckingParties = Set(partyA),
+        rightCheckingParties = Set(partyA),
+        hostedParties = Set(partyA),
+        rightResult = otherExternalCallOutput.copy(functionId = "other-function"),
+      )
+
+      result.inconsistentParties shouldBe Set.empty
+    }
+
+    "report repeated semantic calls on the same node with different outputs" in {
+      val example = factory.MultipleRoots
+      val view = withExternalCallResults(
+        example.rootViews(4),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(partyA),
+            callIndex = 0,
+          ),
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = otherExternalCallOutput,
+            checkingParties = Set(partyA),
+            callIndex = 1,
+          ),
+        ),
+      )
+
+      val result = ExternalCallConsistencyChecker.check(
+        Map(ViewPosition.root -> validationResult(view)),
+        Set(partyA),
+      )
+
+      result.inconsistentParties shouldBe Set(partyA)
+      val inconsistency = result.inconsistencies(partyA).loneElement
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      inconsistency.occurrences.map(occurrence =>
+        occurrence.exerciseIndex -> occurrence.callIndex
+      ) shouldBe Set(
+        NonNegativeInt.zero -> NonNegativeInt.zero,
+        NonNegativeInt.zero -> NonNegativeInt.one,
+      )
+    }
+
+    "report all independent disagreements for the same hosted checking party" in {
+      val example = factory.MultipleRoots
+      val firstCall = externalCallResult.copy(functionId = "function-a")
+      val secondCall = externalCallResult.copy(functionId = "function-b")
+      val left = withExternalCallResults(
+        example.rootViews(4),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = firstCall,
+            checkingParties = Set(partyA),
+          ),
+          externalCallViewResult(
+            exerciseIndex = 1,
+            result = secondCall,
+            checkingParties = Set(partyA),
+          ),
+        ),
+      )
+      val right = withExternalCallResults(
+        example.rootViews(5),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = firstCall.copy(output = Bytes.fromStringUtf8("other-output-a")),
+            checkingParties = Set(partyA),
+          ),
+          externalCallViewResult(
+            exerciseIndex = 1,
+            result = secondCall.copy(output = Bytes.fromStringUtf8("other-output-b")),
+            checkingParties = Set(partyA),
+          ),
+        ),
+      )
+
+      val result = ExternalCallConsistencyChecker.check(
+        Map(
+          ViewPosition.root -> validationResult(left),
+          ViewPosition(
+            List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+          ) ->
+            validationResult(right),
+        ),
+        Set(partyA),
+      )
+
+      result.inconsistentParties shouldBe Set(partyA)
+      result.inconsistencies(partyA).map(_.key.functionId).toSet shouldBe Set(
+        "function-a",
+        "function-b",
+      )
+    }
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -7,7 +7,7 @@ import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.ViewPosition
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.version.ProtocolVersion
-import com.digitalasset.canton.{BaseTest, LfPartyId}
+import com.digitalasset.canton.{BaseTest, LfPartyId, ProtocolVersionChecksAnyWordSpec}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
 import org.scalatest.wordspec.AnyWordSpec
@@ -17,12 +17,12 @@ import scala.concurrent.ExecutionContext
 class ExternalCallConsistencyCheckerTest
     extends AnyWordSpec
     with BaseTest
+    with ProtocolVersionChecksAnyWordSpec
     with ExternalCallValidationTestUtil {
 
   implicit val ec: ExecutionContext = directExecutionContext
 
-  protected val factory =
-    new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
+  protected val factory: ExampleTransactionFactory = new ExampleTransactionFactory()()
 
   private val partyA = ExampleTransactionFactory.signatory
   private val partyB = ExampleTransactionFactory.submitter
@@ -69,7 +69,7 @@ class ExternalCallConsistencyCheckerTest
   }
 
   "ExternalCallConsistencyChecker" should {
-    "report only hosted parties that check conflicting outputs" in {
+    "report only hosted parties that check conflicting outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val result = check(
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyA),
@@ -79,7 +79,7 @@ class ExternalCallConsistencyCheckerTest
       result.inconsistentParties shouldBe Set(partyA)
     }
 
-    "not report conflicting outputs for disjoint checking parties" in {
+    "not report conflicting outputs for disjoint checking parties" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val result = check(
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyB),
@@ -90,7 +90,7 @@ class ExternalCallConsistencyCheckerTest
       result.visibleInconsistencies should have size 1
     }
 
-    "record visible disagreements without reporting non-hosted checking parties" in {
+    "record visible disagreements without reporting non-hosted checking parties" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val result = check(
         leftCheckingParties = Set(partyC),
         rightCheckingParties = Set(partyC),
@@ -106,7 +106,7 @@ class ExternalCallConsistencyCheckerTest
       )
     }
 
-    "not report identical outputs" in {
+    "not report identical outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val result = check(
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyA),
@@ -117,7 +117,7 @@ class ExternalCallConsistencyCheckerTest
       result.inconsistentParties shouldBe Set.empty
     }
 
-    "not report different semantic calls with different outputs" in {
+    "not report different semantic calls with different outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val result = check(
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyA),
@@ -128,7 +128,7 @@ class ExternalCallConsistencyCheckerTest
       result.inconsistentParties shouldBe Set.empty
     }
 
-    "report repeated semantic calls on the same node with different outputs" in {
+    "report repeated semantic calls on the same node with different outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val example = factory.MultipleRoots
       val view = withExternalCallResults(
         example.rootViews(4),
@@ -164,7 +164,7 @@ class ExternalCallConsistencyCheckerTest
       )
     }
 
-    "report all independent disagreements for the same hosted checking party" in {
+    "report all independent disagreements for the same hosted checking party" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val example = factory.MultipleRoots
       val firstCall = externalCallResult.copy(functionId = "function-a")
       val secondCall = externalCallResult.copy(functionId = "function-b")
@@ -215,6 +215,17 @@ class ExternalCallConsistencyCheckerTest
         "function-a",
         "function-b",
       )
+    }
+
+    "return the empty result for views without external-call results" in {
+      val example = factory.MultipleRoots
+
+      val result = ExternalCallConsistencyChecker.check(
+        Map(ViewPosition.root -> validationResult(example.rootViews(4))),
+        Set(partyA),
+      )
+
+      result shouldBe ExternalCallConsistencyChecker.Result.empty
     }
   }
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -3,36 +3,19 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
+import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.{
-  CantonTimestamp,
   ParticipantTransactionView,
-  PathRollbackContextFactory,
   TransactionView,
-  ViewConfirmationParameters,
   ViewParticipantData,
-  ViewPosition,
 }
-import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
-import com.digitalasset.canton.logging.LogEntry
-import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
-import com.digitalasset.canton.{BaseTest, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
-import com.digitalasset.nonempty.NonEmpty
 
-import scala.jdk.CollectionConverters.*
-
-/** Shared fixtures for the external-call validation tests.
-  *
-  * Mixed into the test bases so that fixtures depending on `loggerFactory` (and other [[BaseTest]]
-  * facilities) can live alongside the pure builders.
-  */
-private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
-
-  protected val requestId = RequestId(CantonTimestamp.Epoch)
+/** Shared fixtures for the external-call validation tests. */
+private[validation] trait ExternalCallValidationTestUtil {
 
   /** Provided by the mixing test, where an implicit `ExecutionContext` is available to build it. */
   protected def factory: ExampleTransactionFactory
@@ -57,58 +40,6 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
     TransactionView.Optics.viewParticipantDataUnsafe
       .modify(vpd => vpd.tryUnwrap.copy(externalCallResults = results))(view)
 
-  protected final class RecordingExternalCallValidator(
-      results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
-  ) extends ExternalCallValidator {
-    private val observedKeys =
-      new java.util.concurrent.ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
-
-    def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq
-
-    override def validate(
-        key: DAMLe.ExternalCallKey,
-        recordedOutput: Bytes,
-    )(implicit
-        traceContext: com.digitalasset.canton.tracing.TraceContext
-    ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
-      observedKeys.add(key -> recordedOutput)
-      FutureUnlessShutdown.pure(
-        results.getOrElse(key, ExternalCallValidator.Matched)
-      )
-    }
-  }
-
-  protected val matchingExternalCallValidator: ExternalCallValidator = new ExternalCallValidator {
-    override def validate(
-        key: DAMLe.ExternalCallKey,
-        recordedOutput: Bytes,
-    )(implicit
-        traceContext: com.digitalasset.canton.tracing.TraceContext
-    ): FutureUnlessShutdown[ExternalCallValidator.Result] =
-      FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
-  }
-
-  protected val leftViewPosition = ViewPosition.root
-  protected val rightViewPosition =
-    ViewPosition(
-      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
-    )
-  protected val unrelatedViewPosition =
-    ViewPosition(
-      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Left)))
-    )
-  protected val secondRightViewPosition =
-    ViewPosition(
-      List(
-        ViewPosition.MerkleSeqIndex(
-          List(
-            ViewPosition.MerkleSeqIndex.Direction.Left,
-            ViewPosition.MerkleSeqIndex.Direction.Right,
-          )
-        )
-      )
-    )
-
   protected val externalCallResult = ExternalCallResult(
     extensionId = "extension",
     functionId = "function",
@@ -119,20 +50,6 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
 
   protected val otherExternalCallOutput =
     externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
-
-  protected def withConfirmers(
-      view: TransactionView,
-      confirmers: Set[LfPartyId],
-  ): TransactionView = {
-    val confirmationParameters = ViewConfirmationParameters.create(
-      informees = confirmers.map(_ -> NonNegativeInt.one).toMap,
-      threshold = NonNegativeInt.tryCreate(confirmers.size),
-    )
-    TransactionView.Optics.viewCommonDataUnsafe
-      .modify(commonData =>
-        commonData.tryUnwrap.copy(viewConfirmationParameters = confirmationParameters)
-      )(view)
-  }
 
   protected def validationResult(
       view: TransactionView,
@@ -145,50 +62,5 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
     ViewValidationResult(
       ParticipantTransactionView.tryCreate(view),
       activenessResult,
-    )
-
-  protected def defaultModelConformanceResult: ModelConformanceChecker.Result = {
-    val example = factory.MultipleRoots
-    ModelConformanceChecker.Result(
-      example.updateId,
-      WellFormedTransaction.checkOrThrow(
-        example.versionedSuffixedTransaction,
-        example.metadata,
-        WellFormedTransaction.WithSuffixesAndMerged,
-        PathRollbackContextFactory,
-      ),
-      unmergedTransactionsWithoutTopLevelRollbackNodes = Seq.empty,
-    )
-  }
-
-  protected def modelConformanceRecordedDisagreement(
-      view: TransactionView,
-      result: ExternalCallResult,
-      conflictingOutput: Bytes = otherExternalCallOutput.output,
-  ): ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect] =
-    ModelConformanceChecker.ErrorWithSubTransaction(
-      NonEmpty(
-        Seq,
-        ModelConformanceChecker.DAMLeError(
-          DAMLe.ExternalCallRecordedResultDisagreement(
-            key = DAMLe.ExternalCallKey.fromResult(result),
-            outputs = Set(result.output, conflictingOutput),
-          ),
-          view.viewHash,
-        ),
-      ),
-      validSubTransactionO = None,
-      validSubViewEffects = Seq.empty,
-    )
-
-  protected def assertRecordedDisagreementAlarms[A](count: Int = 1)(within: => A): A =
-    loggerFactory.assertLogs(
-      within,
-      Seq.fill(count) { (logEntry: LogEntry) =>
-        logEntry.shouldBeCantonErrorCode(
-          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
-        )
-        logEntry.mdc should contain("requestId" -> requestId.toString)
-      }*
     )
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -40,7 +40,7 @@ private[validation] trait ExternalCallValidationTestUtil {
     TransactionView.Optics.viewParticipantDataUnsafe
       .modify(vpd => vpd.tryUnwrap.copy(externalCallResults = results))(view)
 
-  protected val externalCallResult = ExternalCallResult(
+  protected val externalCallResult: ExternalCallResult = ExternalCallResult(
     extensionId = "extension",
     functionId = "function",
     config = Bytes.fromStringUtf8("config"),
@@ -48,7 +48,7 @@ private[validation] trait ExternalCallValidationTestUtil {
     output = Bytes.fromStringUtf8("output"),
   )
 
-  protected val otherExternalCallOutput =
+  protected val otherExternalCallOutput: ExternalCallResult =
     externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
 
   protected def validationResult(

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
+import com.digitalasset.canton.data.{
+  CantonTimestamp,
+  ParticipantTransactionView,
+  PathRollbackContextFactory,
+  TransactionView,
+  ViewConfirmationParameters,
+  ViewParticipantData,
+  ViewPosition,
+}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.{BaseTest, LfPartyId}
+import com.digitalasset.daml.lf.data.Bytes
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+import com.digitalasset.nonempty.NonEmpty
+
+import scala.jdk.CollectionConverters.*
+
+/** Shared fixtures for the external-call validation tests.
+  *
+  * Mixed into the test bases so that fixtures depending on `loggerFactory` (and other [[BaseTest]]
+  * facilities) can live alongside the pure builders.
+  */
+private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
+
+  protected val requestId = RequestId(CantonTimestamp.Epoch)
+
+  /** Provided by the mixing test, where an implicit `ExecutionContext` is available to build it. */
+  protected def factory: ExampleTransactionFactory
+
+  def externalCallViewResult(
+      exerciseIndex: Int,
+      result: ExternalCallResult,
+      checkingParties: Set[LfPartyId],
+      callIndex: Int = 0,
+  ): ViewParticipantData.ViewExternalCallResult =
+    ViewParticipantData.ViewExternalCallResult(
+      result = result,
+      exerciseIndex = NonNegativeInt.tryCreate(exerciseIndex),
+      callIndex = NonNegativeInt.tryCreate(callIndex),
+      checkingParties = checkingParties,
+    )
+
+  def withExternalCallResults(
+      view: TransactionView,
+      results: Seq[ViewParticipantData.ViewExternalCallResult],
+  ): TransactionView =
+    TransactionView.Optics.viewParticipantDataUnsafe
+      .modify(vpd => vpd.tryUnwrap.copy(externalCallResults = results))(view)
+
+  protected final class RecordingExternalCallValidator(
+      results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
+  ) extends ExternalCallValidator {
+    private val observedKeys =
+      new java.util.concurrent.ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
+
+    def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq
+
+    override def validate(
+        key: DAMLe.ExternalCallKey,
+        recordedOutput: Bytes,
+    )(implicit
+        traceContext: com.digitalasset.canton.tracing.TraceContext
+    ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
+      observedKeys.add(key -> recordedOutput)
+      FutureUnlessShutdown.pure(
+        results.getOrElse(key, ExternalCallValidator.Matched)
+      )
+    }
+  }
+
+  protected val matchingExternalCallValidator: ExternalCallValidator = new ExternalCallValidator {
+    override def validate(
+        key: DAMLe.ExternalCallKey,
+        recordedOutput: Bytes,
+    )(implicit
+        traceContext: com.digitalasset.canton.tracing.TraceContext
+    ): FutureUnlessShutdown[ExternalCallValidator.Result] =
+      FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
+  }
+
+  protected val leftViewPosition = ViewPosition.root
+  protected val rightViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+    )
+  protected val unrelatedViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Left)))
+    )
+  protected val secondRightViewPosition =
+    ViewPosition(
+      List(
+        ViewPosition.MerkleSeqIndex(
+          List(
+            ViewPosition.MerkleSeqIndex.Direction.Left,
+            ViewPosition.MerkleSeqIndex.Direction.Right,
+          )
+        )
+      )
+    )
+
+  protected val externalCallResult = ExternalCallResult(
+    extensionId = "extension",
+    functionId = "function",
+    config = Bytes.fromStringUtf8("config"),
+    input = Bytes.fromStringUtf8("input"),
+    output = Bytes.fromStringUtf8("output"),
+  )
+
+  protected val otherExternalCallOutput =
+    externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
+
+  protected def withConfirmers(
+      view: TransactionView,
+      confirmers: Set[LfPartyId],
+  ): TransactionView = {
+    val confirmationParameters = ViewConfirmationParameters.create(
+      informees = confirmers.map(_ -> NonNegativeInt.one).toMap,
+      threshold = NonNegativeInt.tryCreate(confirmers.size),
+    )
+    TransactionView.Optics.viewCommonDataUnsafe
+      .modify(commonData =>
+        commonData.tryUnwrap.copy(viewConfirmationParameters = confirmationParameters)
+      )(view)
+  }
+
+  protected def validationResult(
+      view: TransactionView,
+      activenessResult: ViewActivenessResult = ViewActivenessResult(
+        inactiveContracts = Set.empty,
+        alreadyLockedContracts = Set.empty,
+        existingContracts = Set.empty,
+      ),
+  ): ViewValidationResult =
+    ViewValidationResult(
+      ParticipantTransactionView.tryCreate(view),
+      activenessResult,
+    )
+
+  protected def defaultModelConformanceResult: ModelConformanceChecker.Result = {
+    val example = factory.MultipleRoots
+    ModelConformanceChecker.Result(
+      example.updateId,
+      WellFormedTransaction.checkOrThrow(
+        example.versionedSuffixedTransaction,
+        example.metadata,
+        WellFormedTransaction.WithSuffixesAndMerged,
+        PathRollbackContextFactory,
+      ),
+      unmergedTransactionsWithoutTopLevelRollbackNodes = Seq.empty,
+    )
+  }
+
+  protected def modelConformanceRecordedDisagreement(
+      view: TransactionView,
+      result: ExternalCallResult,
+      conflictingOutput: Bytes = otherExternalCallOutput.output,
+  ): ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect] =
+    ModelConformanceChecker.ErrorWithSubTransaction(
+      NonEmpty(
+        Seq,
+        ModelConformanceChecker.DAMLeError(
+          DAMLe.ExternalCallRecordedResultDisagreement(
+            key = DAMLe.ExternalCallKey.fromResult(result),
+            outputs = Set(result.output, conflictingOutput),
+          ),
+          view.viewHash,
+        ),
+      ),
+      validSubTransactionO = None,
+      validSubViewEffects = Seq.empty,
+    )
+
+  protected def assertRecordedDisagreementAlarms[A](count: Int = 1)(within: => A): A =
+    loggerFactory.assertLogs(
+      within,
+      Seq.fill(count) { (logEntry: LogEntry) =>
+        logEntry.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        )
+        logEntry.mdc should contain("requestId" -> requestId.toString)
+      }*
+    )
+}


### PR DESCRIPTION
## Summary

This is PR 6 of 8 in the external-call runtime-integration series tracked in #513, stacked on PR 5.

The external-call stack (#513): #506 added the transaction-side representation for recording external-call results; #514 added the LF `EXTERNAL_CALL` builtin surface; #518 wired it into Speedy and the LF engine; #522 added transaction protobuf encoding/decoding; #526 added Canton protocol serialization for recorded results; #537 added the participant-side extension-service client. #541 implemented the remaining runtime integration as one PR; this series splits #541 into 8 independently reviewable PRs (each < 1000 lines) and supersedes it.

This PR adds the consistency checker that compares recorded external-call results against locally checked results, and the concrete extension-service validator implementing the PR 4 SPI.

## Scope

This PR adds:

- `ExternalCallConsistencyChecker`, which compares recorded results with locally checked results and identifies disagreements
- `ExtensionServiceExternalCallValidator`, the extension-service implementation of the PR 4 `ExternalCallValidator` SPI
- consistency-checker tests and the shared external-call validation test fixtures used here and in PR 7

## Out of scope

Routing of disagreements to checking parties (PR 7) and activation of the validator in transaction processing (PR 8). The validator is implemented here but not yet threaded into confirmation; it is dev-gated and dormant until PR 8.

## Stacking & review

This PR is stacked on PR 5, so its diff against `main` is **cumulative**. The incremental change for this PR alone (it depends on PR 3 and PR 4, not PR 5):
https://github.com/digital-asset/canton/compare/zenith-network:angelol/external-call-06-split-pr5-extension...zenith-network:angelol/external-call-06-split-pr6-checker

Refs #513.
