### PR TITLE
feat(external-call): confirmation-responses factory and validation activation

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
@@ -35,7 +35,10 @@ import com.digitalasset.canton.participant.admin.*
 import com.digitalasset.canton.participant.admin.grpc.*
 import com.digitalasset.canton.participant.admin.party.{PartyReplicationEndpoints, PartyReplicator}
 import com.digitalasset.canton.participant.config.*
-import com.digitalasset.canton.participant.extension.ExtensionServiceManager
+import com.digitalasset.canton.participant.extension.{
+  ExtensionServiceExternalCallValidator,
+  ExtensionServiceManager,
+}
 import com.digitalasset.canton.participant.health.admin.ParticipantStatus
 import com.digitalasset.canton.participant.ledger.api.{
   AcsCommitmentPublicationPostProcessor,
@@ -49,6 +52,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
   CommandDeduplicatorImpl,
   InFlightSubmissionTracker,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.{AcsCommitmentProcessor, PruningProcessor}
 import com.digitalasset.canton.participant.replica.ParticipantReplicaManager
 import com.digitalasset.canton.participant.scheduler.{
@@ -774,6 +778,9 @@ class ParticipantNodeBootstrap(
             )
         )
 
+        externalCallValidator: ExternalCallValidator =
+          ExtensionServiceExternalCallValidator.create(extensionServiceManagerO)
+
         // Sync Service
         sync = CantonSyncService.create(
           participantId,
@@ -804,6 +811,7 @@ class ParticipantNodeBootstrap(
           connectedSynchronizersLookupContainer,
           () => triggerDeclarativeChange(),
           trafficEnforcementBackendO,
+          externalCallValidator,
         )
 
         _ <-

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -914,8 +914,9 @@ class TransactionProcessingSteps(
           val participantViews = parsedRequest.rootViewTrees.forgetNE
             .flatMap(viewTree => viewTree.view.allSubviewsWithPosition(viewTree.viewPosition))
             .map { case (view, viewPosition) =>
-              // The root view trees received for validation are fully unblinded, so tryCreate
-              // cannot throw (computeValidationResult below relies on the same invariant).
+              // The represented view of each root view tree is fully unblinded
+              // (FullTransactionViewTree invariant), so tryCreate cannot throw for it or any of
+              // its subviews (computeValidationResult below relies on the same invariant).
               viewPosition -> checked(ParticipantTransactionView.tryCreate(view))
             }
             .toMap
@@ -932,7 +933,7 @@ class TransactionProcessingSteps(
             // than silently discarded.
             FutureUnlessShutdownUtil.doNotAwaitUnlessShutdown(
               checkResultF,
-              "external-call check on a request with malformed payloads",
+              "external-call check failed for a request with malformed payloads",
             )
           }
           checkResultF

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -131,6 +131,7 @@ class TransactionProcessingSteps(
     createNodeEnricher: ContractEnricher,
     authorizationValidator: AuthorizationValidator,
     internalConsistencyChecker: InternalConsistencyChecker,
+    externalCallResponseRouter: ExternalCallResponseRouter,
     tracker: CommandProgressTracker,
     protected val loggerFactory: NamedLoggerFactory,
     futureSupervisor: FutureSupervisor,
@@ -898,12 +899,34 @@ class TransactionProcessingSteps(
             }
         )
 
+        // The external-call check re-validates recorded external-call results against the
+        // extension service. Like the model conformance check, it is kicked off here and only
+        // awaited when the confirmation responses are created, so that its network I/O runs
+        // concurrently with the other checks (including the reinterpretation, whose errors it
+        // consumes to route replay disagreements).
+        externalCallValidationResultF = {
+          val participantViews = parsedRequest.rootViewTrees.forgetNE
+            .flatMap(viewTree => viewTree.view.allSubviewsWithPosition(viewTree.viewPosition))
+            .map { case (view, viewPosition) =>
+              viewPosition -> ParticipantTransactionView.tryCreate(view)
+            }
+            .toMap
+          externalCallResponseRouter.check(
+            requestId,
+            participantViews,
+            ipsSnapshot,
+            conformanceResultET.value.map(_.swap.toSeq.flatMap(_.nonAbortErrors)),
+            runValidation = malformedPayloads.isEmpty,
+          )
+        }
+
       } yield ParallelChecksResult(
         authenticationResult,
         consistencyResultE,
         authorizationResult,
         conformanceResultET,
         internalConsistencyResultET,
+        externalCallValidationResultF,
         timeValidationE,
         replayCheckResult,
       )
@@ -976,6 +999,7 @@ class TransactionProcessingSteps(
         authorizationResult = parallelChecksResult.authorizationResult,
         modelConformanceResultET = parallelChecksResult.conformanceResultET,
         internalConsistencyResultET = parallelChecksResult.internalConsistencyResultET,
+        externalCallValidationResultF = parallelChecksResult.externalCallValidationResultF,
         consumedInputsOfHostedParties = usedAndCreated.contracts.consumedInputsOfHostedStakeholders,
         witnessed = usedAndCreated.contracts.witnessed,
         createdContracts = usedAndCreated.contracts.created,
@@ -1637,6 +1661,7 @@ object TransactionProcessingSteps {
         ErrorWithInternalConsistencyCheck,
         Unit,
       ],
+      externalCallValidationResultF: FutureUnlessShutdown[ExternalCallResponseRouter.Result],
       timeValidationResultE: Either[TimeCheckFailure, Unit],
       replayCheckResult: Option[String],
   ) {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -94,7 +94,13 @@ import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.topology.{ParticipantId, PhysicalSynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
-import com.digitalasset.canton.util.{EitherTUtil, ErrorUtil, LoggerUtil, RoseTree}
+import com.digitalasset.canton.util.{
+  EitherTUtil,
+  ErrorUtil,
+  FutureUnlessShutdownUtil,
+  LoggerUtil,
+  RoseTree,
+}
 import com.digitalasset.canton.version.ProtocolVersion
 import com.digitalasset.canton.{
   LedgerSubmissionId,
@@ -908,16 +914,28 @@ class TransactionProcessingSteps(
           val participantViews = parsedRequest.rootViewTrees.forgetNE
             .flatMap(viewTree => viewTree.view.allSubviewsWithPosition(viewTree.viewPosition))
             .map { case (view, viewPosition) =>
-              viewPosition -> ParticipantTransactionView.tryCreate(view)
+              // The root view trees received for validation are fully unblinded, so tryCreate
+              // cannot throw (computeValidationResult below relies on the same invariant).
+              viewPosition -> checked(ParticipantTransactionView.tryCreate(view))
             }
             .toMap
-          externalCallResponseRouter.check(
+          val checkResultF = externalCallResponseRouter.check(
             requestId,
             participantViews,
             ipsSnapshot,
             conformanceResultET.value.map(_.swap.toSeq.flatMap(_.nonAbortErrors)),
             runValidation = malformedPayloads.isEmpty,
           )
+          if (malformedPayloads.nonEmpty) {
+            // Responses for malformed requests are constructed without awaiting the check
+            // (only its alarms matter there); drain it so that failures are logged rather
+            // than silently discarded.
+            FutureUnlessShutdownUtil.doNotAwaitUnlessShutdown(
+              checkResultF,
+              "external-call check on a request with malformed payloads",
+            )
+          }
+          checkResultF
         }
 
       } yield ParallelChecksResult(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -902,8 +902,8 @@ class TransactionProcessingSteps(
         // The external-call check re-validates recorded external-call results against the
         // extension service. Like the model conformance check, it is kicked off here and only
         // awaited when the confirmation responses are created, so that its network I/O runs
-        // concurrently with the other checks (including the reinterpretation, whose errors it
-        // consumes to route replay disagreements).
+        // concurrently with the remaining checks (in particular the reinterpretation, whose
+        // errors it consumes to route replay disagreements).
         externalCallValidationResultF = {
           val participantViews = parsedRequest.rootViewTrees.forgetNE
             .flatMap(viewTree => viewTree.view.allSubviewsWithPosition(viewTree.viewPosition))

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
@@ -16,7 +16,6 @@ import com.digitalasset.base.error.{
 }
 import com.digitalasset.canton.*
 import com.digitalasset.canton.concurrent.FutureSupervisor
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.config.{ProcessingTimeout, TestingConfigInternal}
 import com.digitalasset.canton.crypto.*
 import com.digitalasset.canton.data.CantonTimestamp
@@ -42,6 +41,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
 }
 import com.digitalasset.canton.participant.protocol.validation.{
   AuthorizationValidator,
+  ExternalCallResponseRouter,
   ExternalCallValidator,
   InternalConsistencyChecker,
   ModelConformanceChecker,
@@ -104,8 +104,6 @@ class TransactionProcessor(
         new TransactionConfirmationResponsesFactory(
           participantId,
           synchronizerId,
-          externalCallValidator,
-          TransactionProcessor.externalCallValidationParallelism(participantNodeParameters),
           loggerFactory,
         ),
         ModelConformanceChecker(
@@ -130,6 +128,12 @@ class TransactionProcessor(
         InternalConsistencyChecker(
           participantId,
           staticSynchronizerParameters.protocolVersion,
+          loggerFactory,
+        ),
+        new ExternalCallResponseRouter(
+          participantId,
+          externalCallValidator,
+          participantNodeParameters.general.batchingConfig.parallelism,
           loggerFactory,
         ),
         commandProgressTracker,
@@ -217,11 +221,6 @@ class TransactionProcessor(
 }
 
 object TransactionProcessor {
-
-  private def externalCallValidationParallelism(
-      participantNodeParameters: ParticipantNodeParameters
-  ): PositiveInt =
-    participantNodeParameters.general.batchingConfig.parallelism
 
   sealed trait TransactionProcessorError
       extends WrapsProcessorError

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
@@ -16,6 +16,7 @@ import com.digitalasset.base.error.{
 }
 import com.digitalasset.canton.*
 import com.digitalasset.canton.concurrent.FutureSupervisor
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.config.{ProcessingTimeout, TestingConfigInternal}
 import com.digitalasset.canton.crypto.*
 import com.digitalasset.canton.data.CantonTimestamp
@@ -41,6 +42,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
 }
 import com.digitalasset.canton.participant.protocol.validation.{
   AuthorizationValidator,
+  ExternalCallValidator,
   InternalConsistencyChecker,
   ModelConformanceChecker,
   TransactionConfirmationResponsesFactory,
@@ -87,6 +89,7 @@ class TransactionProcessor(
     promiseFactory: PromiseUnlessShutdownFactory,
     participantNodeParameters: ParticipantNodeParameters,
     trafficEnforcementBackendO: Option[TrafficEnforcementBackend],
+    externalCallValidator: ExternalCallValidator,
 )(implicit val ec: ExecutionContext)
     extends ProtocolProcessor[
       TransactionProcessingSteps.SubmissionParam,
@@ -101,6 +104,8 @@ class TransactionProcessor(
         new TransactionConfirmationResponsesFactory(
           participantId,
           synchronizerId,
+          externalCallValidator,
+          TransactionProcessor.externalCallValidationParallelism(participantNodeParameters),
           loggerFactory,
         ),
         ModelConformanceChecker(
@@ -212,6 +217,11 @@ class TransactionProcessor(
 }
 
 object TransactionProcessor {
+
+  private def externalCallValidationParallelism(
+      participantNodeParameters: ParticipantNodeParameters
+  ): PositiveInt =
+    participantNodeParameters.general.batchingConfig.parallelism
 
   sealed trait TransactionProcessorError
       extends WrapsProcessorError

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -6,7 +6,7 @@ package com.digitalasset.canton.participant.protocol.validation
 import cats.Order
 import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
-import com.digitalasset.canton.data.ViewPosition
+import com.digitalasset.canton.data.{ParticipantTransactionView, ViewPosition}
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.participant.util.ExternalCallPayloadDescription.{
@@ -147,24 +147,23 @@ object ExternalCallConsistencyChecker {
   }
 
   private def visibleOccurrences(
-      viewValidationResults: Map[ViewPosition, ViewValidationResult]
+      views: Map[ViewPosition, ParticipantTransactionView]
   ): Seq[VisibleExternalCallOccurrence] =
-    viewValidationResults.toSeq
+    views.toSeq
       .sortBy(_._1)(ViewPosition.orderViewPosition.toOrdering)
-      .flatMap { case (viewPosition, viewValidationResult) =>
-        viewValidationResult.view.viewParticipantData.externalCallResults.map {
-          externalCallResult =>
-            val occurrence = ExternalCallOccurrence(
-              viewPosition,
-              externalCallResult.exerciseIndex,
-              externalCallResult.callIndex,
-            )
-            VisibleExternalCallOccurrence(
-              DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
-              externalCallResult.result.output,
-              occurrence,
-              externalCallResult.checkingParties,
-            )
+      .flatMap { case (viewPosition, view) =>
+        view.viewParticipantData.externalCallResults.map { externalCallResult =>
+          val occurrence = ExternalCallOccurrence(
+            viewPosition,
+            externalCallResult.exerciseIndex,
+            externalCallResult.callIndex,
+          )
+          VisibleExternalCallOccurrence(
+            DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
+            externalCallResult.result.output,
+            occurrence,
+            externalCallResult.checkingParties,
+          )
         }
       }
 
@@ -204,10 +203,10 @@ object ExternalCallConsistencyChecker {
     * [[Result]] for how the two differ.
     */
   def check(
-      viewValidationResults: Map[ViewPosition, ViewValidationResult],
+      views: Map[ViewPosition, ParticipantTransactionView],
       hostedConfirmingParties: Set[LfPartyId],
   ): Result = {
-    val occurrences = visibleOccurrences(viewValidationResults)
+    val occurrences = visibleOccurrences(views)
     Result(
       hostedInconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
       visibleInconsistencies = visibleInconsistencies(occurrences),

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -161,7 +161,7 @@ private[validation] final class ExternalCallRoutingContext(
       hostedConfirmingParties: Set[LfPartyId],
   ): Seq[(LfPartyId, Inconsistency)] = {
     val recordedResultInconsistencies =
-      recordedConsistencyResult.inconsistencies.toSeq.flatMap {
+      recordedConsistencyResult.hostedInconsistencies.toSeq.flatMap {
         case (party, inconsistencies) if hostedConfirmingParties(party) =>
           inconsistencies
             .find(_.occurrences.exists(_.viewPosition == viewPosition))

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -290,24 +290,21 @@ private[validation] object ExternalCallResponseRouter {
     val orderedDisagreements =
       disagreements.distinct.sorted(orderRecordedResultDisagreement)
 
-    if (orderedDisagreements.isEmpty) Map.empty
-    else {
-      val orderedViews =
-        viewsWithHostedParties.sortBy(_.viewPosition)(ViewPosition.orderViewPosition.toOrdering)
+    val orderedViews =
+      viewsWithHostedParties.sortBy(_.viewPosition)(ViewPosition.orderViewPosition.toOrdering)
 
-      val routed =
-        orderedDisagreements.flatMap { disagreement =>
-          occurrencesByParty(disagreement, orderedViews).toSeq.map { case (party, occurrences) =>
-            party -> (disagreement -> Inconsistency(
-              disagreement.key,
-              disagreement.outputs,
-              occurrences,
-            ))
-          }
+    val routed =
+      orderedDisagreements.flatMap { disagreement =>
+        occurrencesByParty(disagreement, orderedViews).toSeq.map { case (party, occurrences) =>
+          party -> (disagreement -> Inconsistency(
+            disagreement.key,
+            disagreement.outputs,
+            occurrences,
+          ))
         }
+      }
 
-      routed.groupMap(_._1)(_._2)
-    }
+    routed.groupMap(_._1)(_._2)
   }
 
   /** For a single recorded disagreement, the occurrences of its external call that each hosted

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -168,7 +168,6 @@ private[validation] class ExternalCallResponseRouter(
 ) extends NamedLogging {
 
   import ExternalCallResponseRouter.*
-  import com.digitalasset.canton.util.ShowUtil.*
 
   def validationOccurrences(
       viewsWithHostedParties: Seq[ViewWithHostedParties],
@@ -255,16 +254,13 @@ private[validation] class ExternalCallResponseRouter(
       recordedConsistencyResult: ExternalCallConsistencyChecker.Result,
   )(implicit traceContext: TraceContext): Unit =
     recordedConsistencyResult.visibleInconsistencies.foreach { inconsistency =>
-      val details = inconsistency.description.limit(maxExternalCallDisagreementDetailsLength)
       ExternalCallValidationError.ExternalCallResultDisagreementAlarm
-        .Warn(s"Observed inconsistent external call results: $details")
+        .Warn(s"Observed inconsistent external call results: ${inconsistency.description}")
         .logWithContext(Map("requestId" -> requestId.toString))
     }
 }
 
 private[validation] object ExternalCallResponseRouter {
-
-  val maxExternalCallDisagreementDetailsLength = 1024
 
   private val orderRecordedResultDisagreement
       : Ordering[DAMLe.ExternalCallRecordedResultDisagreement] =

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -3,9 +3,10 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
+import cats.syntax.parallel.*
 import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
-import com.digitalasset.canton.data.{ViewParticipantData, ViewPosition}
+import com.digitalasset.canton.data.{ParticipantTransactionView, ViewParticipantData, ViewPosition}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsistencyChecker.{
@@ -14,33 +15,18 @@ import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsi
 }
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.RequestId
+import com.digitalasset.canton.topology.ParticipantId
+import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.daml.lf.data.Bytes
 
 import scala.concurrent.ExecutionContext
 
-/** A received view together with the confirming parties of the view that this participant hosts.
-  */
-private[validation] final case class ViewWithHostedParties(
-    viewPosition: ViewPosition,
-    validationResult: ViewValidationResult,
-    hostedConfirmingParties: Set[LfPartyId],
-)
-
-/** A recorded external-call result selected for re-validation, together with the hosted checking
-  * parties whose approval of the view depends on it.
-  */
-private[validation] final case class ExternalCallValidationOccurrence(
-    viewPosition: ViewPosition,
-    result: ViewParticipantData.ViewExternalCallResult,
-    hostedCheckingParties: Set[LfPartyId],
-)
-
 /** An abstention from confirming a view because a recorded external-call result could not be
   * re-validated.
   */
-private[validation] final case class ExternalCallValidationAbstain(
+final case class ExternalCallValidationAbstain(
     viewPosition: ViewPosition,
     reason: String,
 )
@@ -49,21 +35,27 @@ private[validation] final case class ExternalCallValidationAbstain(
   * re-validation mismatches (as inconsistencies carrying the recorded and the computed output),
   * `abstains` holds the per-view abstentions where a result could not be re-validated.
   */
-private[validation] final case class ExternalCallValidationRoutes(
+final case class ExternalCallValidationRoutes(
     rejects: Map[LfPartyId, Seq[Inconsistency]],
     abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
 ) {
 
-  /** Yields for every party in `hostedConfirmingParties` an inconsistency in `rejects(party)` that
-    * has the given `viewPosition` (provided it exists). Picks the smallest inconsistency per party
-    * by [[ExternalCallConsistencyChecker.orderInconsistency]] so that the result is deterministic.
+  /** Yields for every party in `nonRejectingConfirmingParties` an inconsistency in `rejects(party)`
+    * that has the given `viewPosition` (provided it exists). Picks the smallest inconsistency per
+    * party by [[ExternalCallConsistencyChecker.orderInconsistency]] so that the result is
+    * deterministic.
+    *
+    * @param nonRejectingConfirmingParties
+    *   The hosted confirming parties that are not already rejecting for this view (rejections for
+    *   disagreements take precedence over re-validation outcomes, and at most one external-call
+    *   rejection is routed per party and view).
     */
   def rejectsForView(
       viewPosition: ViewPosition,
-      hostedConfirmingParties: Set[LfPartyId],
+      nonRejectingConfirmingParties: Set[LfPartyId],
   ): Seq[(LfPartyId, Inconsistency)] =
     rejects.toSeq.sortBy { case (party, _) => party }.flatMap {
-      case (party, inconsistencies) if hostedConfirmingParties(party) =>
+      case (party, inconsistencies) if nonRejectingConfirmingParties(party) =>
         inconsistencies
           .filter(_.occurrences.exists(_.viewPosition == viewPosition))
           .minByOption(identity)(ExternalCallConsistencyChecker.orderInconsistency)
@@ -92,140 +84,43 @@ private[validation] final case class ExternalCallValidationRoutes(
     }
 }
 
-/** Per-request external-call routing state.
-  *
-  * Aggregates the two disagreement sources of a request, namely the results recorded across the
-  * received views (checked by [[ExternalCallConsistencyChecker]]) and the disagreements raised
-  * during replay reinterpretation, and computes which hosted confirming parties must reject because
-  * of them (or which model-conformance rejections they suppress and partially replace, see
-  * [[isRoutableModelConformanceError]]).
-  */
-private[validation] final class ExternalCallRoutingContext(
-    recordedResultDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
-    viewsWithHostedParties: Seq[ViewWithHostedParties],
-    viewValidationResults: Map[ViewPosition, ViewValidationResult],
-) {
-  private lazy val hasAnyVisibleExternalCallResults: Boolean =
-    viewValidationResults.valuesIterator.exists { viewValidationResult =>
-      val viewParticipantData = viewValidationResult.view.viewParticipantData
-      viewParticipantData.externalCallResults.nonEmpty
-    }
-
-  private lazy val recordedExternalCallDisagreementInconsistencies
-      : Map[LfPartyId, Seq[(DAMLe.ExternalCallRecordedResultDisagreement, Inconsistency)]] =
-    ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
-      recordedResultDisagreements,
-      viewsWithHostedParties,
-    )
-
-  private lazy val routableRecordedExternalCallDisagreements
-      : Set[DAMLe.ExternalCallRecordedResultDisagreement] =
-    recordedExternalCallDisagreementInconsistencies.valuesIterator
-      .flatMap(_.iterator)
-      .map(_._1)
-      .toSet
-
-  /** Consistency of the external-call results recorded across all received views, checked for the
-    * union of the hosted confirming parties of all views. See
-    * [[ExternalCallConsistencyChecker.Result]].
-    */
-  lazy val recordedConsistencyResult: ExternalCallConsistencyChecker.Result =
-    if (hasAnyVisibleExternalCallResults) {
-      val allHostedConfirmingParties =
-        viewsWithHostedParties.flatMap(_.hostedConfirmingParties).toSet
-      ExternalCallConsistencyChecker.check(
-        viewValidationResults,
-        allHostedConfirmingParties,
-      )
-    } else ExternalCallConsistencyChecker.Result.empty
-
-  /** Whether `error` is an external-call replay disagreement for which some hosted confirming party
-    * checks a matching occurrence. Such an error is expected to suppress the generic (malformed)
-    * model-conformance rejection of the request; in its place, the hosted confirming parties that
-    * check a matching occurrence reject per view with the disagreement inconsistency provided by
-    * [[inconsistenciesForView]]. Note that the routed rejections cover at most as many parties as
-    * the suppressed blanket rejection, and in general fewer: views without a matching occurrence
-    * and confirming parties that do not check the result are not rejected through this path.
-    */
-  def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
-    ExternalCallResponseRouter
-      .externalCallRecordedResultDisagreement(error)
-      .exists(routableRecordedExternalCallDisagreements)
-
-  /** Yields for every party in `hostedConfirmingParties` at most one inconsistency among the
-    * disagreeing external-call results that the party checks in the given view: from the results
-    * recorded across views where the party is affected there, otherwise from the replay
-    * disagreements. Parties in the result are expected to reject the view with the returned
-    * inconsistency.
-    */
-  def inconsistenciesForView(
-      viewPosition: ViewPosition,
-      hostedConfirmingParties: Set[LfPartyId],
-  ): Seq[(LfPartyId, Inconsistency)] = {
-    val recordedResultInconsistencies =
-      recordedConsistencyResult.hostedInconsistencies.toSeq.flatMap {
-        case (party, inconsistencies) if hostedConfirmingParties(party) =>
-          inconsistencies
-            .find(_.occurrences.exists(_.viewPosition == viewPosition))
-            .map(party -> _)
-        case _ => None
-      }
-
-    val partiesWithRecordedResultInconsistencies =
-      recordedResultInconsistencies.map(_._1).toSet
-
-    val recordedReplayInconsistencies =
-      recordedExternalCallDisagreementInconsistencies.toSeq.flatMap {
-        case (party, disagreementInconsistencies)
-            if hostedConfirmingParties(party) &&
-              !partiesWithRecordedResultInconsistencies(party) =>
-          disagreementInconsistencies
-            .find(_._2.occurrences.exists(_.viewPosition == viewPosition))
-            .map { case (_, inconsistency) => party -> inconsistency }
-        case _ => None
-      }
-
-    recordedResultInconsistencies ++
-      recordedReplayInconsistencies
-  }
+object ExternalCallValidationRoutes {
+  val empty: ExternalCallValidationRoutes = ExternalCallValidationRoutes(Map.empty, Map.empty)
 }
 
-/** Routes external-call validation outcomes to per-view, per-party local verdicts.
+/** Checks and re-validates the external-call results of a transaction request, as one of the
+  * parallel validation suites invoked from `TransactionProcessingSteps.doParallelChecks`.
   *
   * External-call verdicts derive from three sources:
   *   - disagreements between the results recorded across the views of the transaction, computed by
   *     [[ExternalCallConsistencyChecker]] (see
-  *     [[ExternalCallRoutingContext.recordedConsistencyResult]]),
+  *     [[ExternalCallResponseRouter.Result.recordedConsistency]]),
   *   - disagreements within the replay data of a single reinterpretation, that is, of a view
   *     together with its subviews, surfaced as
   *     [[com.digitalasset.canton.participant.util.DAMLe.ExternalCallRecordedResultDisagreement]]
-  *     model-conformance errors (see [[ExternalCallRoutingContext.inconsistenciesForView]]),
+  *     model-conformance errors (see [[ExternalCallResponseRouter.Result.inconsistenciesForView]]),
   *   - re-validation of undisputed recorded results against the extension service (see
-  *     [[validationOccurrences]] and [[validateExternalCalls]]).
+  *     `validationOccurrences` and `validateExternalCalls`).
   *
-  * Intended data flow for a request: construct an [[ExternalCallRoutingContext]] from the view
-  * validation results and the reinterpretation disagreements; alarm on all visible recorded
-  * disagreements, including those that affect no hosted party
-  * ([[reportVisibleRecordedDisagreementAlarms]]); obtain the per-party disagreement rejections of
-  * every view ([[ExternalCallRoutingContext.inconsistenciesForView]]); for the views that would
-  * otherwise be approved, select the candidate occurrences for re-validation
-  * ([[validationOccurrences]]) and re-run them against the extension service
-  * ([[validateExternalCalls]]). The resulting [[ExternalCallValidationRoutes]] are folded into the
-  * per-view verdicts via [[ExternalCallValidationRoutes.rejectsForView]] and
-  * [[ExternalCallValidationRoutes.abstainsForView]], with rejections taking precedence:
-  * [[ExternalCallValidationRoutes.abstainsForView]] is fed only the parties that are not already
-  * rejecting. Net effect per hosted confirming party: it rejects the disagreements and mismatches
-  * among the occurrences it checks, abstains where re-validation was not possible, and approves
-  * otherwise.
+  * Intended data flow for a request: `doParallelChecks` invokes [[check]] concurrently with the
+  * other validation suites (following the pattern of `ModelConformanceChecker.check`); the returned
+  * [[ExternalCallResponseRouter.Result]] travels to `TransactionConfirmationResponsesFactory`
+  * through the transaction validation result, and the factory translates it -- without further
+  * validation work -- into per-view, per-party verdicts: rejections for the disagreements and
+  * re-validation mismatches a hosted confirming party checks, abstentions where re-validation was
+  * not possible, and approval otherwise.
   *
   * Stateless helpers that do not need the validator live on the companion object.
   *
+  * @param participantId
+  *   The participant running the validation, used to resolve the hosted confirming parties.
   * @param externalCallValidator
   *   The validator used to re-run external calls during validation.
   * @param externalCallValidationParallelism
-  *   Bounds the number of concurrent validator calls in [[validateExternalCalls]].
+  *   Bounds the number of concurrent validator calls in `validateExternalCalls`.
   */
-private[validation] class ExternalCallResponseRouter(
+class ExternalCallResponseRouter(
+    participantId: ParticipantId,
     externalCallValidator: ExternalCallValidator,
     externalCallValidationParallelism: PositiveInt,
     protected val loggerFactory: NamedLoggerFactory,
@@ -233,47 +128,137 @@ private[validation] class ExternalCallResponseRouter(
 
   import ExternalCallResponseRouter.*
 
-  /** Selects the recorded external-call results that a view is expected to re-validate against the
-    * extension service before its hosted parties approve it.
+  /** Checks the external-call results recorded in the received views and re-validates them against
+    * the extension service. The check consists of:
+    *   - resolving the confirming parties of every view that this participant hosts,
+    *   - checking the consistency of the recorded results across all views
+    *     ([[ExternalCallConsistencyChecker.check]]) and alarming on every visible disagreement,
+    *     including those that affect no hosted party,
+    *   - re-validating the undisputed recorded results that a hosted confirming party checks
+    *     (`validationOccurrences`, `validateExternalCalls`). The network I/O starts before the
+    *     model-conformance result is available, so it runs concurrently with the reinterpretation,
+    *   - routing the replay disagreements surfaced by the model-conformance errors to the hosted
+    *     confirming parties that check a matching occurrence
+    *     (`recordedExternalCallDisagreementInconsistencies`).
     *
-    * For every view in `approvingViewPositions` (mapping the views that would otherwise be approved
-    * to their approving hosted parties), every recorded result of the view is selected for the
-    * parties that check it and would approve, excluding the parties that already reject the view
-    * because of a disagreement ([[ExternalCallRoutingContext.inconsistenciesForView]]). Results
-    * with no such party yield no occurrence.
+    * The returned [[ExternalCallResponseRouter.Result]] completes once all of the above have; it is
+    * pure data and translated into verdicts by `TransactionConfirmationResponsesFactory`.
+    *
+    * If no view records an external-call result -- in particular, always, on protocol versions
+    * without external-call support -- the check short-circuits to
+    * [[ExternalCallResponseRouter.Result.empty]] without topology lookups: replay disagreements
+    * carry outputs recorded in the views, so none can exist without recorded results either.
+    *
+    * @param requestId
+    *   The request under validation, used to correlate logs and alarms.
+    * @param views
+    *   All views of the request received by this participant, by position.
+    * @param topologySnapshot
+    *   Used to resolve which confirming parties of each view this participant hosts.
+    * @param conformanceErrorsF
+    *   The non-abort errors of the model conformance check; awaited only for the replay-routing
+    *   step, after the re-validation has been kicked off.
+    * @param runValidation
+    *   Whether to re-validate undisputed recorded results. False for requests with malformed
+    *   payloads, which are rejected wholesale: only the alarms are of interest there.
     */
-  def validationOccurrences(
+  def check(
+      requestId: RequestId,
+      views: Map[ViewPosition, ParticipantTransactionView],
+      topologySnapshot: TopologySnapshot,
+      conformanceErrorsF: FutureUnlessShutdown[Seq[ModelConformanceChecker.Error]],
+      runValidation: Boolean,
+  )(implicit
+      traceContext: TraceContext,
+      ec: ExecutionContext,
+  ): FutureUnlessShutdown[Result] = {
+    val hasAnyVisibleExternalCallResults =
+      views.valuesIterator.exists(_.viewParticipantData.externalCallResults.nonEmpty)
+
+    if (!hasAnyVisibleExternalCallResults)
+      FutureUnlessShutdown.pure(Result.empty)
+    else {
+      val viewsWithHostedPartiesF =
+        views.toSeq
+          .sortBy { case (viewPosition, _) => viewPosition }(
+            ViewPosition.orderViewPosition.toOrdering
+          )
+          .parTraverse { case (viewPosition, view) =>
+            topologySnapshot
+              .canConfirm(
+                participantId,
+                view.viewCommonData.viewConfirmationParameters.confirmers,
+              )
+              .map(hostedConfirmingParties =>
+                ViewWithHostedParties(viewPosition, view, hostedConfirmingParties)
+              )
+          }
+
+      for {
+        viewsWithHostedParties <- viewsWithHostedPartiesF
+        recordedConsistency = {
+          val allHostedConfirmingParties =
+            viewsWithHostedParties.flatMap(_.hostedConfirmingParties).toSet
+          ExternalCallConsistencyChecker.check(views, allHostedConfirmingParties)
+        }
+        _ = reportVisibleRecordedDisagreementAlarms(requestId, recordedConsistency)
+        // Kick off the re-validation before awaiting the model-conformance errors, so that the
+        // network I/O runs concurrently with the reinterpretation.
+        validationRoutesF =
+          if (runValidation)
+            validateExternalCalls(
+              validationOccurrences(viewsWithHostedParties, recordedConsistency)
+            )
+          else FutureUnlessShutdown.pure(ExternalCallValidationRoutes.empty)
+        conformanceErrors <- conformanceErrorsF
+        replayDisagreementInconsistencies = recordedExternalCallDisagreementInconsistencies(
+          conformanceErrors.flatMap(externalCallRecordedResultDisagreement),
+          viewsWithHostedParties,
+        )
+        validationRoutes <- validationRoutesF
+      } yield Result(recordedConsistency, replayDisagreementInconsistencies, validationRoutes)
+    }
+  }
+
+  /** Selects the recorded external-call results to re-validate against the extension service.
+    *
+    * Every recorded result of every view is selected for the hosted confirming parties that check
+    * it, excluding the parties that already reject the view because they check a disagreement among
+    * the recorded results. Results with no such party yield no occurrence.
+    *
+    * Whether a view will be approved is not known at selection time (re-validation runs
+    * concurrently with the other validation suites), so results of views that end up rejected may
+    * be re-validated needlessly; the factory folds re-validation outcomes only into views that
+    * would otherwise be approved.
+    */
+  private[validation] def validationOccurrences(
       viewsWithHostedParties: Seq[ViewWithHostedParties],
-      approvingViewPositions: Map[ViewPosition, Set[LfPartyId]],
-      externalCallRouting: ExternalCallRoutingContext,
+      recordedConsistency: ExternalCallConsistencyChecker.Result,
   ): Seq[ExternalCallValidationOccurrence] =
     viewsWithHostedParties
       .sortBy(_.viewPosition)(ViewPosition.orderViewPosition.toOrdering)
       .flatMap { viewWithHostedParties =>
-        approvingViewPositions.get(viewWithHostedParties.viewPosition).toList.flatMap {
-          approvingParties =>
-            val viewParticipantData =
-              viewWithHostedParties.validationResult.view.viewParticipantData
-            if (viewParticipantData.externalCallResults.isEmpty) Seq.empty
-            else {
-              val alreadyRejectedParties =
-                externalCallRouting
-                  .inconsistenciesForView(viewWithHostedParties.viewPosition, approvingParties)
-                  .map(_._1)
-                  .toSet
+        val viewPosition = viewWithHostedParties.viewPosition
+        val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
 
-              viewParticipantData.externalCallResults.flatMap { result =>
-                val affectedParties =
-                  result.checkingParties.intersect(approvingParties) -- alreadyRejectedParties
-                Option.when(affectedParties.nonEmpty)(
-                  ExternalCallValidationOccurrence(
-                    viewWithHostedParties.viewPosition,
-                    result,
-                    affectedParties,
-                  )
-                )
-              }
-            }
+        val alreadyRejectedParties =
+          recordedConsistency.hostedInconsistencies.collect {
+            case (party, inconsistencies)
+                if hostedConfirmingParties(party) &&
+                  inconsistencies.exists(_.occurrences.exists(_.viewPosition == viewPosition)) =>
+              party
+          }.toSet
+
+        viewWithHostedParties.view.viewParticipantData.externalCallResults.flatMap { result =>
+          val affectedParties =
+            result.checkingParties.intersect(hostedConfirmingParties) -- alreadyRejectedParties
+          Option.when(affectedParties.nonEmpty)(
+            ExternalCallValidationOccurrence(
+              viewPosition,
+              result,
+              affectedParties,
+            )
+          )
         }
       }
 
@@ -284,18 +269,21 @@ private[validation] class ExternalCallResponseRouter(
     * ([[com.digitalasset.canton.participant.util.DAMLe.ExternalCallKey]]). Only keys whose selected
     * occurrences all record the same output are re-validated: once per key, with the number of
     * concurrent validator calls bounded by `externalCallValidationParallelism`. Keys with
-    * disagreeing recorded outputs are not re-validated; those disagreements are covered by
-    * [[ExternalCallRoutingContext]] (per-party rejections where a hosted party checks conflicting
-    * occurrences, visible-disagreement alarms otherwise).
+    * disagreeing recorded outputs are not re-validated; those disagreements are covered by the
+    * consistency check (per-party rejections where a hosted party checks conflicting occurrences,
+    * visible-disagreement alarms otherwise). Since the selection spans all views of the request, a
+    * key whose recorded outputs disagree anywhere in the request is never re-validated,
+    * independently of which views end up being approved.
     *
     * Verdict routing, applied to every hosted checking party of every occurrence of the key:
-    * [[ExternalCallValidator.Mismatched]] yields a rejection (an [[Inconsistency]] carrying the
-    * recorded and the computed output), [[ExternalCallValidator.UnableToValidate]] yields an
-    * abstention with the given reason, and [[ExternalCallValidator.Matched]] yields nothing. The
-    * per-party sequences of the returned [[ExternalCallValidationRoutes]] are deduplicated and
-    * sorted, so the routes are deterministic.
+    * [[ExternalCallValidator.Mismatched]] yields a rejection (an
+    * [[ExternalCallConsistencyChecker.Inconsistency]] carrying the recorded and the computed
+    * output), [[ExternalCallValidator.UnableToValidate]] yields an abstention with the given
+    * reason, and [[ExternalCallValidator.Matched]] yields nothing. The per-party sequences of the
+    * returned [[ExternalCallValidationRoutes]] are deduplicated and sorted, so the routes are
+    * deterministic.
     */
-  def validateExternalCalls(
+  private[validation] def validateExternalCalls(
       occurrences: Seq[ExternalCallValidationOccurrence]
   )(implicit
       traceContext: TraceContext,
@@ -344,18 +332,117 @@ private[validation] class ExternalCallResponseRouter(
     * among the recorded results visible to this participant, independently of whether a hosted
     * party is affected.
     */
-  def reportVisibleRecordedDisagreementAlarms(
+  private def reportVisibleRecordedDisagreementAlarms(
       requestId: RequestId,
-      recordedConsistencyResult: ExternalCallConsistencyChecker.Result,
+      recordedConsistency: ExternalCallConsistencyChecker.Result,
   )(implicit traceContext: TraceContext): Unit =
-    recordedConsistencyResult.visibleInconsistencies.foreach { inconsistency =>
+    recordedConsistency.visibleInconsistencies.foreach { inconsistency =>
       ExternalCallValidationError.ExternalCallResultDisagreementAlarm
         .Warn(s"Observed inconsistent external call results: ${inconsistency.description}")
         .logWithContext(Map("requestId" -> requestId.toString))
     }
 }
 
-private[validation] object ExternalCallResponseRouter {
+object ExternalCallResponseRouter {
+
+  /** A received view together with the confirming parties of the view that this participant hosts.
+    */
+  private[validation] final case class ViewWithHostedParties(
+      viewPosition: ViewPosition,
+      view: ParticipantTransactionView,
+      hostedConfirmingParties: Set[LfPartyId],
+  )
+
+  /** A recorded external-call result selected for re-validation, together with the hosted checking
+    * parties whose approval of the view depends on it.
+    */
+  private[validation] final case class ExternalCallValidationOccurrence(
+      viewPosition: ViewPosition,
+      result: ViewParticipantData.ViewExternalCallResult,
+      hostedCheckingParties: Set[LfPartyId],
+  )
+
+  /** Precomputed external-call validation outcome of a request, produced by `check` and consumed by
+    * `TransactionConfirmationResponsesFactory` as pure data.
+    *
+    * Aggregates the two disagreement sources of a request, namely the results recorded across the
+    * received views (checked by [[ExternalCallConsistencyChecker]]) and the disagreements raised
+    * during replay reinterpretation, together with the outcome of re-validating the undisputed
+    * results against the extension service.
+    */
+  final case class Result(
+      recordedConsistency: ExternalCallConsistencyChecker.Result,
+      replayDisagreementInconsistencies: Map[
+        LfPartyId,
+        Seq[(DAMLe.ExternalCallRecordedResultDisagreement, Inconsistency)],
+      ],
+      validationRoutes: ExternalCallValidationRoutes,
+  ) {
+
+    private lazy val routableReplayDisagreements
+        : Set[DAMLe.ExternalCallRecordedResultDisagreement] =
+      replayDisagreementInconsistencies.valuesIterator
+        .flatMap(_.iterator)
+        .map { case (disagreement, _) => disagreement }
+        .toSet
+
+    /** Whether `error` is an external-call replay disagreement for which some hosted confirming
+      * party checks a matching occurrence. Such an error is expected to suppress the generic
+      * (malformed) model-conformance rejection of the request; in its place, the hosted confirming
+      * parties that check a matching occurrence reject per view with the disagreement inconsistency
+      * provided by [[inconsistenciesForView]]. Note that the routed rejections cover at most as
+      * many parties as the suppressed blanket rejection, and in general fewer: views without a
+      * matching occurrence and confirming parties that do not check the result are not rejected
+      * through this path.
+      */
+    def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
+      externalCallRecordedResultDisagreement(error).exists(routableReplayDisagreements)
+
+    /** Yields for every party in `hostedConfirmingParties` at most one inconsistency among the
+      * disagreeing external-call results that the party checks in the given view: from the results
+      * recorded across views where the party is affected there, otherwise from the replay
+      * disagreements. Parties in the result are expected to reject the view with the returned
+      * inconsistency.
+      */
+    def inconsistenciesForView(
+        viewPosition: ViewPosition,
+        hostedConfirmingParties: Set[LfPartyId],
+    ): Seq[(LfPartyId, Inconsistency)] = {
+      val recordedResultInconsistencies =
+        recordedConsistency.hostedInconsistencies.toSeq.flatMap {
+          case (party, inconsistencies) if hostedConfirmingParties(party) =>
+            inconsistencies
+              .find(_.occurrences.exists(_.viewPosition == viewPosition))
+              .map(party -> _)
+          case _ => None
+        }
+
+      val partiesWithRecordedResultInconsistencies =
+        recordedResultInconsistencies.map(_._1).toSet
+
+      val recordedReplayInconsistencies =
+        replayDisagreementInconsistencies.toSeq.flatMap {
+          case (party, disagreementInconsistencies)
+              if hostedConfirmingParties(party) &&
+                !partiesWithRecordedResultInconsistencies(party) =>
+            disagreementInconsistencies
+              .find(_._2.occurrences.exists(_.viewPosition == viewPosition))
+              .map { case (_, inconsistency) => party -> inconsistency }
+          case _ => None
+        }
+
+      recordedResultInconsistencies ++
+        recordedReplayInconsistencies
+    }
+  }
+
+  object Result {
+    val empty: Result = Result(
+      ExternalCallConsistencyChecker.Result.empty,
+      Map.empty,
+      ExternalCallValidationRoutes.empty,
+    )
+  }
 
   private val orderRecordedResultDisagreement
       : Ordering[DAMLe.ExternalCallRecordedResultDisagreement] =
@@ -370,7 +457,7 @@ private[validation] object ExternalCallResponseRouter {
       )
       .orElseBy(_.reason)
 
-  def externalCallRecordedResultDisagreement(
+  private def externalCallRecordedResultDisagreement(
       error: ModelConformanceChecker.Error
   ): Option[DAMLe.ExternalCallRecordedResultDisagreement] = error match {
     case ModelConformanceChecker.DAMLeError(
@@ -381,7 +468,7 @@ private[validation] object ExternalCallResponseRouter {
     case _ => None
   }
 
-  def recordedExternalCallDisagreementInconsistencies(
+  private def recordedExternalCallDisagreementInconsistencies(
       disagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
       viewsWithHostedParties: Seq[ViewWithHostedParties],
   ): Map[LfPartyId, Seq[(DAMLe.ExternalCallRecordedResultDisagreement, Inconsistency)]] = {
@@ -415,7 +502,7 @@ private[validation] object ExternalCallResponseRouter {
   ): Map[LfPartyId, Set[ExternalCallOccurrence]] =
     orderedViews
       .flatMap { view =>
-        view.validationResult.view.viewParticipantData.externalCallResults
+        view.view.viewParticipantData.externalCallResults
           .filter(result => matchesDisagreement(disagreement, result))
           .flatMap { result =>
             val occurrence = ExternalCallOccurrence(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -97,7 +97,8 @@ private[validation] final case class ExternalCallValidationRoutes(
   * Aggregates the two disagreement sources of a request, namely the results recorded across the
   * received views (checked by [[ExternalCallConsistencyChecker]]) and the disagreements raised
   * during replay reinterpretation, and computes which hosted confirming parties must reject because
-  * of them (or which model-conformance rejections they supersede).
+  * of them (or which model-conformance rejections they suppress and partially replace, see
+  * [[isRoutableModelConformanceError]]).
   */
 private[validation] final class ExternalCallRoutingContext(
     recordedResultDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
@@ -140,9 +141,9 @@ private[validation] final class ExternalCallRoutingContext(
     * checks a matching occurrence. Such an error is expected to suppress the generic (malformed)
     * model-conformance rejection of the request; in its place, the hosted confirming parties that
     * check a matching occurrence reject per view with the disagreement inconsistency provided by
-    * [[inconsistenciesForView]]. Note that the routed rejections cover fewer parties than the
-    * suppressed blanket rejection: views without a matching occurrence and confirming parties that
-    * do not check the result are not rejected through this path.
+    * [[inconsistenciesForView]]. Note that the routed rejections cover at most as many parties as
+    * the suppressed blanket rejection, and in general fewer: views without a matching occurrence
+    * and confirming parties that do not check the result are not rejected through this path.
     */
   def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
     ExternalCallResponseRouter

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -41,6 +41,11 @@ private[validation] final case class ExternalCallValidationRoutes(
     rejects: Map[LfPartyId, Seq[Inconsistency]],
     abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
 ) {
+
+  /** Yields for every party in `hostedConfirmingParties` an inconsistency in `rejects(party)` that
+    * has the given `viewPosition` (provided it exists). Picks the smallest inconsistency per party
+    * by [[ExternalCallConsistencyChecker.orderInconsistency]] so that the result is deterministic.
+    */
   def rejectsForView(
       viewPosition: ViewPosition,
       hostedConfirmingParties: Set[LfPartyId],

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -20,23 +20,35 @@ import com.digitalasset.daml.lf.data.Bytes
 
 import scala.concurrent.ExecutionContext
 
+/** A received view together with the confirming parties of the view that this participant hosts.
+  */
 private[validation] final case class ViewWithHostedParties(
     viewPosition: ViewPosition,
     validationResult: ViewValidationResult,
     hostedConfirmingParties: Set[LfPartyId],
 )
 
+/** A recorded external-call result selected for re-validation, together with the hosted checking
+  * parties whose approval of the view depends on it.
+  */
 private[validation] final case class ExternalCallValidationOccurrence(
     viewPosition: ViewPosition,
     result: ViewParticipantData.ViewExternalCallResult,
     hostedCheckingParties: Set[LfPartyId],
 )
 
+/** An abstention from confirming a view because a recorded external-call result could not be
+  * re-validated.
+  */
 private[validation] final case class ExternalCallValidationAbstain(
     viewPosition: ViewPosition,
     reason: String,
 )
 
+/** Per-party outcome of re-validating recorded external-call results: `rejects` holds the
+  * re-validation mismatches (as inconsistencies carrying the recorded and the computed output),
+  * `abstains` holds the per-view abstentions where a result could not be re-validated.
+  */
 private[validation] final case class ExternalCallValidationRoutes(
     rejects: Map[LfPartyId, Seq[Inconsistency]],
     abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
@@ -82,9 +94,10 @@ private[validation] final case class ExternalCallValidationRoutes(
 
 /** Per-request external-call routing state.
   *
-  * Computes which hosted confirming parties must reject (or whose model-conformance rejections are
-  * superseded) because of external-call result disagreements, both for results visible across views
-  * and for disagreements surfaced during replay reinterpretation.
+  * Aggregates the two disagreement sources of a request, namely the results recorded across the
+  * received views (checked by [[ExternalCallConsistencyChecker]]) and the disagreements raised
+  * during replay reinterpretation, and computes which hosted confirming parties must reject because
+  * of them (or which model-conformance rejections they supersede).
   */
 private[validation] final class ExternalCallRoutingContext(
     recordedResultDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
@@ -109,6 +122,10 @@ private[validation] final class ExternalCallRoutingContext(
       .map(_._1)
       .toSet
 
+  /** Consistency of the external-call results recorded across all received views, checked for the
+    * union of the hosted confirming parties of all views. See
+    * [[ExternalCallConsistencyChecker.Result]].
+    */
   lazy val recordedConsistencyResult: ExternalCallConsistencyChecker.Result =
     if (hasAnyVisibleExternalCallResults) {
       val allHostedConfirmingParties =
@@ -119,11 +136,22 @@ private[validation] final class ExternalCallRoutingContext(
       )
     } else ExternalCallConsistencyChecker.Result.empty
 
+  /** Whether `error` is an external-call replay disagreement for which some hosted confirming party
+    * checks a matching occurrence. Such errors are expected to supersede the generic
+    * model-conformance rejection of the view: the affected parties reject with the disagreement
+    * inconsistency provided by [[inconsistenciesForView]] instead.
+    */
   def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
     ExternalCallResponseRouter
       .externalCallRecordedResultDisagreement(error)
       .exists(routableRecordedExternalCallDisagreements)
 
+  /** Yields for every party in `hostedConfirmingParties` at most one inconsistency among the
+    * disagreeing external-call results that the party checks in the given view: from the results
+    * recorded across views where the party is affected there, otherwise from the replay
+    * disagreements. Parties in the result are expected to reject the view with the returned
+    * inconsistency.
+    */
   def inconsistenciesForView(
       viewPosition: ViewPosition,
       hostedConfirmingParties: Set[LfPartyId],
@@ -156,10 +184,39 @@ private[validation] final class ExternalCallRoutingContext(
   }
 }
 
-/** Routes external-call result disagreements to per-view, per-party local verdicts.
+/** Routes external-call validation outcomes to per-view, per-party local verdicts.
   *
-  * Holds the external-call validator used to re-run calls during validation. Stateless helpers that
-  * do not need the validator live on the companion object.
+  * External-call verdicts derive from three sources:
+  *   - disagreements between the results recorded across the views of the transaction, computed by
+  *     [[ExternalCallConsistencyChecker]] (see
+  *     [[ExternalCallRoutingContext.recordedConsistencyResult]]),
+  *   - disagreements within the replay data of a single view, surfaced by reinterpretation as
+  *     [[com.digitalasset.canton.participant.util.DAMLe.ExternalCallRecordedResultDisagreement]]
+  *     model-conformance errors (see [[ExternalCallRoutingContext.inconsistenciesForView]]),
+  *   - re-validation of undisputed recorded results against the extension service (see
+  *     [[validationOccurrences]] and [[validateExternalCalls]]).
+  *
+  * Intended data flow for a request: construct an [[ExternalCallRoutingContext]] from the view
+  * validation results and the reinterpretation disagreements; alarm on all visible recorded
+  * disagreements, including those that affect no hosted party
+  * ([[reportVisibleRecordedDisagreementAlarms]]); obtain the per-party disagreement rejections of
+  * every view ([[ExternalCallRoutingContext.inconsistenciesForView]]); for the views that would
+  * otherwise be approved, select the candidate occurrences for re-validation
+  * ([[validationOccurrences]]) and re-run them against the extension service
+  * ([[validateExternalCalls]]). The resulting [[ExternalCallValidationRoutes]] are folded into the
+  * per-view verdicts via [[ExternalCallValidationRoutes.rejectsForView]] and
+  * [[ExternalCallValidationRoutes.abstainsForView]], with rejections taking precedence:
+  * [[ExternalCallValidationRoutes.abstainsForView]] is fed only the parties that are not already
+  * rejecting. Net effect per hosted confirming party: it rejects the disagreements and mismatches
+  * among the occurrences it checks, abstains where re-validation was not possible, and approves
+  * otherwise.
+  *
+  * Stateless helpers that do not need the validator live on the companion object.
+  *
+  * @param externalCallValidator
+  *   The validator used to re-run external calls during validation.
+  * @param externalCallValidationParallelism
+  *   Bounds the number of concurrent validator calls in [[validateExternalCalls]].
   */
 private[validation] class ExternalCallResponseRouter(
     externalCallValidator: ExternalCallValidator,
@@ -169,6 +226,15 @@ private[validation] class ExternalCallResponseRouter(
 
   import ExternalCallResponseRouter.*
 
+  /** Selects the recorded external-call results that a view is expected to re-validate against the
+    * extension service before its hosted parties approve it.
+    *
+    * For every view in `approvingViewPositions` (mapping the views that would otherwise be approved
+    * to their approving hosted parties), every recorded result of the view is selected for the
+    * parties that check it and would approve, excluding the parties that already reject the view
+    * because of a disagreement ([[ExternalCallRoutingContext.inconsistenciesForView]]). Results
+    * with no such party yield no occurrence.
+    */
   def validationOccurrences(
       viewsWithHostedParties: Seq[ViewWithHostedParties],
       approvingViewPositions: Map[ViewPosition, Set[LfPartyId]],
@@ -204,6 +270,24 @@ private[validation] class ExternalCallResponseRouter(
         }
       }
 
+  /** Re-validates the selected occurrences against the extension service and routes the verdicts to
+    * parties.
+    *
+    * Occurrences are grouped by their semantic call
+    * ([[com.digitalasset.canton.participant.util.DAMLe.ExternalCallKey]]). Only keys whose selected
+    * occurrences all record the same output are re-validated: once per key, with the number of
+    * concurrent validator calls bounded by `externalCallValidationParallelism`. Keys with
+    * disagreeing recorded outputs are not re-validated; those disagreements are covered by
+    * [[ExternalCallRoutingContext]] (per-party rejections where a hosted party checks conflicting
+    * occurrences, visible-disagreement alarms otherwise).
+    *
+    * Verdict routing, applied to every hosted checking party of every occurrence of the key:
+    * [[ExternalCallValidator.Mismatched]] yields a rejection (an [[Inconsistency]] carrying the
+    * recorded and the computed output), [[ExternalCallValidator.UnableToValidate]] yields an
+    * abstention with the given reason, and [[ExternalCallValidator.Matched]] yields nothing. The
+    * per-party sequences of the returned [[ExternalCallValidationRoutes]] are deduplicated and
+    * sorted, so the routes are deterministic.
+    */
   def validateExternalCalls(
       occurrences: Seq[ExternalCallValidationOccurrence]
   )(implicit
@@ -249,6 +333,10 @@ private[validation] class ExternalCallResponseRouter(
       }
   }
 
+  /** Emits one [[ExternalCallValidationError.ExternalCallResultDisagreementAlarm]] per disagreement
+    * among the recorded results visible to this participant, independently of whether a hosted
+    * party is affected.
+    */
   def reportVisibleRecordedDisagreementAlarms(
       requestId: RequestId,
       recordedConsistencyResult: ExternalCallConsistencyChecker.Result,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -59,13 +59,19 @@ private[validation] final case class ExternalCallValidationRoutes(
       case _ => None
     }
 
+  /** Yields for every party in `nonRejectingConfirmingParties` the abstain reason in
+    * `abstains(party)` recorded for the given `viewPosition` (provided it exists). Picks the
+    * smallest reason per party so that the result is deterministic.
+    *
+    * @param nonRejectingConfirmingParties
+    *   The hosted confirming parties that are not already rejecting for this view.
+    */
   def abstainsForView(
       viewPosition: ViewPosition,
-      hostedConfirmingParties: Set[LfPartyId],
-      rejectedParties: Set[LfPartyId],
+      nonRejectingConfirmingParties: Set[LfPartyId],
   ): Seq[(LfPartyId, String)] =
     abstains.toSeq.sortBy { case (party, _) => party }.flatMap {
-      case (party, abstains) if hostedConfirmingParties(party) && !rejectedParties(party) =>
+      case (party, abstains) if nonRejectingConfirmingParties(party) =>
         abstains
           .filter(_.viewPosition == viewPosition)
           .minByOption(_.reason)

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -317,22 +317,19 @@ private[validation] object ExternalCallResponseRouter {
   ): Map[LfPartyId, Set[ExternalCallOccurrence]] =
     orderedViews
       .flatMap { view =>
-        val viewParticipantData = view.validationResult.view.viewParticipantData
-        if (!viewParticipantData.supportsExternalCallResults) Seq.empty
-        else
-          viewParticipantData.externalCallResults
-            .filter(result => matchesDisagreement(disagreement, result))
-            .flatMap { result =>
-              val occurrence = ExternalCallOccurrence(
-                view.viewPosition,
-                result.exerciseIndex,
-                result.callIndex,
-              )
-              result.checkingParties
-                .intersect(view.hostedConfirmingParties)
-                .toSeq
-                .map(_ -> occurrence)
-            }
+        view.validationResult.view.viewParticipantData.externalCallResults
+          .filter(result => matchesDisagreement(disagreement, result))
+          .flatMap { result =>
+            val occurrence = ExternalCallOccurrence(
+              view.viewPosition,
+              result.exerciseIndex,
+              result.callIndex,
+            )
+            result.checkingParties
+              .intersect(view.hostedConfirmingParties)
+              .toSeq
+              .map(_ -> occurrence)
+          }
       }
       .groupMap(_._1)(_._2)
       .view

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -102,13 +102,14 @@ object ExternalCallValidationRoutes {
   *   - re-validation of undisputed recorded results against the extension service (see
   *     `validationOccurrences` and `validateExternalCalls`).
   *
-  * Intended data flow for a request: `doParallelChecks` invokes [[check]] concurrently with the
-  * other validation suites (following the pattern of `ModelConformanceChecker.check`); the returned
+  * Intended data flow for a request: `doParallelChecks` invokes [[check]] without awaiting it, so
+  * that it runs concurrently with the model conformance and internal consistency checks (following
+  * the pattern of `ModelConformanceChecker.check`); the returned
   * [[ExternalCallResponseRouter.Result]] travels to `TransactionConfirmationResponsesFactory`
   * through the transaction validation result, and the factory translates it -- without further
-  * validation work -- into per-view, per-party verdicts: rejections for the disagreements and
-  * re-validation mismatches a hosted confirming party checks, abstentions where re-validation was
-  * not possible, and approval otherwise.
+  * validation work -- into per-view, per-party verdicts: rejections for the disagreements a hosted
+  * confirming party checks, rejections and abstentions from re-validation on views that would
+  * otherwise be approved, and the view's own verdict for the remaining parties.
   *
   * Stateless helpers that do not need the validator live on the companion object.
   *
@@ -134,9 +135,11 @@ class ExternalCallResponseRouter(
     *   - checking the consistency of the recorded results across all views
     *     ([[ExternalCallConsistencyChecker.check]]) and alarming on every visible disagreement,
     *     including those that affect no hosted party,
-    *   - re-validating the undisputed recorded results that a hosted confirming party checks
-    *     (`validationOccurrences`, `validateExternalCalls`). The network I/O starts before the
-    *     model-conformance result is available, so it runs concurrently with the reinterpretation,
+    *   - re-validating the recorded results that a hosted confirming party checks and is not
+    *     already rejecting, where the selected occurrences agree on the output
+    *     (`validationOccurrences`, `validateExternalCalls`). The network I/O is kicked off without
+    *     awaiting the model-conformance result, so it can run concurrently with the
+    *     reinterpretation,
     *   - routing the replay disagreements surfaced by the model-conformance errors to the hosted
     *     confirming parties that check a matching occurrence
     *     (`recordedExternalCallDisagreementInconsistencies`).
@@ -271,9 +274,12 @@ class ExternalCallResponseRouter(
     * concurrent validator calls bounded by `externalCallValidationParallelism`. Keys with
     * disagreeing recorded outputs are not re-validated; those disagreements are covered by the
     * consistency check (per-party rejections where a hosted party checks conflicting occurrences,
-    * visible-disagreement alarms otherwise). Since the selection spans all views of the request, a
-    * key whose recorded outputs disagree anywhere in the request is never re-validated,
-    * independently of which views end up being approved.
+    * and visible-disagreement alarms in every case). Since the selection spans all views of the
+    * request (not only those that end up approved), this skip is independent of the per-view
+    * verdicts. It is however scoped to the selected occurrences: a conflicting occurrence that no
+    * hosted, non-rejecting confirming party checks does not participate in the aggregation, so the
+    * remaining side of such a disagreement is still re-validated for the parties that check it,
+    * while the dropped side stays covered by the consistency check as above.
     *
     * Verdict routing, applied to every hosted checking party of every occurrence of the key:
     * [[ExternalCallValidator.Mismatched]] yields a rejection (an

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -83,7 +83,6 @@ private[validation] final class ExternalCallRoutingContext(
   private lazy val hasAnyVisibleExternalCallResults: Boolean =
     viewValidationResults.valuesIterator.exists { viewValidationResult =>
       val viewParticipantData = viewValidationResult.view.viewParticipantData
-      viewParticipantData.supportsExternalCallResults &&
       viewParticipantData.externalCallResults.nonEmpty
     }
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import com.digitalasset.canton.LfPartyId
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.{ViewParticipantData, ViewPosition}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsistencyChecker.{
+  ExternalCallOccurrence,
+  Inconsistency,
+}
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.RequestId
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.MonadUtil
+import com.digitalasset.daml.lf.data.Bytes
+
+import scala.concurrent.ExecutionContext
+
+private[validation] final case class ViewWithHostedParties(
+    viewPosition: ViewPosition,
+    validationResult: ViewValidationResult,
+    hostedConfirmingParties: Set[LfPartyId],
+)
+
+private[validation] final case class ExternalCallValidationOccurrence(
+    viewPosition: ViewPosition,
+    result: ViewParticipantData.ViewExternalCallResult,
+    hostedCheckingParties: Set[LfPartyId],
+)
+
+private[validation] final case class ExternalCallValidationAbstain(
+    viewPosition: ViewPosition,
+    reason: String,
+)
+
+private[validation] final case class ExternalCallValidationRoutes(
+    rejects: Map[LfPartyId, Seq[Inconsistency]],
+    abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
+) {
+  def rejectsForView(
+      viewPosition: ViewPosition,
+      hostedConfirmingParties: Set[LfPartyId],
+  ): Seq[(LfPartyId, Inconsistency)] =
+    rejects.toSeq.sortBy { case (party, _) => party }.flatMap {
+      case (party, inconsistencies) if hostedConfirmingParties(party) =>
+        inconsistencies
+          .filter(_.occurrences.exists(_.viewPosition == viewPosition))
+          .minByOption(identity)(ExternalCallConsistencyChecker.orderInconsistency)
+          .map(party -> _)
+      case _ => None
+    }
+
+  def abstainsForView(
+      viewPosition: ViewPosition,
+      hostedConfirmingParties: Set[LfPartyId],
+      rejectedParties: Set[LfPartyId],
+  ): Seq[(LfPartyId, String)] =
+    abstains.toSeq.sortBy { case (party, _) => party }.flatMap {
+      case (party, abstains) if hostedConfirmingParties(party) && !rejectedParties(party) =>
+        abstains
+          .filter(_.viewPosition == viewPosition)
+          .minByOption(_.reason)
+          .map(abstain => party -> abstain.reason)
+      case _ => None
+    }
+}
+
+/** Per-request external-call routing state.
+  *
+  * Computes which hosted confirming parties must reject (or whose model-conformance rejections are
+  * superseded) because of external-call result disagreements, both for results visible across views
+  * and for disagreements surfaced during replay reinterpretation.
+  */
+private[validation] final class ExternalCallRoutingContext(
+    recordedResultDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
+    viewsWithHostedParties: Seq[ViewWithHostedParties],
+    viewValidationResults: Map[ViewPosition, ViewValidationResult],
+) {
+  private lazy val hasAnyVisibleExternalCallResults: Boolean =
+    viewValidationResults.valuesIterator.exists { viewValidationResult =>
+      val viewParticipantData = viewValidationResult.view.viewParticipantData
+      viewParticipantData.supportsExternalCallResults &&
+      viewParticipantData.externalCallResults.nonEmpty
+    }
+
+  private lazy val recordedReplayDisagreementInconsistencies =
+    ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
+      recordedResultDisagreements,
+      viewsWithHostedParties,
+    )
+
+  private lazy val routableRecordedExternalCallDisagreements =
+    recordedReplayDisagreementInconsistencies.valuesIterator
+      .flatMap(_.iterator)
+      .map(_._1)
+      .toSet
+
+  lazy val recordedConsistencyResult: ExternalCallConsistencyChecker.Result =
+    if (hasAnyVisibleExternalCallResults) {
+      val allHostedConfirmingParties =
+        viewsWithHostedParties.flatMap(_.hostedConfirmingParties).toSet
+      ExternalCallConsistencyChecker.check(
+        viewValidationResults,
+        allHostedConfirmingParties,
+      )
+    } else ExternalCallConsistencyChecker.Result.empty
+
+  def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
+    ExternalCallResponseRouter
+      .externalCallRecordedResultDisagreement(error)
+      .exists(routableRecordedExternalCallDisagreements)
+
+  def inconsistenciesForView(
+      viewPosition: ViewPosition,
+      hostedConfirmingParties: Set[LfPartyId],
+  ): Seq[(LfPartyId, Inconsistency)] = {
+    val recordedResultInconsistencies =
+      recordedConsistencyResult.inconsistencies.toSeq.flatMap {
+        case (party, inconsistencies) if hostedConfirmingParties(party) =>
+          inconsistencies
+            .find(_.occurrences.exists(_.viewPosition == viewPosition))
+            .map(party -> _)
+        case _ => None
+      }
+
+    val partiesWithRecordedResultInconsistencies =
+      recordedResultInconsistencies.map(_._1).toSet
+
+    val recordedReplayInconsistencies =
+      recordedReplayDisagreementInconsistencies.toSeq.flatMap {
+        case (party, disagreementInconsistencies)
+            if hostedConfirmingParties(party) &&
+              !partiesWithRecordedResultInconsistencies(party) =>
+          disagreementInconsistencies
+            .find(_._2.occurrences.exists(_.viewPosition == viewPosition))
+            .map { case (_, inconsistency) => party -> inconsistency }
+        case _ => None
+      }
+
+    recordedResultInconsistencies ++
+      recordedReplayInconsistencies
+  }
+}
+
+/** Routes external-call result disagreements to per-view, per-party local verdicts.
+  *
+  * Holds the external-call validator used to re-run calls during validation. Stateless helpers that
+  * do not need the validator live on the companion object.
+  */
+private[validation] class ExternalCallResponseRouter(
+    externalCallValidator: ExternalCallValidator,
+    externalCallValidationParallelism: PositiveInt,
+    protected val loggerFactory: NamedLoggerFactory,
+) extends NamedLogging {
+
+  import ExternalCallResponseRouter.*
+  import com.digitalasset.canton.util.ShowUtil.*
+
+  def validationOccurrences(
+      viewsWithHostedParties: Seq[ViewWithHostedParties],
+      approvingViewPositions: Map[ViewPosition, Set[LfPartyId]],
+      externalCallRouting: ExternalCallRoutingContext,
+  ): Seq[ExternalCallValidationOccurrence] =
+    viewsWithHostedParties
+      .sortBy(_.viewPosition)(ViewPosition.orderViewPosition.toOrdering)
+      .flatMap { viewWithHostedParties =>
+        approvingViewPositions.get(viewWithHostedParties.viewPosition).toList.flatMap {
+          approvingParties =>
+            val viewParticipantData =
+              viewWithHostedParties.validationResult.view.viewParticipantData
+            if (
+              !viewParticipantData.supportsExternalCallResults ||
+              viewParticipantData.externalCallResults.isEmpty
+            ) Seq.empty
+            else {
+              val alreadyRejectedParties =
+                externalCallRouting
+                  .inconsistenciesForView(viewWithHostedParties.viewPosition, approvingParties)
+                  .map(_._1)
+                  .toSet
+
+              viewParticipantData.externalCallResults.flatMap { result =>
+                val affectedParties =
+                  result.checkingParties.intersect(approvingParties) -- alreadyRejectedParties
+                Option.when(affectedParties.nonEmpty)(
+                  ExternalCallValidationOccurrence(
+                    viewWithHostedParties.viewPosition,
+                    result,
+                    affectedParties,
+                  )
+                )
+              }
+            }
+        }
+      }
+
+  def validateExternalCalls(
+      occurrences: Seq[ExternalCallValidationOccurrence]
+  )(implicit
+      traceContext: TraceContext,
+      ec: ExecutionContext,
+  ): FutureUnlessShutdown[ExternalCallValidationRoutes] = {
+    val keyedOccurrences =
+      occurrences.map(occurrence =>
+        KeyedValidationOccurrence(
+          DAMLe.ExternalCallKey.fromResult(occurrence.result.result),
+          occurrence,
+        )
+      )
+
+    val outputByKey =
+      keyedOccurrences
+        .groupMap(_.key)(_.output)
+        .view
+        .mapValues(_.toSet)
+        .toMap
+
+    val keysWithSingleOutput =
+      outputByKey.toSeq
+        .flatMap { case (key, outputs) =>
+          outputs.toList match {
+            case recordedOutput :: Nil => Some(key -> recordedOutput)
+            case _ => None
+          }
+        }
+        .sortBy { case (key, _) => key }
+
+    MonadUtil
+      .parTraverseWithLimit(externalCallValidationParallelism)(keysWithSingleOutput) {
+        case (key, recordedOutput) =>
+          externalCallValidator.validate(key, recordedOutput).map(key -> _)
+      }
+      .map { validationResults =>
+        val resultsByKey = validationResults.toMap
+        ExternalCallValidationRoutes(
+          rejects = rejectsFrom(keyedOccurrences, resultsByKey),
+          abstains = abstainsFrom(keyedOccurrences, resultsByKey),
+        )
+      }
+  }
+
+  def reportVisibleRecordedDisagreementAlarms(
+      requestId: RequestId,
+      recordedConsistencyResult: ExternalCallConsistencyChecker.Result,
+  )(implicit traceContext: TraceContext): Unit =
+    recordedConsistencyResult.visibleInconsistencies.foreach { inconsistency =>
+      val details = inconsistency.description.limit(maxExternalCallDisagreementDetailsLength)
+      ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        .Warn(s"Observed inconsistent external call results: $details")
+        .logWithContext(Map("requestId" -> requestId.toString))
+    }
+}
+
+private[validation] object ExternalCallResponseRouter {
+
+  val maxExternalCallDisagreementDetailsLength = 1024
+
+  private val orderRecordedResultDisagreement
+      : Ordering[DAMLe.ExternalCallRecordedResultDisagreement] =
+    Ordering
+      .by[DAMLe.ExternalCallRecordedResultDisagreement, DAMLe.ExternalCallKey](_.key)
+      .orElseBy(_.outputs)(ExternalCallConsistencyChecker.orderOutputSets)
+
+  private val orderExternalCallValidationAbstain: Ordering[ExternalCallValidationAbstain] =
+    Ordering
+      .by[ExternalCallValidationAbstain, ViewPosition](_.viewPosition)(
+        ViewPosition.orderViewPosition.toOrdering
+      )
+      .orElseBy(_.reason)
+
+  def externalCallRecordedResultDisagreement(
+      error: ModelConformanceChecker.Error
+  ): Option[DAMLe.ExternalCallRecordedResultDisagreement] = error match {
+    case ModelConformanceChecker.DAMLeError(
+          disagreement: DAMLe.ExternalCallRecordedResultDisagreement,
+          _,
+        ) =>
+      Some(disagreement)
+    case _ => None
+  }
+
+  def recordedExternalCallDisagreementInconsistencies(
+      disagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement],
+      viewsWithHostedParties: Seq[ViewWithHostedParties],
+  ): Map[LfPartyId, Seq[(DAMLe.ExternalCallRecordedResultDisagreement, Inconsistency)]] = {
+    val orderedDisagreements =
+      disagreements.distinct.sorted(orderRecordedResultDisagreement)
+
+    if (orderedDisagreements.isEmpty) Map.empty
+    else {
+      val orderedViews =
+        viewsWithHostedParties.sortBy(_.viewPosition)(ViewPosition.orderViewPosition.toOrdering)
+
+      val routed =
+        orderedDisagreements.flatMap { disagreement =>
+          occurrencesByParty(disagreement, orderedViews).toSeq.map { case (party, occurrences) =>
+            party -> (disagreement -> Inconsistency(
+              disagreement.key,
+              disagreement.outputs,
+              occurrences,
+            ))
+          }
+        }
+
+      routed.groupMap(_._1)(_._2)
+    }
+  }
+
+  /** For a single recorded disagreement, the occurrences of its external call that each hosted
+    * confirming party can see across all views. A party sees an occurrence when it is a checking
+    * party of a matching external-call result in a view it confirms.
+    */
+  private def occurrencesByParty(
+      disagreement: DAMLe.ExternalCallRecordedResultDisagreement,
+      orderedViews: Seq[ViewWithHostedParties],
+  ): Map[LfPartyId, Set[ExternalCallOccurrence]] =
+    orderedViews
+      .flatMap { view =>
+        val viewParticipantData = view.validationResult.view.viewParticipantData
+        if (!viewParticipantData.supportsExternalCallResults) Seq.empty
+        else
+          viewParticipantData.externalCallResults
+            .filter(result => matchesDisagreement(disagreement, result))
+            .flatMap { result =>
+              val occurrence = ExternalCallOccurrence(
+                view.viewPosition,
+                result.exerciseIndex,
+                result.callIndex,
+              )
+              result.checkingParties
+                .intersect(view.hostedConfirmingParties)
+                .toSeq
+                .map(_ -> occurrence)
+            }
+      }
+      .groupMap(_._1)(_._2)
+      .view
+      .mapValues(_.toSet)
+      .toMap
+
+  /** Whether `result` records the same external call (and one of the disagreeing outputs) as
+    * `disagreement`.
+    */
+  private def matchesDisagreement(
+      disagreement: DAMLe.ExternalCallRecordedResultDisagreement,
+      result: ViewParticipantData.ViewExternalCallResult,
+  ): Boolean =
+    DAMLe.ExternalCallKey.fromResult(result.result) == disagreement.key &&
+      disagreement.outputs(result.result.output)
+
+  /** An external-call occurrence paired with the key it re-validates under. */
+  private final case class KeyedValidationOccurrence(
+      key: DAMLe.ExternalCallKey,
+      occurrence: ExternalCallValidationOccurrence,
+  ) {
+    def output: Bytes = occurrence.result.result.output
+    def hostedCheckingParties: Set[LfPartyId] = occurrence.hostedCheckingParties
+    def externalCallOccurrence: ExternalCallOccurrence = ExternalCallOccurrence(
+      occurrence.viewPosition,
+      occurrence.result.exerciseIndex,
+      occurrence.result.callIndex,
+    )
+  }
+
+  private final case class RejectRow(
+      party: LfPartyId,
+      key: DAMLe.ExternalCallKey,
+      outputs: Set[Bytes],
+      occurrence: ExternalCallOccurrence,
+  )
+
+  private final case class AbstainRow(
+      party: LfPartyId,
+      abstain: ExternalCallValidationAbstain,
+  )
+
+  /** Per-party rejections for occurrences whose re-validation produced a mismatching output. */
+  private def rejectsFrom(
+      keyedOccurrences: Seq[KeyedValidationOccurrence],
+      resultsByKey: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result],
+  ): Map[LfPartyId, Seq[Inconsistency]] = {
+    val rejectRows = keyedOccurrences.flatMap { keyedOccurrence =>
+      resultsByKey.get(keyedOccurrence.key).toList.flatMap {
+        case ExternalCallValidator.Mismatched(computedOutput, recordedOutput) =>
+          val outputs = Set(computedOutput, recordedOutput)
+          keyedOccurrence.hostedCheckingParties.toSeq.sorted.map(party =>
+            RejectRow(
+              party,
+              keyedOccurrence.key,
+              outputs,
+              keyedOccurrence.externalCallOccurrence,
+            )
+          )
+
+        case _ =>
+          Seq.empty
+      }
+    }
+
+    rejectRows
+      .groupMap(row => (row.party, row.key, row.outputs))(_.occurrence)
+      .toSeq
+      .groupMap { case ((party, _, _), _) => party } { case ((_, key, outputs), occurrences) =>
+        Inconsistency(key, outputs, occurrences.toSet)
+      }
+      .view
+      .mapValues(_.sorted(ExternalCallConsistencyChecker.orderInconsistency))
+      .toMap
+  }
+
+  /** Per-party abstentions for occurrences whose re-validation could not be performed. */
+  private def abstainsFrom(
+      keyedOccurrences: Seq[KeyedValidationOccurrence],
+      resultsByKey: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result],
+  ): Map[LfPartyId, Seq[ExternalCallValidationAbstain]] = {
+    val abstainRows = keyedOccurrences.flatMap { keyedOccurrence =>
+      resultsByKey.get(keyedOccurrence.key).toList.flatMap {
+        case ExternalCallValidator.UnableToValidate(reason) =>
+          val abstain = ExternalCallValidationAbstain(
+            keyedOccurrence.occurrence.viewPosition,
+            reason,
+          )
+          keyedOccurrence.hostedCheckingParties.toSeq.sorted
+            .map(party => AbstainRow(party, abstain))
+
+        case _ =>
+          Seq.empty
+      }
+    }
+
+    abstainRows.distinct
+      .groupMap(_.party)(_.abstain)
+      .view
+      .mapValues(_.sorted(orderExternalCallValidationAbstain))
+      .toMap
+  }
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -137,9 +137,12 @@ private[validation] final class ExternalCallRoutingContext(
     } else ExternalCallConsistencyChecker.Result.empty
 
   /** Whether `error` is an external-call replay disagreement for which some hosted confirming party
-    * checks a matching occurrence. Such errors are expected to supersede the generic
-    * model-conformance rejection of the view: the affected parties reject with the disagreement
-    * inconsistency provided by [[inconsistenciesForView]] instead.
+    * checks a matching occurrence. Such an error is expected to suppress the generic (malformed)
+    * model-conformance rejection of the request; in its place, the hosted confirming parties that
+    * check a matching occurrence reject per view with the disagreement inconsistency provided by
+    * [[inconsistenciesForView]]. Note that the routed rejections cover fewer parties than the
+    * suppressed blanket rejection: views without a matching occurrence and confirming parties that
+    * do not check the result are not rejected through this path.
     */
   def isRoutableModelConformanceError(error: ModelConformanceChecker.Error): Boolean =
     ExternalCallResponseRouter
@@ -190,7 +193,8 @@ private[validation] final class ExternalCallRoutingContext(
   *   - disagreements between the results recorded across the views of the transaction, computed by
   *     [[ExternalCallConsistencyChecker]] (see
   *     [[ExternalCallRoutingContext.recordedConsistencyResult]]),
-  *   - disagreements within the replay data of a single view, surfaced by reinterpretation as
+  *   - disagreements within the replay data of a single reinterpretation, that is, of a view
+  *     together with its subviews, surfaced as
   *     [[com.digitalasset.canton.participant.util.DAMLe.ExternalCallRecordedResultDisagreement]]
   *     model-conformance errors (see [[ExternalCallRoutingContext.inconsistenciesForView]]),
   *   - re-validation of undisputed recorded results against the extension service (see

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -171,10 +171,7 @@ private[validation] class ExternalCallResponseRouter(
           approvingParties =>
             val viewParticipantData =
               viewWithHostedParties.validationResult.view.viewParticipantData
-            if (
-              !viewParticipantData.supportsExternalCallResults ||
-              viewParticipantData.externalCallResults.isEmpty
-            ) Seq.empty
+            if (viewParticipantData.externalCallResults.isEmpty) Seq.empty
             else {
               val alreadyRejectedParties =
                 externalCallRouting

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -97,14 +97,14 @@ private[validation] final class ExternalCallRoutingContext(
       viewParticipantData.externalCallResults.nonEmpty
     }
 
-  private lazy val recordedReplayDisagreementInconsistencies =
+  private lazy val recordedExternalCallDisagreementInconsistencies =
     ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
       recordedResultDisagreements,
       viewsWithHostedParties,
     )
 
   private lazy val routableRecordedExternalCallDisagreements =
-    recordedReplayDisagreementInconsistencies.valuesIterator
+    recordedExternalCallDisagreementInconsistencies.valuesIterator
       .flatMap(_.iterator)
       .map(_._1)
       .toSet
@@ -141,7 +141,7 @@ private[validation] final class ExternalCallRoutingContext(
       recordedResultInconsistencies.map(_._1).toSet
 
     val recordedReplayInconsistencies =
-      recordedReplayDisagreementInconsistencies.toSeq.flatMap {
+      recordedExternalCallDisagreementInconsistencies.toSeq.flatMap {
         case (party, disagreementInconsistencies)
             if hostedConfirmingParties(party) &&
               !partiesWithRecordedResultInconsistencies(party) =>

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -23,71 +23,6 @@ import com.digitalasset.daml.lf.data.Bytes
 
 import scala.concurrent.ExecutionContext
 
-/** An abstention from confirming a view because a recorded external-call result could not be
-  * re-validated.
-  */
-final case class ExternalCallValidationAbstain(
-    viewPosition: ViewPosition,
-    reason: String,
-)
-
-/** Per-party outcome of re-validating recorded external-call results: `rejects` holds the
-  * re-validation mismatches (as inconsistencies carrying the recorded and the computed output),
-  * `abstains` holds the per-view abstentions where a result could not be re-validated.
-  */
-final case class ExternalCallValidationRoutes(
-    rejects: Map[LfPartyId, Seq[Inconsistency]],
-    abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
-) {
-
-  /** Yields for every party in `nonRejectingConfirmingParties` an inconsistency in `rejects(party)`
-    * that has the given `viewPosition` (provided it exists). Picks the smallest inconsistency per
-    * party by [[ExternalCallConsistencyChecker.orderInconsistency]] so that the result is
-    * deterministic.
-    *
-    * @param nonRejectingConfirmingParties
-    *   The hosted confirming parties that are not already rejecting for this view (rejections for
-    *   disagreements take precedence over re-validation outcomes, and at most one external-call
-    *   rejection is routed per party and view).
-    */
-  def rejectsForView(
-      viewPosition: ViewPosition,
-      nonRejectingConfirmingParties: Set[LfPartyId],
-  ): Seq[(LfPartyId, Inconsistency)] =
-    rejects.toSeq.sortBy { case (party, _) => party }.flatMap {
-      case (party, inconsistencies) if nonRejectingConfirmingParties(party) =>
-        inconsistencies
-          .filter(_.occurrences.exists(_.viewPosition == viewPosition))
-          .minByOption(identity)(ExternalCallConsistencyChecker.orderInconsistency)
-          .map(party -> _)
-      case _ => None
-    }
-
-  /** Yields for every party in `nonRejectingConfirmingParties` the abstain reason in
-    * `abstains(party)` recorded for the given `viewPosition` (provided it exists). Picks the
-    * smallest reason per party so that the result is deterministic.
-    *
-    * @param nonRejectingConfirmingParties
-    *   The hosted confirming parties that are not already rejecting for this view.
-    */
-  def abstainsForView(
-      viewPosition: ViewPosition,
-      nonRejectingConfirmingParties: Set[LfPartyId],
-  ): Seq[(LfPartyId, String)] =
-    abstains.toSeq.sortBy { case (party, _) => party }.flatMap {
-      case (party, abstains) if nonRejectingConfirmingParties(party) =>
-        abstains
-          .filter(_.viewPosition == viewPosition)
-          .minByOption(_.reason)
-          .map(abstain => party -> abstain.reason)
-      case _ => None
-    }
-}
-
-object ExternalCallValidationRoutes {
-  val empty: ExternalCallValidationRoutes = ExternalCallValidationRoutes(Map.empty, Map.empty)
-}
-
 /** Checks and re-validates the external-call results of a transaction request, as one of the
   * parallel validation suites invoked from `TransactionProcessingSteps.doParallelChecks`.
   *
@@ -368,6 +303,71 @@ object ExternalCallResponseRouter {
       hostedCheckingParties: Set[LfPartyId],
   )
 
+  /** An abstention from confirming a view because a recorded external-call result could not be
+    * re-validated.
+    */
+  final case class ExternalCallValidationAbstain(
+      viewPosition: ViewPosition,
+      reason: String,
+  )
+
+  /** Per-party outcome of re-validating recorded external-call results: `rejects` holds the
+    * re-validation mismatches (as inconsistencies carrying the recorded and the computed output),
+    * `abstains` holds the per-view abstentions where a result could not be re-validated.
+    */
+  final case class ExternalCallValidationRoutes(
+      rejects: Map[LfPartyId, Seq[Inconsistency]],
+      abstains: Map[LfPartyId, Seq[ExternalCallValidationAbstain]],
+  ) {
+
+    /** Yields for every party in `nonRejectingConfirmingParties` an inconsistency in
+      * `rejects(party)` that has the given `viewPosition` (provided it exists). Picks the smallest
+      * inconsistency per party by `ExternalCallConsistencyChecker.orderInconsistency` so that the
+      * result is deterministic.
+      *
+      * @param nonRejectingConfirmingParties
+      *   The hosted confirming parties that are not already rejecting for this view (rejections for
+      *   disagreements take precedence over re-validation outcomes, and at most one external-call
+      *   rejection is routed per party and view).
+      */
+    def rejectsForView(
+        viewPosition: ViewPosition,
+        nonRejectingConfirmingParties: Set[LfPartyId],
+    ): Seq[(LfPartyId, Inconsistency)] =
+      rejects.toSeq.sortBy { case (party, _) => party }.flatMap {
+        case (party, inconsistencies) if nonRejectingConfirmingParties(party) =>
+          inconsistencies
+            .filter(_.occurrences.exists(_.viewPosition == viewPosition))
+            .minByOption(identity)(ExternalCallConsistencyChecker.orderInconsistency)
+            .map(party -> _)
+        case _ => None
+      }
+
+    /** Yields for every party in `nonRejectingConfirmingParties` the abstain reason in
+      * `abstains(party)` recorded for the given `viewPosition` (provided it exists). Picks the
+      * smallest reason per party so that the result is deterministic.
+      *
+      * @param nonRejectingConfirmingParties
+      *   The hosted confirming parties that are not already rejecting for this view.
+      */
+    def abstainsForView(
+        viewPosition: ViewPosition,
+        nonRejectingConfirmingParties: Set[LfPartyId],
+    ): Seq[(LfPartyId, String)] =
+      abstains.toSeq.sortBy { case (party, _) => party }.flatMap {
+        case (party, abstains) if nonRejectingConfirmingParties(party) =>
+          abstains
+            .filter(_.viewPosition == viewPosition)
+            .minByOption(_.reason)
+            .map(abstain => party -> abstain.reason)
+        case _ => None
+      }
+  }
+
+  object ExternalCallValidationRoutes {
+    val empty: ExternalCallValidationRoutes = ExternalCallValidationRoutes(Map.empty, Map.empty)
+  }
+
   /** Precomputed external-call validation outcome of a request, produced by `check` and consumed by
     * `TransactionConfirmationResponsesFactory` as pure data.
     *
@@ -507,17 +507,17 @@ object ExternalCallResponseRouter {
       orderedViews: Seq[ViewWithHostedParties],
   ): Map[LfPartyId, Set[ExternalCallOccurrence]] =
     orderedViews
-      .flatMap { view =>
-        view.view.viewParticipantData.externalCallResults
+      .flatMap { viewWithHostedParties =>
+        viewWithHostedParties.view.viewParticipantData.externalCallResults
           .filter(result => matchesDisagreement(disagreement, result))
           .flatMap { result =>
             val occurrence = ExternalCallOccurrence(
-              view.viewPosition,
+              viewWithHostedParties.viewPosition,
               result.exerciseIndex,
               result.callIndex,
             )
             result.checkingParties
-              .intersect(view.hostedConfirmingParties)
+              .intersect(viewWithHostedParties.hostedConfirmingParties)
               .toSeq
               .map(_ -> occurrence)
           }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouter.scala
@@ -111,13 +111,15 @@ private[validation] final class ExternalCallRoutingContext(
       viewParticipantData.externalCallResults.nonEmpty
     }
 
-  private lazy val recordedExternalCallDisagreementInconsistencies =
+  private lazy val recordedExternalCallDisagreementInconsistencies
+      : Map[LfPartyId, Seq[(DAMLe.ExternalCallRecordedResultDisagreement, Inconsistency)]] =
     ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
       recordedResultDisagreements,
       viewsWithHostedParties,
     )
 
-  private lazy val routableRecordedExternalCallDisagreements =
+  private lazy val routableRecordedExternalCallDisagreements
+      : Set[DAMLe.ExternalCallRecordedResultDisagreement] =
     recordedExternalCallDisagreementInconsistencies.valuesIterator
       .flatMap(_.iterator)
       .map(_._1)

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -134,9 +134,10 @@ class TransactionConfirmationResponsesFactory(
     /** Converts the local verdict of a view into confirmation responses, splitting it by party
       * where precomputed external-call outcomes ([[ExternalCallResponseRouter.Result]]) apply:
       * hosted confirming parties that check a disagreeing external-call result reject the view with
-      * the disagreement, parties whose checked results could not be re-validated abstain, and the
-      * remaining parties respond with the view's own verdict. For a request without external calls,
-      * `externalCallResult` is empty and the view's verdict is returned unsplit.
+      * the disagreement, parties whose checked results could not be re-validated abstain (on views
+      * that would otherwise be approved), and the remaining parties respond with the view's own
+      * verdict. For a request without external calls, `externalCallResult` is empty and the view's
+      * verdict is returned unsplit.
       */
     def responsesForVerdict(
         viewPosition: ViewPosition,
@@ -256,8 +257,11 @@ class TransactionConfirmationResponsesFactory(
               // An external-call replay disagreement that is routed to a hosted checking party is
               // not turned into (nor logged as) a malformed model-conformance rejection of the
               // whole view: the routed parties instead reject the affected views with a dedicated,
-              // equally logged ExternalCallResultDisagreement rejection (see responsesForVerdict),
-              // so every model-conformance error still surfaces in exactly one logged rejection.
+              // equally logged ExternalCallResultDisagreement rejection (see responsesForVerdict).
+              // A routed error is never silent: its visible-disagreement alarm has fired in the
+              // external-call check, and each affected view logs its rejection when emitting it --
+              // unless the view is rejected as malformed for another reason, in which case that
+              // stronger rejection wins the view (the alarm remains on record).
               Option.unless(externalCallResult.isRoutableModelConformanceError(cause))(
                 logged(
                   requestId,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -131,14 +131,13 @@ class TransactionConfirmationResponsesFactory(
       }
     }
 
-    /** Converts the local verdict of a view into confirmation responses, splitting it by party
-      * where precomputed external-call outcomes ([[ExternalCallResponseRouter.Result]]) apply:
-      * hosted confirming parties that check a disagreeing external-call result reject the view with
-      * the disagreement, parties whose checked results could not be re-validated abstain (on views
-      * that would otherwise be approved), and the remaining parties respond with the view's own
-      * verdict. For a request without external calls, `externalCallResult` is empty and the view's
-      * verdict is returned unsplit.
-      */
+    // Converts the local verdict of a view into confirmation responses, splitting it by party
+    // where precomputed external-call outcomes (ExternalCallResponseRouter.Result) apply:
+    // hosted confirming parties that check a disagreeing external-call result reject the view
+    // with the disagreement, parties whose checked results could not be re-validated abstain (on
+    // views that would otherwise be approved), and the remaining parties respond with the view's
+    // own verdict. For a request without external calls, `externalCallResult` is empty and the
+    // view's verdict is returned unsplit.
     def responsesForVerdict(
         viewPosition: ViewPosition,
         hostedConfirmingParties: Set[LfPartyId],
@@ -214,9 +213,10 @@ class TransactionConfirmationResponsesFactory(
                 checked(
                   ConfirmationResponse.tryCreate(
                     Some(viewPosition),
-                    LocalAbstainError.CannotPerformAllValidations
-                      .Abstain(reason)
-                      .toLocalAbstain(protocolVersion),
+                    logged(
+                      requestId,
+                      LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
+                    ).toLocalAbstain(protocolVersion),
                     parties.toSet,
                   )
                 )

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.canton.participant.protocol.validation
 
 import cats.syntax.parallel.*
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.data.{CantonTimestamp, ViewPosition}
 import com.digitalasset.canton.error.TransactionError
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
@@ -24,242 +23,12 @@ import scala.concurrent.ExecutionContext
 class TransactionConfirmationResponsesFactory(
     participantId: ParticipantId,
     synchronizerId: PhysicalSynchronizerId,
-    externalCallValidator: ExternalCallValidator,
-    externalCallValidationParallelism: PositiveInt,
     protected val loggerFactory: NamedLoggerFactory,
 ) extends NamedLogging {
 
   import com.digitalasset.canton.util.ShowUtil.*
 
   private val protocolVersion = synchronizerId.protocolVersion
-  private val externalCallRouter =
-    new ExternalCallResponseRouter(
-      externalCallValidator,
-      externalCallValidationParallelism,
-      loggerFactory,
-    )
-
-  private def responseForView(
-      viewPosition: ViewPosition,
-      localVerdict: LocalVerdict,
-      parties: Set[LfPartyId],
-  ): ConfirmationResponse =
-    checked(
-      ConfirmationResponse
-        .tryCreate(
-          Some(viewPosition),
-          localVerdict,
-          parties,
-        )
-    )
-
-  private def responsesForView(
-      requestId: RequestId,
-      viewWithHostedParties: ViewWithHostedParties,
-      localVerdictAndPartiesO: Option[(LocalVerdict, Set[LfPartyId])],
-      externalCallRouting: ExternalCallRoutingContext,
-      localValidationRoutes: ExternalCallValidationRoutes,
-  )(implicit traceContext: TraceContext): Seq[ConfirmationResponse] = {
-    val viewPosition = viewWithHostedParties.viewPosition
-    val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
-
-    localVerdictAndPartiesO match {
-      case Some((malformed: LocalReject, _)) if malformed.isMalformed =>
-        Seq(responseForView(viewPosition, malformed, Set.empty))
-      case None => Seq.empty
-      case Some((localVerdict, parties)) =>
-        val recordedExternalCallInconsistencies =
-          externalCallRouting.inconsistenciesForView(viewPosition, hostedConfirmingParties)
-
-        val localValidationInconsistencies =
-          localVerdict match {
-            case _: LocalApprove =>
-              localValidationRoutes.rejectsForView(viewPosition, hostedConfirmingParties)
-            case _ =>
-              Seq.empty
-          }
-
-        val externalCallInconsistencies =
-          recordedExternalCallInconsistencies ++ localValidationInconsistencies
-
-        val rejectedParties = externalCallInconsistencies.map(_._1).toSet
-
-        val externalCallAbstains =
-          localVerdict match {
-            case _: LocalApprove =>
-              localValidationRoutes.abstainsForView(
-                viewPosition,
-                hostedConfirmingParties -- rejectedParties,
-              )
-            case _ =>
-              Seq.empty
-          }
-
-        val externalCallResponses =
-          externalCallInconsistencies
-            .groupMap(_._2)(_._1)
-            .toSeq
-            .sortBy(_._1)(ExternalCallConsistencyChecker.orderInconsistency)
-            .map { case (inconsistency, parties) =>
-              val reject = logged(
-                requestId,
-                LocalRejectError.ConsistencyRejections.ExternalCallResultDisagreement
-                  .Reject(inconsistency.description),
-              ).toLocalReject(protocolVersion)
-              responseForView(
-                viewPosition,
-                reject,
-                parties.toSet,
-              )
-            }
-
-        val externalCallAbstainResponses =
-          externalCallAbstains
-            .groupMap(_._2)(_._1)
-            .toSeq
-            .sortBy { case (reason, _) => reason }
-            .map { case (reason, parties) =>
-              responseForView(
-                viewPosition,
-                LocalAbstainError.CannotPerformAllValidations
-                  .Abstain(reason)
-                  .toLocalAbstain(protocolVersion),
-                parties.toSet,
-              )
-            }
-
-        val abstainedParties = externalCallAbstains.map(_._1).toSet
-        val remainingParties = parties -- rejectedParties -- abstainedParties
-
-        externalCallResponses ++
-          externalCallAbstainResponses ++
-          Option
-            .when(remainingParties.nonEmpty)(
-              responseForView(viewPosition, localVerdict, remainingParties)
-            )
-            .toList
-    }
-  }
-
-  private def ordinaryLocalVerdictAndParties(
-      requestId: RequestId,
-      transactionValidationResult: TransactionValidationResult,
-      internalConsistencyResultE: Either[
-        InternalConsistencyChecker.ErrorWithInternalConsistencyCheck,
-        Unit,
-      ],
-      modelConformanceRejections: Seq[LocalVerdict],
-      viewWithHostedParties: ViewWithHostedParties,
-      consistencyVerdict: Option[LocalVerdict],
-  )(implicit
-      traceContext: TraceContext
-  ): Option[(LocalVerdict, Set[LfPartyId])] = {
-    val viewPosition = viewWithHostedParties.viewPosition
-    val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
-
-    // Rejections due to a failed internal consistency check
-    val internalConsistencyRejections =
-      internalConsistencyResultE.swap.toOption.map(cause =>
-        logged(
-          requestId,
-          LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
-        ).toLocalReject(protocolVersion)
-      )
-
-    // Rejections due to a failed authentication check
-    val authenticationRejections =
-      transactionValidationResult.authenticationResult
-        .get(viewPosition)
-        .map(err =>
-          logged(
-            requestId,
-            LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.message),
-          ).toLocalReject(protocolVersion)
-        )
-
-    // Rejections due to a transaction detected as a replay
-    val replayRejections =
-      transactionValidationResult.replayCheckResult
-        .map(err =>
-          logged(
-            requestId,
-            // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
-            // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
-            // ensures that this rejection or something at least as strong will make it to the mediator.
-            LocalRejectError.MalformedRejects.MalformedRequest.Reject(
-              err.format(viewPosition)
-            ),
-          ).toLocalReject(protocolVersion)
-        )
-
-    // Rejections due to a failed authorization check
-    val authorizationRejections =
-      transactionValidationResult.authorizationResult
-        .get(viewPosition)
-        .map(cause =>
-          logged(
-            requestId,
-            LocalRejectError.MalformedRejects.MalformedRequest.Reject(cause),
-          ).toLocalReject(protocolVersion)
-        )
-
-    // Rejections due to a failed time validation
-    val timeValidationRejections =
-      transactionValidationResult.timeValidationResultE.swap.toOption
-        .map {
-          case TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(
-                ledgerTime,
-                recordTime,
-                maxDelta,
-              ) =>
-            LocalRejectError.TimeRejects.LedgerTime.Reject(
-              s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
-            )
-          case TimeValidator.PreparationTimeRecordTimeDeltaTooLargeError(
-                preparationTime,
-                recordTime,
-                maxDelta,
-              ) =>
-            LocalRejectError.TimeRejects.PreparationTime.Reject(
-              s"preparationTime=$preparationTime, recordTime=$recordTime, maxDelta=$maxDelta"
-            )
-          case TimeValidator.ExternallySignedRecordTimeExceedsMaximum(
-                recordTime: CantonTimestamp,
-                maxRecordTime: CantonTimestamp,
-              ) =>
-            LocalRejectError.TimeRejects.MaxRecordTimeExceeded.Reject(
-              s"recordTime=$recordTime, maxRecordTime=$maxRecordTime"
-            )
-        }
-        .map(logged(requestId, _))
-        .map(_.toLocalReject(protocolVersion))
-
-    val contractConsistencyRejections =
-      transactionValidationResult.contractConsistencyResultE.swap.toOption.map(err =>
-        logged(
-          requestId,
-          LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.toString),
-        ).toLocalReject(protocolVersion)
-      )
-
-    val localVerdicts: Seq[LocalVerdict] =
-      consistencyVerdict.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
-        authenticationRejections ++ authorizationRejections ++
-        modelConformanceRejections ++ internalConsistencyRejections ++
-        replayRejections
-
-    localVerdicts
-      .collectFirst[(LocalVerdict, Set[LfPartyId])] {
-        case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
-        case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
-          localReject -> hostedConfirmingParties
-      }
-      .orElse(
-        Option.when(hostedConfirmingParties.nonEmpty)(
-          LocalApprove(protocolVersion) -> hostedConfirmingParties
-        )
-      )
-  }
 
   /** Takes a `transactionValidationResult` and computes the
     * [[protocol.messages.ConfirmationResponses]], to be sent to the mediator.
@@ -362,100 +131,265 @@ class TransactionConfirmationResponsesFactory(
       }
     }
 
+    /** Converts the local verdict of a view into confirmation responses, splitting it by party
+      * where precomputed external-call outcomes ([[ExternalCallResponseRouter.Result]]) apply:
+      * hosted confirming parties that check a disagreeing external-call result reject the view with
+      * the disagreement, parties whose checked results could not be re-validated abstain, and the
+      * remaining parties respond with the view's own verdict. For a request without external calls,
+      * `externalCallResult` is empty and the view's verdict is returned unsplit.
+      */
+    def responsesForVerdict(
+        viewPosition: ViewPosition,
+        hostedConfirmingParties: Set[LfPartyId],
+        localVerdictAndPartiesO: Option[(LocalVerdict, Set[LfPartyId])],
+        externalCallResult: ExternalCallResponseRouter.Result,
+    ): Seq[ConfirmationResponse] =
+      localVerdictAndPartiesO match {
+        case None => Seq.empty
+
+        case Some((malformed: LocalReject, parties)) if malformed.isMalformed =>
+          // A malformed rejection covers the whole view, so no external-call verdicts are routed
+          // for it. `parties` is empty by construction of localVerdictAndPartiesO, meeting the
+          // ConfirmationResponse invariant for malformed verdicts, so tryCreate cannot throw.
+          Seq(checked(ConfirmationResponse.tryCreate(Some(viewPosition), malformed, parties)))
+
+        case Some((localVerdict, parties)) =>
+          // Parties that reject because they check disagreeing external-call results (recorded
+          // across views, or within the replay data of a reinterpretation).
+          val disagreementRejects =
+            externalCallResult.inconsistenciesForView(viewPosition, hostedConfirmingParties)
+
+          // Parties that reject because re-validating a recorded result produced a different
+          // output. Only relevant if the view would otherwise be approved. Disagreement
+          // rejections take precedence, so parties already rejecting above are excluded and at
+          // most one external-call rejection is emitted per party and view.
+          val validationRejects = localVerdict match {
+            case _: LocalApprove =>
+              externalCallResult.validationRoutes.rejectsForView(
+                viewPosition,
+                hostedConfirmingParties -- disagreementRejects.map(_._1).toSet,
+              )
+            case _ => Seq.empty
+          }
+
+          val externalCallRejects = disagreementRejects ++ validationRejects
+          val rejectedParties = externalCallRejects.map(_._1).toSet
+
+          // Parties that abstain because a recorded result they check could not be re-validated.
+          // Rejections take precedence, so rejecting parties are excluded.
+          val externalCallAbstains = localVerdict match {
+            case _: LocalApprove =>
+              externalCallResult.validationRoutes.abstainsForView(
+                viewPosition,
+                hostedConfirmingParties -- rejectedParties,
+              )
+            case _ => Seq.empty
+          }
+
+          val externalCallRejectResponses =
+            externalCallRejects
+              .groupMap(_._2)(_._1)
+              .toSeq
+              .sortBy(_._1)(ExternalCallConsistencyChecker.orderInconsistency)
+              .map { case (inconsistency, parties) =>
+                val reject = logged(
+                  requestId,
+                  LocalRejectError.ConsistencyRejections.ExternalCallResultDisagreement
+                    .Reject(inconsistency.description),
+                ).toLocalReject(protocolVersion)
+                // The parties of a groupMap group are nonEmpty, meeting the
+                // ConfirmationResponse invariant for non-malformed verdicts.
+                checked(ConfirmationResponse.tryCreate(Some(viewPosition), reject, parties.toSet))
+              }
+
+          val externalCallAbstainResponses =
+            externalCallAbstains
+              .groupMap(_._2)(_._1)
+              .toSeq
+              .sortBy { case (reason, _) => reason }
+              .map { case (reason, parties) =>
+                // The parties of a groupMap group are nonEmpty, meeting the
+                // ConfirmationResponse invariant for non-malformed verdicts.
+                checked(
+                  ConfirmationResponse.tryCreate(
+                    Some(viewPosition),
+                    LocalAbstainError.CannotPerformAllValidations
+                      .Abstain(reason)
+                      .toLocalAbstain(protocolVersion),
+                    parties.toSet,
+                  )
+                )
+              }
+
+          val abstainedParties = externalCallAbstains.map(_._1).toSet
+          val remainingParties = parties -- rejectedParties -- abstainedParties
+
+          externalCallRejectResponses ++
+            externalCallAbstainResponses ++
+            Option
+              .when(remainingParties.nonEmpty)(
+                // remainingParties is guarded nonEmpty, meeting the ConfirmationResponse
+                // invariant for non-malformed verdicts.
+                checked(
+                  ConfirmationResponse
+                    .tryCreate(Some(viewPosition), localVerdict, remainingParties)
+                )
+              )
+              .toList
+      }
+
     def responsesForWellFormedPayloads(
         transactionValidationResult: TransactionValidationResult
-    ): FutureUnlessShutdown[Option[ConfirmationResponses]] =
+    ): FutureUnlessShutdown[Option[ConfirmationResponses]] = {
       for {
         modelConformanceResultE <- transactionValidationResult.modelConformanceResultET.value
 
         internalConsistencyResultE <- transactionValidationResult.internalConsistencyResultET.value
 
-        modelConformanceErrors =
-          modelConformanceResultE.swap.toSeq.flatMap(_.nonAbortErrors)
-
-        externalCallRecordedResultDisagreements =
-          modelConformanceErrors.flatMap(
-            ExternalCallResponseRouter.externalCallRecordedResultDisagreement
-          )
-
-        viewsWithHostedParties <- transactionValidationResult.viewValidationResults.toSeq
-          .parTraverse { case (viewPosition, viewValidationResult) =>
-            for {
-              hostedConfirmingParties <-
-                hostedConfirmingPartiesOfView(viewValidationResult)
-            } yield ViewWithHostedParties(
-              viewPosition = viewPosition,
-              validationResult = viewValidationResult,
-              hostedConfirmingParties = hostedConfirmingParties,
-            )
-          }
-
-        externalCallRouting = new ExternalCallRoutingContext(
-          externalCallRecordedResultDisagreements,
-          viewsWithHostedParties,
-          transactionValidationResult.viewValidationResults,
-        )
-
-        _ = externalCallRouter.reportVisibleRecordedDisagreementAlarms(
-          requestId,
-          externalCallRouting.recordedConsistencyResult,
-        )
+        externalCallResult <- transactionValidationResult.externalCallValidationResultF
 
         // Rejections due to a failed model conformance check
         // Aborts are logged by the Engine callback when the abort happens
         modelConformanceRejections =
-          modelConformanceErrors.flatMap { case cause =>
-            Option.unless(externalCallRouting.isRoutableModelConformanceError(cause))(
-              logged(
-                requestId,
-                LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
-              ).toLocalReject(protocolVersion)
+          modelConformanceResultE.swap.toSeq.flatMap(error =>
+            error.nonAbortErrors.flatMap(cause =>
+              // An external-call replay disagreement that is routed to a hosted checking party is
+              // not turned into (nor logged as) a malformed model-conformance rejection of the
+              // whole view: the routed parties instead reject the affected views with a dedicated,
+              // equally logged ExternalCallResultDisagreement rejection (see responsesForVerdict),
+              // so every model-conformance error still surfaces in exactly one logged rejection.
+              Option.unless(externalCallResult.isRoutableModelConformanceError(cause))(
+                logged(
+                  requestId,
+                  LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
+                ).toLocalReject(protocolVersion)
+              )
             )
-          }
-
-        ordinaryViewResults = viewsWithHostedParties.map { viewWithHostedParties =>
-          val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
-          val consistencyVerdict =
-            verdictsForView(viewWithHostedParties.validationResult, hostedConfirmingParties)
-          val ordinaryVerdictAndPartiesO =
-            ordinaryLocalVerdictAndParties(
-              requestId,
-              transactionValidationResult,
-              internalConsistencyResultE,
-              modelConformanceRejections,
-              viewWithHostedParties,
-              consistencyVerdict,
-            )
-          viewWithHostedParties -> ordinaryVerdictAndPartiesO
-        }
-
-        approvingViewPositions =
-          ordinaryViewResults.collect {
-            case (viewWithHostedParties, Some((_: LocalApprove, parties))) if parties.nonEmpty =>
-              viewWithHostedParties.viewPosition -> parties
-          }.toMap
-
-        localValidationOccurrences =
-          externalCallRouter.validationOccurrences(
-            viewsWithHostedParties,
-            approvingViewPositions,
-            externalCallRouting,
           )
 
-        localValidationRoutes <- externalCallRouter.validateExternalCalls(
-          localValidationOccurrences
-        )
+        responses <- transactionValidationResult.viewValidationResults.toSeq
+          .parFlatTraverse { case (viewPosition, viewValidationResult) =>
+            for {
+              hostedConfirmingParties <-
+                hostedConfirmingPartiesOfView(viewValidationResult)
 
-        responses = ordinaryViewResults.flatMap {
-          case (viewWithHostedParties, localVerdictAndPartiesO) =>
-            responsesForView(
-              requestId,
-              viewWithHostedParties,
-              localVerdictAndPartiesO,
-              externalCallRouting,
-              localValidationRoutes,
-            )
-        }
+            } yield {
+
+              // Rejections due to a failed internal consistency check
+              val internalConsistencyRejections =
+                internalConsistencyResultE.swap.toOption.map(cause =>
+                  logged(
+                    requestId,
+                    LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
+                  ).toLocalReject(protocolVersion)
+                )
+
+              // Rejections due to a failed authentication check
+              val authenticationRejections =
+                transactionValidationResult.authenticationResult
+                  .get(viewPosition)
+                  .map(err =>
+                    logged(
+                      requestId,
+                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.message),
+                    ).toLocalReject(protocolVersion)
+                  )
+
+              // Rejections due to a transaction detected as a replay
+              val replayRejections =
+                transactionValidationResult.replayCheckResult
+                  .map(err =>
+                    logged(
+                      requestId,
+                      // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
+                      // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
+                      // ensures that this rejection or something at least as strong will make it to the mediator.
+                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(
+                        err.format(viewPosition)
+                      ),
+                    ).toLocalReject(protocolVersion)
+                  )
+
+              // Rejections due to a failed authorization check
+              val authorizationRejections =
+                transactionValidationResult.authorizationResult
+                  .get(viewPosition)
+                  .map(cause =>
+                    logged(
+                      requestId,
+                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(cause),
+                    ).toLocalReject(protocolVersion)
+                  )
+
+              // Rejections due to a failed time validation
+              val timeValidationRejections =
+                transactionValidationResult.timeValidationResultE.swap.toOption
+                  .map {
+                    case TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(
+                          ledgerTime,
+                          recordTime,
+                          maxDelta,
+                        ) =>
+                      LocalRejectError.TimeRejects.LedgerTime.Reject(
+                        s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
+                      )
+                    case TimeValidator.PreparationTimeRecordTimeDeltaTooLargeError(
+                          preparationTime,
+                          recordTime,
+                          maxDelta,
+                        ) =>
+                      LocalRejectError.TimeRejects.PreparationTime.Reject(
+                        s"preparationTime=$preparationTime, recordTime=$recordTime, maxDelta=$maxDelta"
+                      )
+                    case TimeValidator.ExternallySignedRecordTimeExceedsMaximum(
+                          recordTime: CantonTimestamp,
+                          maxRecordTime: CantonTimestamp,
+                        ) =>
+                      LocalRejectError.TimeRejects.MaxRecordTimeExceeded.Reject(
+                        s"recordTime=$recordTime, maxRecordTime=$maxRecordTime"
+                      )
+                  }
+                  .map(logged(requestId, _))
+                  .map(_.toLocalReject(protocolVersion))
+
+              val contractConsistencyRejections =
+                transactionValidationResult.contractConsistencyResultE.swap.toOption.map(err =>
+                  logged(
+                    requestId,
+                    LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.toString),
+                  ).toLocalReject(protocolVersion)
+                )
+
+              // Approve if the consistency check succeeded, reject otherwise.
+              val consistencyVerdicts =
+                verdictsForView(viewValidationResult, hostedConfirmingParties)
+
+              val localVerdicts: Seq[LocalVerdict] =
+                consistencyVerdicts.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
+                  authenticationRejections ++ authorizationRejections ++
+                  modelConformanceRejections ++ internalConsistencyRejections ++
+                  replayRejections
+
+              val localVerdictAndPartiesO = localVerdicts
+                .collectFirst[(LocalVerdict, Set[LfPartyId])] {
+                  case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
+                  case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
+                    localReject -> hostedConfirmingParties
+                }
+                .orElse(
+                  Option.when(hostedConfirmingParties.nonEmpty)(
+                    LocalApprove(protocolVersion) -> hostedConfirmingParties
+                  )
+                )
+
+              responsesForVerdict(
+                viewPosition,
+                hostedConfirmingParties,
+                localVerdictAndPartiesO,
+                externalCallResult,
+              )
+            }
+          }
       } yield {
         checked(
           NonEmpty
@@ -473,15 +407,9 @@ class TransactionConfirmationResponsesFactory(
             )
         )
       }
+    }
 
     if (malformedPayloads.nonEmpty) {
-      externalCallRouter.reportVisibleRecordedDisagreementAlarms(
-        requestId,
-        ExternalCallConsistencyChecker.check(
-          transactionValidationResult.viewValidationResults,
-          Set.empty,
-        ),
-      )
       FutureUnlessShutdown.pure(
         ProcessingSteps.constructResponsesForMalformedPayloads(
           requestId = requestId,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -451,10 +451,9 @@ class TransactionConfirmationResponsesFactory(
             externalCallRouting,
           )
 
-        localValidationRoutes <-
-          if (localValidationOccurrences.isEmpty)
-            FutureUnlessShutdown.pure(ExternalCallValidationRoutes(Map.empty, Map.empty))
-          else externalCallRouter.validateExternalCalls(localValidationOccurrences)
+        localValidationRoutes <- externalCallRouter.validateExternalCalls(
+          localValidationOccurrences
+        )
 
         responses = ordinaryViewResults.flatMap {
           case (viewWithHostedParties, localVerdictAndPartiesO) =>

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -4,7 +4,8 @@
 package com.digitalasset.canton.participant.protocol.validation
 
 import cats.syntax.parallel.*
-import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.{CantonTimestamp, ViewPosition}
 import com.digitalasset.canton.error.TransactionError
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
@@ -23,12 +24,251 @@ import scala.concurrent.ExecutionContext
 class TransactionConfirmationResponsesFactory(
     participantId: ParticipantId,
     synchronizerId: PhysicalSynchronizerId,
+    externalCallValidator: ExternalCallValidator,
+    externalCallValidationParallelism: PositiveInt,
     protected val loggerFactory: NamedLoggerFactory,
 ) extends NamedLogging {
 
   import com.digitalasset.canton.util.ShowUtil.*
 
   private val protocolVersion = synchronizerId.protocolVersion
+  private val externalCallRouter =
+    new ExternalCallResponseRouter(
+      externalCallValidator,
+      externalCallValidationParallelism,
+      loggerFactory,
+    )
+
+  private def responseForView(
+      viewPosition: ViewPosition,
+      localVerdict: LocalVerdict,
+      parties: Set[LfPartyId],
+  ): ConfirmationResponse =
+    checked(
+      ConfirmationResponse
+        .tryCreate(
+          Some(viewPosition),
+          localVerdict,
+          parties,
+        )
+    )
+
+  private def responsesForView(
+      requestId: RequestId,
+      viewWithHostedParties: ViewWithHostedParties,
+      localVerdictAndPartiesO: Option[(LocalVerdict, Set[LfPartyId])],
+      externalCallRouting: ExternalCallRoutingContext,
+      localValidationRoutes: ExternalCallValidationRoutes,
+  )(implicit traceContext: TraceContext): Seq[ConfirmationResponse] = {
+    val viewPosition = viewWithHostedParties.viewPosition
+    val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
+
+    localVerdictAndPartiesO match {
+      case Some((malformed: LocalReject, _)) if malformed.isMalformed =>
+        Seq(responseForView(viewPosition, malformed, Set.empty))
+      case None => Seq.empty
+      case Some((localVerdict, parties)) =>
+        val recordedExternalCallInconsistencies =
+          externalCallRouting.inconsistenciesForView(viewPosition, hostedConfirmingParties)
+
+        val localValidationInconsistencies =
+          localVerdict match {
+            case _: LocalApprove =>
+              localValidationRoutes.rejectsForView(viewPosition, hostedConfirmingParties)
+            case _ =>
+              Seq.empty
+          }
+
+        val externalCallInconsistencies =
+          recordedExternalCallInconsistencies ++ localValidationInconsistencies
+
+        val rejectedParties = externalCallInconsistencies.map(_._1).toSet
+
+        val externalCallAbstains =
+          localVerdict match {
+            case _: LocalApprove =>
+              localValidationRoutes.abstainsForView(
+                viewPosition,
+                hostedConfirmingParties,
+                rejectedParties,
+              )
+            case _ =>
+              Seq.empty
+          }
+
+        val externalCallResponses =
+          externalCallInconsistencies
+            .groupMap(_._2)(_._1)
+            .toSeq
+            .sortBy(_._1)(ExternalCallConsistencyChecker.orderInconsistency)
+            .map { case (inconsistency, parties) =>
+              val reject = logged(
+                requestId,
+                LocalRejectError.ConsistencyRejections.ExternalCallResultDisagreement
+                  .Reject(
+                    inconsistency.description
+                      .limit(ExternalCallResponseRouter.maxExternalCallDisagreementDetailsLength)
+                      .toString
+                  ),
+              ).toLocalReject(protocolVersion)
+              responseForView(
+                viewPosition,
+                reject,
+                parties.toSet,
+              )
+            }
+
+        val externalCallAbstainResponses =
+          externalCallAbstains
+            .groupMap(_._2)(_._1)
+            .toSeq
+            .sortBy { case (reason, _) => reason }
+            .map { case (reason, parties) =>
+              responseForView(
+                viewPosition,
+                LocalAbstainError.CannotPerformAllValidations
+                  .Abstain(
+                    reason
+                      .limit(ExternalCallResponseRouter.maxExternalCallDisagreementDetailsLength)
+                      .toString
+                  )
+                  .toLocalAbstain(protocolVersion),
+                parties.toSet,
+              )
+            }
+
+        val abstainedParties = externalCallAbstains.map(_._1).toSet
+        val remainingParties = parties -- rejectedParties -- abstainedParties
+
+        externalCallResponses ++
+          externalCallAbstainResponses ++
+          Option
+            .when(remainingParties.nonEmpty)(
+              responseForView(viewPosition, localVerdict, remainingParties)
+            )
+            .toList
+    }
+  }
+
+  private def ordinaryLocalVerdictAndParties(
+      requestId: RequestId,
+      transactionValidationResult: TransactionValidationResult,
+      internalConsistencyResultE: Either[
+        InternalConsistencyChecker.ErrorWithInternalConsistencyCheck,
+        Unit,
+      ],
+      modelConformanceRejections: Seq[LocalVerdict],
+      viewWithHostedParties: ViewWithHostedParties,
+      consistencyVerdict: Option[LocalVerdict],
+  )(implicit
+      traceContext: TraceContext
+  ): Option[(LocalVerdict, Set[LfPartyId])] = {
+    val viewPosition = viewWithHostedParties.viewPosition
+    val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
+
+    // Rejections due to a failed internal consistency check
+    val internalConsistencyRejections =
+      internalConsistencyResultE.swap.toOption.map(cause =>
+        logged(
+          requestId,
+          LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
+        ).toLocalReject(protocolVersion)
+      )
+
+    // Rejections due to a failed authentication check
+    val authenticationRejections =
+      transactionValidationResult.authenticationResult
+        .get(viewPosition)
+        .map(err =>
+          logged(
+            requestId,
+            LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.message),
+          ).toLocalReject(protocolVersion)
+        )
+
+    // Rejections due to a transaction detected as a replay
+    val replayRejections =
+      transactionValidationResult.replayCheckResult
+        .map(err =>
+          logged(
+            requestId,
+            // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
+            // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
+            // ensures that this rejection or something at least as strong will make it to the mediator.
+            LocalRejectError.MalformedRejects.MalformedRequest.Reject(
+              err.format(viewPosition)
+            ),
+          ).toLocalReject(protocolVersion)
+        )
+
+    // Rejections due to a failed authorization check
+    val authorizationRejections =
+      transactionValidationResult.authorizationResult
+        .get(viewPosition)
+        .map(cause =>
+          logged(
+            requestId,
+            LocalRejectError.MalformedRejects.MalformedRequest.Reject(cause),
+          ).toLocalReject(protocolVersion)
+        )
+
+    // Rejections due to a failed time validation
+    val timeValidationRejections =
+      transactionValidationResult.timeValidationResultE.swap.toOption
+        .map {
+          case TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(
+                ledgerTime,
+                recordTime,
+                maxDelta,
+              ) =>
+            LocalRejectError.TimeRejects.LedgerTime.Reject(
+              s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
+            )
+          case TimeValidator.PreparationTimeRecordTimeDeltaTooLargeError(
+                preparationTime,
+                recordTime,
+                maxDelta,
+              ) =>
+            LocalRejectError.TimeRejects.PreparationTime.Reject(
+              s"preparationTime=$preparationTime, recordTime=$recordTime, maxDelta=$maxDelta"
+            )
+          case TimeValidator.ExternallySignedRecordTimeExceedsMaximum(
+                recordTime: CantonTimestamp,
+                maxRecordTime: CantonTimestamp,
+              ) =>
+            LocalRejectError.TimeRejects.MaxRecordTimeExceeded.Reject(
+              s"recordTime=$recordTime, maxRecordTime=$maxRecordTime"
+            )
+        }
+        .map(logged(requestId, _))
+        .map(_.toLocalReject(protocolVersion))
+
+    val contractConsistencyRejections =
+      transactionValidationResult.contractConsistencyResultE.swap.toOption.map(err =>
+        logged(
+          requestId,
+          LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.toString),
+        ).toLocalReject(protocolVersion)
+      )
+
+    val localVerdicts: Seq[LocalVerdict] =
+      consistencyVerdict.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
+        authenticationRejections ++ authorizationRejections ++
+        modelConformanceRejections ++ internalConsistencyRejections ++
+        replayRejections
+
+    localVerdicts
+      .collectFirst[(LocalVerdict, Set[LfPartyId])] {
+        case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
+        case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
+          localReject -> hostedConfirmingParties
+      }
+      .orElse(
+        Option.when(hostedConfirmingParties.nonEmpty)(
+          LocalApprove(protocolVersion) -> hostedConfirmingParties
+        )
+      )
+  }
 
   /** Takes a `transactionValidationResult` and computes the
     * [[protocol.messages.ConfirmationResponses]], to be sent to the mediator.
@@ -133,151 +373,99 @@ class TransactionConfirmationResponsesFactory(
 
     def responsesForWellFormedPayloads(
         transactionValidationResult: TransactionValidationResult
-    ): FutureUnlessShutdown[Option[ConfirmationResponses]] = {
+    ): FutureUnlessShutdown[Option[ConfirmationResponses]] =
       for {
         modelConformanceResultE <- transactionValidationResult.modelConformanceResultET.value
 
         internalConsistencyResultE <- transactionValidationResult.internalConsistencyResultET.value
 
+        modelConformanceErrors =
+          modelConformanceResultE.swap.toSeq.flatMap(_.nonAbortErrors)
+
+        externalCallRecordedResultDisagreements =
+          modelConformanceErrors.flatMap(
+            ExternalCallResponseRouter.externalCallRecordedResultDisagreement
+          )
+
+        viewsWithHostedParties <- transactionValidationResult.viewValidationResults.toSeq
+          .parTraverse { case (viewPosition, viewValidationResult) =>
+            for {
+              hostedConfirmingParties <-
+                hostedConfirmingPartiesOfView(viewValidationResult)
+            } yield ViewWithHostedParties(
+              viewPosition = viewPosition,
+              validationResult = viewValidationResult,
+              hostedConfirmingParties = hostedConfirmingParties,
+            )
+          }
+
+        externalCallRouting = new ExternalCallRoutingContext(
+          externalCallRecordedResultDisagreements,
+          viewsWithHostedParties,
+          transactionValidationResult.viewValidationResults,
+        )
+
+        _ = externalCallRouter.reportVisibleRecordedDisagreementAlarms(
+          requestId,
+          externalCallRouting.recordedConsistencyResult,
+        )
+
         // Rejections due to a failed model conformance check
         // Aborts are logged by the Engine callback when the abort happens
         modelConformanceRejections =
-          modelConformanceResultE.swap.toSeq.flatMap(error =>
-            error.nonAbortErrors.map(cause =>
+          modelConformanceErrors.flatMap { case cause =>
+            Option.unless(externalCallRouting.isRoutableModelConformanceError(cause))(
               logged(
                 requestId,
                 LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
               ).toLocalReject(protocolVersion)
             )
+          }
+
+        ordinaryViewResults = viewsWithHostedParties.map { viewWithHostedParties =>
+          val hostedConfirmingParties = viewWithHostedParties.hostedConfirmingParties
+          val consistencyVerdict =
+            verdictsForView(viewWithHostedParties.validationResult, hostedConfirmingParties)
+          val ordinaryVerdictAndPartiesO =
+            ordinaryLocalVerdictAndParties(
+              requestId,
+              transactionValidationResult,
+              internalConsistencyResultE,
+              modelConformanceRejections,
+              viewWithHostedParties,
+              consistencyVerdict,
+            )
+          viewWithHostedParties -> ordinaryVerdictAndPartiesO
+        }
+
+        approvingViewPositions =
+          ordinaryViewResults.collect {
+            case (viewWithHostedParties, Some((_: LocalApprove, parties))) if parties.nonEmpty =>
+              viewWithHostedParties.viewPosition -> parties
+          }.toMap
+
+        localValidationOccurrences =
+          externalCallRouter.validationOccurrences(
+            viewsWithHostedParties,
+            approvingViewPositions,
+            externalCallRouting,
           )
 
-        responses <- transactionValidationResult.viewValidationResults.toSeq
-          .parTraverseFilter { case (viewPosition, viewValidationResult) =>
-            for {
-              hostedConfirmingParties <-
-                hostedConfirmingPartiesOfView(viewValidationResult)
+        localValidationRoutes <-
+          if (localValidationOccurrences.isEmpty)
+            FutureUnlessShutdown.pure(ExternalCallValidationRoutes(Map.empty, Map.empty))
+          else externalCallRouter.validateExternalCalls(localValidationOccurrences)
 
-            } yield {
-
-              // Rejections due to a failed internal consistency check
-              val internalConsistencyRejections =
-                internalConsistencyResultE.swap.toOption.map(cause =>
-                  logged(
-                    requestId,
-                    LocalRejectError.MalformedRejects.ModelConformance.Reject(cause.toString),
-                  ).toLocalReject(protocolVersion)
-                )
-
-              // Rejections due to a failed authentication check
-              val authenticationRejections =
-                transactionValidationResult.authenticationResult
-                  .get(viewPosition)
-                  .map(err =>
-                    logged(
-                      requestId,
-                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.message),
-                    ).toLocalReject(protocolVersion)
-                  )
-
-              // Rejections due to a transaction detected as a replay
-              val replayRejections =
-                transactionValidationResult.replayCheckResult
-                  .map(err =>
-                    logged(
-                      requestId,
-                      // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
-                      // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
-                      // ensures that this rejection or something at least as strong will make it to the mediator.
-                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(
-                        err.format(viewPosition)
-                      ),
-                    ).toLocalReject(protocolVersion)
-                  )
-
-              // Rejections due to a failed authorization check
-              val authorizationRejections =
-                transactionValidationResult.authorizationResult
-                  .get(viewPosition)
-                  .map(cause =>
-                    logged(
-                      requestId,
-                      LocalRejectError.MalformedRejects.MalformedRequest.Reject(cause),
-                    ).toLocalReject(protocolVersion)
-                  )
-
-              // Rejections due to a failed time validation
-              val timeValidationRejections =
-                transactionValidationResult.timeValidationResultE.swap.toOption
-                  .map {
-                    case TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(
-                          ledgerTime,
-                          recordTime,
-                          maxDelta,
-                        ) =>
-                      LocalRejectError.TimeRejects.LedgerTime.Reject(
-                        s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
-                      )
-                    case TimeValidator.PreparationTimeRecordTimeDeltaTooLargeError(
-                          preparationTime,
-                          recordTime,
-                          maxDelta,
-                        ) =>
-                      LocalRejectError.TimeRejects.PreparationTime.Reject(
-                        s"preparationTime=$preparationTime, recordTime=$recordTime, maxDelta=$maxDelta"
-                      )
-                    case TimeValidator.ExternallySignedRecordTimeExceedsMaximum(
-                          recordTime: CantonTimestamp,
-                          maxRecordTime: CantonTimestamp,
-                        ) =>
-                      LocalRejectError.TimeRejects.MaxRecordTimeExceeded.Reject(
-                        s"recordTime=$recordTime, maxRecordTime=$maxRecordTime"
-                      )
-                  }
-                  .map(logged(requestId, _))
-                  .map(_.toLocalReject(protocolVersion))
-
-              val contractConsistencyRejections =
-                transactionValidationResult.contractConsistencyResultE.swap.toOption.map(err =>
-                  logged(
-                    requestId,
-                    LocalRejectError.MalformedRejects.MalformedRequest.Reject(err.toString),
-                  ).toLocalReject(protocolVersion)
-                )
-
-              // Approve if the consistency check succeeded, reject otherwise.
-              val consistencyVerdicts =
-                verdictsForView(viewValidationResult, hostedConfirmingParties)
-
-              val localVerdicts: Seq[LocalVerdict] =
-                consistencyVerdicts.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
-                  authenticationRejections ++ authorizationRejections ++
-                  modelConformanceRejections ++ internalConsistencyRejections ++
-                  replayRejections
-
-              val localVerdictAndPartiesO = localVerdicts
-                .collectFirst[(LocalVerdict, Set[LfPartyId])] {
-                  case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
-                  case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
-                    localReject -> hostedConfirmingParties
-                }
-                .orElse(
-                  Option.when(hostedConfirmingParties.nonEmpty)(
-                    LocalApprove(protocolVersion) -> hostedConfirmingParties
-                  )
-                )
-
-              localVerdictAndPartiesO.map { case (localVerdict, parties) =>
-                checked(
-                  ConfirmationResponse
-                    .tryCreate(
-                      Some(viewPosition),
-                      localVerdict,
-                      parties,
-                    )
-                )
-              }
-            }
-          }
+        responses = ordinaryViewResults.flatMap {
+          case (viewWithHostedParties, localVerdictAndPartiesO) =>
+            responsesForView(
+              requestId,
+              viewWithHostedParties,
+              localVerdictAndPartiesO,
+              externalCallRouting,
+              localValidationRoutes,
+            )
+        }
       } yield {
         checked(
           NonEmpty
@@ -295,9 +483,15 @@ class TransactionConfirmationResponsesFactory(
             )
         )
       }
-    }
 
     if (malformedPayloads.nonEmpty) {
+      externalCallRouter.reportVisibleRecordedDisagreementAlarms(
+        requestId,
+        ExternalCallConsistencyChecker.check(
+          transactionValidationResult.viewValidationResults,
+          Set.empty,
+        ),
+      )
       FutureUnlessShutdown.pure(
         ProcessingSteps.constructResponsesForMalformedPayloads(
           requestId = requestId,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -89,8 +89,7 @@ class TransactionConfirmationResponsesFactory(
             case _: LocalApprove =>
               localValidationRoutes.abstainsForView(
                 viewPosition,
-                hostedConfirmingParties,
-                rejectedParties,
+                hostedConfirmingParties -- rejectedParties,
               )
             case _ =>
               Seq.empty
@@ -105,11 +104,7 @@ class TransactionConfirmationResponsesFactory(
               val reject = logged(
                 requestId,
                 LocalRejectError.ConsistencyRejections.ExternalCallResultDisagreement
-                  .Reject(
-                    inconsistency.description
-                      .limit(ExternalCallResponseRouter.maxExternalCallDisagreementDetailsLength)
-                      .toString
-                  ),
+                  .Reject(inconsistency.description),
               ).toLocalReject(protocolVersion)
               responseForView(
                 viewPosition,
@@ -127,11 +122,7 @@ class TransactionConfirmationResponsesFactory(
               responseForView(
                 viewPosition,
                 LocalAbstainError.CannotPerformAllValidations
-                  .Abstain(
-                    reason
-                      .limit(ExternalCallResponseRouter.maxExternalCallDisagreementDetailsLength)
-                      .toString
-                  )
+                  .Abstain(reason)
                   .toLocalAbstain(protocolVersion),
                 parties.toSet,
               )

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
@@ -33,6 +33,7 @@ final case class TransactionValidationResult(
       ErrorWithInternalConsistencyCheck,
       Unit,
     ],
+    externalCallValidationResultF: FutureUnlessShutdown[ExternalCallResponseRouter.Result],
     consumedInputsOfHostedParties: Map[LfContractId, Set[LfPartyId]],
     witnessed: Map[LfContractId, GenContractInstance],
     createdContracts: Map[LfContractId, NewContractInstance],

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/CantonSyncService.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/CantonSyncService.scala
@@ -77,6 +77,7 @@ import com.digitalasset.canton.participant.protocol.submission.routing.{
   RoutingSynchronizerStateFactory,
   TransactionRoutingProcessor,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.PruningProcessor
 import com.digitalasset.canton.participant.replica.ParticipantReplicaManager
 import com.digitalasset.canton.participant.store.*
@@ -180,6 +181,7 @@ class CantonSyncService(
     val ledgerApiIndexer: LifeCycleContainer[LedgerApiIndexer],
     trafficEnforcementBackendO: Option[Eval[TrafficEnforcementBackend]],
     connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContextExecutor, mat: Materializer, val tracer: Tracer)
     extends state.SyncService
     with ParticipantPruningSyncService
@@ -234,6 +236,7 @@ class CantonSyncService(
     testingConfig,
     ledgerApiIndexer,
     connectedSynchronizersLookupContainer,
+    externalCallValidator,
   )
 
   private def connectedSynchronizersLookup: ConnectedSynchronizersLookup =
@@ -1850,6 +1853,7 @@ object CantonSyncService {
       connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
       triggerDeclarativeChange: () => Unit,
       trafficEnforcementBackendO: Option[Eval[TrafficEnforcementBackend]],
+      externalCallValidator: ExternalCallValidator,
   )(implicit ec: ExecutionContextExecutor, mat: Materializer, tracer: Tracer): CantonSyncService = {
 
     // Set initial replica state
@@ -1887,6 +1891,7 @@ object CantonSyncService {
         ledgerApiIndexer,
         trafficEnforcementBackendO,
         connectedSynchronizersLookupContainer,
+        externalCallValidator,
       )
     syncService
   }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/ConnectedSynchronizer.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/ConnectedSynchronizer.scala
@@ -51,6 +51,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
   SeedGenerator,
   TransactionConfirmationRequestFactory,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.{
   AcsCommitmentProcessor,
   JournalGarbageCollector,
@@ -177,6 +178,7 @@ class ConnectedSynchronizer(
     futureSupervisor: FutureSupervisor,
     override protected val loggerFactory: NamedLoggerFactory,
     testingConfig: TestingConfigInternal,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContext, tracer: Tracer)
     extends NamedLogging
     with FlagCloseableAsync
@@ -294,6 +296,7 @@ class ConnectedSynchronizer(
     promiseUSFactory,
     parameters,
     trafficEnforcementBackendO.map(_.value),
+    externalCallValidator,
   )
 
   private val unassignmentProcessor: UnassignmentProcessor = new UnassignmentProcessor(
@@ -1253,6 +1256,7 @@ object ConnectedSynchronizer {
         futureSupervisor: FutureSupervisor,
         loggerFactory: NamedLoggerFactory,
         testingConfig: TestingConfigInternal,
+        externalCallValidator: ExternalCallValidator,
     )(implicit ec: ExecutionContext, mat: Materializer, tracer: Tracer): FutureUnlessShutdown[T]
   }
 
@@ -1281,6 +1285,7 @@ object ConnectedSynchronizer {
         futureSupervisor: FutureSupervisor,
         loggerFactory: NamedLoggerFactory,
         testingConfig: TestingConfigInternal,
+        externalCallValidator: ExternalCallValidator,
     )(implicit
         ec: ExecutionContext,
         mat: Materializer,
@@ -1393,6 +1398,7 @@ object ConnectedSynchronizer {
           futureSupervisor,
           loggerFactory,
           testingConfig,
+          externalCallValidator,
         )
       }
     }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/SynchronizerConnectionsManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/SynchronizerConnectionsManager.scala
@@ -40,6 +40,7 @@ import com.digitalasset.canton.participant.admin.party.{
 import com.digitalasset.canton.participant.ledger.api.LedgerApiIndexer
 import com.digitalasset.canton.participant.metrics.ParticipantMetrics
 import com.digitalasset.canton.participant.protocol.reassignment.ReassignmentCoordination
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.AcsCommitmentProcessor
 import com.digitalasset.canton.participant.store.*
 import com.digitalasset.canton.participant.store.SynchronizerConnectionConfigStore.UnknownAlias
@@ -147,6 +148,7 @@ private[sync] class SynchronizerConnectionsManager(
     testingConfig: TestingConfigInternal,
     ledgerApiIndexer: LifeCycleContainer[LedgerApiIndexer],
     connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContextExecutor, mat: Materializer, val tracer: Tracer)
     extends FlagCloseable
     with Spanning
@@ -1227,6 +1229,7 @@ private[sync] class SynchronizerConnectionsManager(
               futureSupervisor,
               synchronizerLoggerFactory,
               testingConfig,
+              externalCallValidator,
             )
           )
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -58,11 +58,11 @@ class ExternalCallConsistencyCheckerTest
 
     ExternalCallConsistencyChecker.check(
       Map(
-        ViewPosition.root -> validationResult(left),
+        ViewPosition.root -> participantView(left),
         ViewPosition(
           List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
         ) ->
-          validationResult(right),
+          participantView(right),
       ),
       hostedParties,
     )
@@ -149,7 +149,7 @@ class ExternalCallConsistencyCheckerTest
       )
 
       val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> validationResult(view)),
+        Map(ViewPosition.root -> participantView(view)),
         Set(partyA),
       )
 
@@ -201,11 +201,11 @@ class ExternalCallConsistencyCheckerTest
 
       val result = ExternalCallConsistencyChecker.check(
         Map(
-          ViewPosition.root -> validationResult(left),
+          ViewPosition.root -> participantView(left),
           ViewPosition(
             List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
           ) ->
-            validationResult(right),
+            participantView(right),
         ),
         Set(partyA),
       )
@@ -221,7 +221,7 @@ class ExternalCallConsistencyCheckerTest
       val example = factory.MultipleRoots
 
       val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> validationResult(example.rootViews(4))),
+        Map(ViewPosition.root -> participantView(example.rootViews(4))),
         Set(partyA),
       )
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -32,7 +32,7 @@ class ExternalCallConsistencyCheckerTest
       leftCheckingParties: Set[LfPartyId],
       rightCheckingParties: Set[LfPartyId],
       hostedParties: Set[LfPartyId],
-      rightResult: ExternalCallResult = otherExternalCallOutput,
+      rightResult: ExternalCallResult = otherExternalCallResult,
   ): ExternalCallConsistencyChecker.Result = {
     val example = factory.MultipleRoots
     val left = withExternalCallResults(
@@ -102,7 +102,7 @@ class ExternalCallConsistencyCheckerTest
       val visibleInconsistency = result.visibleInconsistencies.loneElement
       visibleInconsistency.outputs shouldBe Set(
         externalCallResult.output,
-        otherExternalCallOutput.output,
+        otherExternalCallResult.output,
       )
     }
 
@@ -122,7 +122,7 @@ class ExternalCallConsistencyCheckerTest
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyA),
         hostedParties = Set(partyA),
-        rightResult = otherExternalCallOutput.copy(functionId = "other-function"),
+        rightResult = otherExternalCallResult.copy(functionId = "other-function"),
       )
 
       result.inconsistentParties shouldBe Set.empty
@@ -141,7 +141,7 @@ class ExternalCallConsistencyCheckerTest
           ),
           externalCallViewResult(
             exerciseIndex = 0,
-            result = otherExternalCallOutput,
+            result = otherExternalCallResult,
             checkingParties = Set(partyA),
             callIndex = 1,
           ),
@@ -155,7 +155,7 @@ class ExternalCallConsistencyCheckerTest
 
       result.inconsistentParties shouldBe Set(partyA)
       val inconsistency = result.hostedInconsistencies(partyA).loneElement
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
       inconsistency.occurrences.map(occurrence =>
         occurrence.exerciseIndex -> occurrence.callIndex
       ) shouldBe Set(

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -24,9 +24,9 @@ class ExternalCallConsistencyCheckerTest
 
   protected val factory: ExampleTransactionFactory = new ExampleTransactionFactory()()
 
-  private val partyA = ExampleTransactionFactory.signatory
-  private val partyB = ExampleTransactionFactory.submitter
-  private val partyC = ExampleTransactionFactory.observer
+  private val partyA: LfPartyId = ExampleTransactionFactory.signatory
+  private val partyB: LfPartyId = ExampleTransactionFactory.submitter
+  private val partyC: LfPartyId = ExampleTransactionFactory.observer
 
   private def check(
       leftCheckingParties: Set[LfPartyId],

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -299,7 +299,7 @@ final class ExternalCallResponseRouterTest
       val sut = router(validator)
 
       // The visible recorded disagreement already rejects the checking party.
-      routing.recordedConsistencyResult.inconsistencies.keySet shouldBe Set(submitter)
+      routing.recordedConsistencyResult.hostedInconsistencies.keySet shouldBe Set(submitter)
       routing.recordedConsistencyResult.visibleInconsistencies should have size 1
       routing
         .inconsistenciesForView(leftViewPosition, Set(submitter, signatory))
@@ -380,8 +380,8 @@ final class ExternalCallResponseRouterTest
 
       // One visible disagreement per distinct external call, both routed to the checking party.
       routing.recordedConsistencyResult.visibleInconsistencies should have size 2
-      routing.recordedConsistencyResult.inconsistencies.keySet shouldBe Set(submitter)
-      routing.recordedConsistencyResult.inconsistencies(submitter) should have size 2
+      routing.recordedConsistencyResult.hostedInconsistencies.keySet shouldBe Set(submitter)
+      routing.recordedConsistencyResult.hostedInconsistencies(submitter) should have size 2
 
       // Each affected view rejects the checking party with the inconsistency for its own call.
       val expectedKeyByView = Map(
@@ -459,7 +459,7 @@ final class ExternalCallResponseRouterTest
 
       // No single hosted party sees both outputs, so the visible (hosted) consistency check finds
       // nothing -- but the disagreement is still globally visible and therefore alarmed.
-      routing.recordedConsistencyResult.inconsistencies shouldBe empty
+      routing.recordedConsistencyResult.hostedInconsistencies shouldBe empty
       routing.recordedConsistencyResult.visibleInconsistencies should have size 1
 
       // The replay disagreement routes to each checking party for the occurrence they can see.

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -87,7 +87,7 @@ final class ExternalCallResponseRouterTest
     )
     val right = withExternalCallResults(
       withConfirmers(example.rootViews(5), confirmers),
-      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(submitter))),
+      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(submitter))),
     )
     Seq(leftViewPosition -> left, rightViewPosition -> right)
   }
@@ -219,7 +219,7 @@ final class ExternalCallResponseRouterTest
       )
       val right = withExternalCallResults(
         withConfirmers(example.rootViews(5), confirmers),
-        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(signatory))),
       )
       val validator = new RecordingExternalCallValidator(Map.empty)
 
@@ -241,7 +241,7 @@ final class ExternalCallResponseRouterTest
       val leftViewHash = views.headOption.value._2.viewHash
       val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
       val sut = externalCallRouter()
 
@@ -261,7 +261,7 @@ final class ExternalCallResponseRouterTest
       // An unrelated disagreement is not routable.
       val unrelatedDisagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = DAMLe.ExternalCallKey.fromResult(externalCallResult.copy(functionId = "unrelated")),
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
       result.isRoutableModelConformanceError(
         ModelConformanceChecker.DAMLeError(unrelatedDisagreement, leftViewHash)
@@ -281,7 +281,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -304,7 +304,7 @@ final class ExternalCallResponseRouterTest
       routes.rejects.keySet shouldBe Set(submitter)
       val inconsistency = routes.rejects(submitter).loneElement
       inconsistency.key shouldBe externalCallKey
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
       routes.abstains shouldBe empty
 
       // Routed to the affected view for the checking party only; the co-confirmer is left to approve.
@@ -397,7 +397,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -435,7 +435,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -563,12 +563,12 @@ final class ExternalCallResponseRouterTest
       val right = withExternalCallResults(
         withConfirmers(example.rootViews(5), confirmers),
         // Same semantic key, different output, seen by a disjoint checking party.
-        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(signatory))),
       )
       val leftViewHash = left.viewHash
       val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
 
       // No single hosted party sees both outputs, so the hosted consistency check finds nothing --

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -1,0 +1,487 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.{TransactionView, ViewPosition}
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.protocol.ExampleTransactionFactory.{signatory, submitter}
+import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}
+import com.digitalasset.daml.lf.data.Bytes
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+
+/** Direct unit tests for [[ExternalCallResponseRouter]] and its routing collaborators
+  * ([[ExternalCallRoutingContext]], [[ExternalCallValidationRoutes]]).
+  *
+  * These exercise the router in isolation -- without going through
+  * [[TransactionConfirmationResponsesFactory]] -- and assert on the router's own outputs
+  * ([[ExternalCallValidationOccurrence]]s, [[ExternalCallValidationRoutes]] and per-party
+  * [[ExternalCallConsistencyChecker.Inconsistency]]s) rather than on assembled
+  * `ConfirmationResponse`s. Verdict merging / response assembly remains covered by
+  * [[TransactionConfirmationResponsesFactoryExternalCallTest]].
+  */
+final class ExternalCallResponseRouterTest
+    extends BaseTestWordSpec
+    with HasExecutionContext
+    with ExternalCallValidationTestUtil {
+
+  protected val factory =
+    new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
+
+  private def router(
+      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator
+  ): ExternalCallResponseRouter =
+    new ExternalCallResponseRouter(
+      externalCallValidator,
+      PositiveInt.tryCreate(8),
+      loggerFactory,
+    )
+
+  private val externalCallKey = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+
+  private def hostedView(
+      viewPosition: ViewPosition,
+      view: TransactionView,
+      hostedConfirmingParties: Set[LfPartyId],
+  ): ViewWithHostedParties =
+    ViewWithHostedParties(viewPosition, validationResult(view), hostedConfirmingParties)
+
+  private def routingContext(
+      viewsWithHostedParties: Seq[ViewWithHostedParties],
+      recordedDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement] = Seq.empty,
+  ): ExternalCallRoutingContext =
+    new ExternalCallRoutingContext(
+      recordedDisagreements,
+      viewsWithHostedParties,
+      viewsWithHostedParties.map(view => view.viewPosition -> view.validationResult).toMap,
+    )
+
+  /** Mirrors the factory's `approvingViewPositions`: every hosted confirming party approves. */
+  private def approvingAll(
+      viewsWithHostedParties: Seq[ViewWithHostedParties]
+  ): Map[ViewPosition, Set[LfPartyId]] =
+    viewsWithHostedParties.map(view => view.viewPosition -> view.hostedConfirmingParties).toMap
+
+  /** Two views recording the same external call with disagreeing outputs, both seen by `submitter`.
+    */
+  private def conflictingViews(
+      hostedConfirmingParties: Set[LfPartyId]
+  ): Seq[ViewWithHostedParties] = {
+    val example = factory.MultipleRoots
+    val confirmers = Set(submitter, signatory)
+    val left = withExternalCallResults(
+      withConfirmers(example.rootViews(4), confirmers),
+      Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+    )
+    val right = withExternalCallResults(
+      withConfirmers(example.rootViews(5), confirmers),
+      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(submitter))),
+    )
+    Seq(
+      hostedView(leftViewPosition, left, hostedConfirmingParties),
+      hostedView(rightViewPosition, right, hostedConfirmingParties),
+    )
+  }
+
+  "ExternalCallResponseRouter local validation" should {
+    "reject locally validated output mismatches for otherwise approving hosted checking parties" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val viewsWithHostedParties = Seq(hostedView(leftViewPosition, view, confirmers))
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallOutput.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val sut = router(validator)
+
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routingContext(viewsWithHostedParties),
+      )
+      // The checking party is the only affected party for the single recorded call.
+      val occurrence = occurrences.loneElement
+      occurrence.viewPosition shouldBe leftViewPosition
+      occurrence.result.result shouldBe externalCallResult
+      occurrence.hostedCheckingParties shouldBe Set(submitter)
+
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+
+      validator.observed shouldBe Seq(externalCallKey -> externalCallResult.output)
+      routes.rejects.keySet shouldBe Set(submitter)
+      val inconsistency = routes.rejects(submitter).loneElement
+      inconsistency.key shouldBe externalCallKey
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      routes.abstains shouldBe empty
+
+      // Routed to the affected view for the checking party only; the co-confirmer is left to approve.
+      routes.rejectsForView(leftViewPosition, confirmers).map(_._1) shouldBe Seq(submitter)
+    }
+
+    "abstain when locally responsible validation cannot obtain comparable output bytes" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val viewsWithHostedParties = Seq(hostedView(leftViewPosition, view, confirmers))
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        )
+      )
+      val sut = router(validator)
+
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routingContext(viewsWithHostedParties),
+      )
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+
+      validator.observed shouldBe Seq(externalCallKey -> externalCallResult.output)
+      routes.rejects shouldBe empty
+      routes.abstains.keySet shouldBe Set(submitter)
+      val abstain = routes.abstains(submitter).loneElement
+      abstain.viewPosition shouldBe leftViewPosition
+      abstain.reason should include("extension service is not configured")
+
+      routes
+        .abstainsForView(leftViewPosition, confirmers, rejectedParties = Set.empty)
+        .map(_._1) shouldBe Seq(submitter)
+    }
+
+    "scope local external-call validation abstains to the affected view" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val right = withConfirmers(example.rootViews(5), confirmers)
+      val viewsWithHostedParties = Seq(
+        hostedView(leftViewPosition, left, confirmers),
+        hostedView(rightViewPosition, right, confirmers),
+      )
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        )
+      )
+      val sut = router(validator)
+
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routingContext(viewsWithHostedParties),
+      )
+      // Only the left view carries an external call result.
+      occurrences.loneElement.viewPosition shouldBe leftViewPosition
+
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+
+      validator.observed shouldBe Seq(externalCallKey -> externalCallResult.output)
+      routes.abstains(submitter).loneElement.viewPosition shouldBe leftViewPosition
+      routes
+        .abstainsForView(leftViewPosition, confirmers, rejectedParties = Set.empty)
+        .map(_._1) shouldBe Seq(submitter)
+      // The abstain does not leak into the unaffected view.
+      routes
+        .abstainsForView(rightViewPosition, confirmers, rejectedParties = Set.empty) shouldBe empty
+    }
+
+    "not locally validate external calls when no hosted confirmer is a checking party" in {
+      val example = factory.MultipleRoots
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), Set(submitter, signatory)),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(signatory))),
+      )
+      // signatory is the checking party but is not hosted as a confirmer here.
+      val viewsWithHostedParties = Seq(hostedView(leftViewPosition, view, Set(submitter)))
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallOutput.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val sut = router(validator)
+
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routingContext(viewsWithHostedParties),
+      )
+      occurrences shouldBe empty
+
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+      validator.observed shouldBe empty
+      routes.rejects shouldBe empty
+      routes.abstains shouldBe empty
+    }
+
+    "deduplicate local external-call validation by semantic key and route the result to all occurrences" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        // Same semantic key and output as `left`, but a distinct occurrence (exerciseIndex 1).
+        Seq(externalCallViewResult(exerciseIndex = 1, externalCallResult, Set(submitter))),
+      )
+      val viewsWithHostedParties = Seq(
+        hostedView(leftViewPosition, left, confirmers),
+        hostedView(rightViewPosition, right, confirmers),
+      )
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallOutput.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val sut = router(validator)
+
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routingContext(viewsWithHostedParties),
+      )
+      occurrences.map(_.viewPosition).toSet shouldBe Set(leftViewPosition, rightViewPosition)
+
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+
+      // The validator is consulted exactly once for the shared semantic key.
+      validator.observed shouldBe Seq(externalCallKey -> externalCallResult.output)
+      routes.rejects.keySet shouldBe Set(submitter)
+      val inconsistency = routes.rejects(submitter).loneElement
+      inconsistency.occurrences.map(_.viewPosition) shouldBe Set(
+        leftViewPosition,
+        rightViewPosition,
+      )
+
+      // The single validation result is routed to every affected view.
+      routes.rejectsForView(leftViewPosition, confirmers).map(_._1) shouldBe Seq(submitter)
+      routes.rejectsForView(rightViewPosition, confirmers).map(_._1) shouldBe Seq(submitter)
+    }
+
+    "prefer recorded external-call disagreements over local external-call validation" in {
+      val viewsWithHostedParties = conflictingViews(Set(submitter, signatory))
+      val routing = routingContext(viewsWithHostedParties)
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        )
+      )
+      val sut = router(validator)
+
+      // The visible recorded disagreement already rejects the checking party.
+      routing.recordedConsistencyResult.inconsistencies.keySet shouldBe Set(submitter)
+      routing.recordedConsistencyResult.visibleInconsistencies should have size 1
+      routing
+        .inconsistenciesForView(leftViewPosition, Set(submitter, signatory))
+        .map(_._1) shouldBe Seq(submitter)
+
+      // Hence the locally-responsible party is already rejected and produces no validation work...
+      val occurrences = sut.validationOccurrences(
+        viewsWithHostedParties,
+        approvingAll(viewsWithHostedParties),
+        routing,
+      )
+      occurrences shouldBe empty
+
+      val routes = sut.validateExternalCalls(occurrences).futureValueUS
+      // ...so the local external-call validator is never invoked.
+      validator.observed shouldBe empty
+      routes.rejects shouldBe empty
+      routes.abstains shouldBe empty
+
+      // The visible disagreement is still alarmed.
+      assertRecordedDisagreementAlarms() {
+        sut.reportVisibleRecordedDisagreementAlarms(requestId, routing.recordedConsistencyResult)
+      }
+    }
+  }
+
+  "ExternalCallResponseRouter recorded-disagreement routing" should {
+    "not attribute external-call disagreements to unrelated hosted views" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val unrelatedView = withConfirmers(example.rootViews(3), confirmers)
+      val viewsWithHostedParties =
+        conflictingViews(confirmers) :+
+          hostedView(unrelatedViewPosition, unrelatedView, confirmers)
+      val routing = routingContext(viewsWithHostedParties)
+
+      // The conflicting views attribute the disagreement to the checking party.
+      routing
+        .inconsistenciesForView(leftViewPosition, confirmers)
+        .map(_._1) shouldBe Seq(submitter)
+      // The unrelated view (no external call results) is not attributed any disagreement.
+      routing.inconsistenciesForView(unrelatedViewPosition, confirmers) shouldBe empty
+    }
+
+    "emit external-call disagreement responses for every affected view" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val firstCall = externalCallResult.copy(functionId = "function-a")
+      val secondCall = externalCallResult.copy(functionId = "function-b")
+      val firstKey = DAMLe.ExternalCallKey.fromResult(firstCall)
+      val secondKey = DAMLe.ExternalCallKey.fromResult(secondCall)
+
+      def view(
+          baseView: TransactionView,
+          result: ExternalCallResult,
+          exerciseIndex: Int,
+      ): TransactionView =
+        withExternalCallResults(
+          withConfirmers(baseView, confirmers),
+          Seq(externalCallViewResult(exerciseIndex = exerciseIndex, result, Set(submitter))),
+        )
+
+      val viewsWithHostedParties = Seq(
+        hostedView(leftViewPosition, view(example.rootViews(4), firstCall, 0), confirmers),
+        hostedView(
+          rightViewPosition,
+          view(example.rootViews(5), firstCall.copy(output = Bytes.fromStringUtf8("other-a")), 1),
+          confirmers,
+        ),
+        hostedView(unrelatedViewPosition, view(example.rootViews(4), secondCall, 2), confirmers),
+        hostedView(
+          secondRightViewPosition,
+          view(example.rootViews(5), secondCall.copy(output = Bytes.fromStringUtf8("other-b")), 3),
+          confirmers,
+        ),
+      )
+      val routing = routingContext(viewsWithHostedParties)
+
+      // One visible disagreement per distinct external call, both routed to the checking party.
+      routing.recordedConsistencyResult.visibleInconsistencies should have size 2
+      routing.recordedConsistencyResult.inconsistencies.keySet shouldBe Set(submitter)
+      routing.recordedConsistencyResult.inconsistencies(submitter) should have size 2
+
+      // Each affected view rejects the checking party with the inconsistency for its own call.
+      val expectedKeyByView = Map(
+        leftViewPosition -> firstKey,
+        rightViewPosition -> firstKey,
+        unrelatedViewPosition -> secondKey,
+        secondRightViewPosition -> secondKey,
+      )
+      expectedKeyByView.foreach { case (viewPosition, expectedKey) =>
+        val routed = routing.inconsistenciesForView(viewPosition, confirmers)
+        routed.map(_._1) shouldBe Seq(submitter)
+        routed.loneElement._2.key shouldBe expectedKey
+      }
+
+      assertRecordedDisagreementAlarms(count = 2) {
+        router().reportVisibleRecordedDisagreementAlarms(
+          requestId,
+          routing.recordedConsistencyResult,
+        )
+      }
+    }
+
+    "route recorded external-call result disagreements by checking party" in {
+      val confirmers = Set(submitter, signatory)
+      val viewsWithHostedParties = conflictingViews(confirmers)
+      val leftViewHash =
+        viewsWithHostedParties.head.validationResult.view.unwrap.viewHash
+      val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
+        key = externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+      )
+      val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
+
+      // The recorded disagreement is attributed to the checking party only.
+      routing
+        .inconsistenciesForView(leftViewPosition, confirmers)
+        .map(_._1) shouldBe Seq(submitter)
+
+      // A model-conformance error carrying this disagreement is routable, so the factory
+      // suppresses the would-be malformed model-conformance reject.
+      val routableError = ModelConformanceChecker.DAMLeError(disagreement, leftViewHash)
+      routing.isRoutableModelConformanceError(routableError) shouldBe true
+
+      // An unrelated disagreement is not routable.
+      val unrelatedDisagreement = DAMLe.ExternalCallRecordedResultDisagreement(
+        key = DAMLe.ExternalCallKey.fromResult(externalCallResult.copy(functionId = "unrelated")),
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+      )
+      routing.isRoutableModelConformanceError(
+        ModelConformanceChecker.DAMLeError(unrelatedDisagreement, leftViewHash)
+      ) shouldBe false
+    }
+
+    "route recorded external-call replay ambiguity for disjoint checking parties" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        // Same semantic key, different output, seen by a disjoint checking party.
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
+      )
+      val viewsWithHostedParties = Seq(
+        hostedView(leftViewPosition, left, confirmers),
+        hostedView(rightViewPosition, right, confirmers),
+      )
+      val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
+        key = externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+      )
+      val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
+
+      // No single hosted party sees both outputs, so the visible (hosted) consistency check finds
+      // nothing -- but the disagreement is still globally visible and therefore alarmed.
+      routing.recordedConsistencyResult.inconsistencies shouldBe empty
+      routing.recordedConsistencyResult.visibleInconsistencies should have size 1
+
+      // The replay disagreement routes to each checking party for the occurrence they can see.
+      val routed = ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
+        Seq(disagreement),
+        viewsWithHostedParties,
+      )
+      routed.keySet shouldBe Set(submitter, signatory)
+      routed(submitter).loneElement._2.occurrences.map(_.viewPosition) shouldBe Set(
+        leftViewPosition
+      )
+      routed(signatory).loneElement._2.occurrences.map(_.viewPosition) shouldBe Set(
+        rightViewPosition
+      )
+
+      // Integrated per-view routing: left -> submitter, right -> signatory.
+      routing
+        .inconsistenciesForView(leftViewPosition, confirmers)
+        .map(_._1) shouldBe Seq(submitter)
+      routing
+        .inconsistenciesForView(rightViewPosition, confirmers)
+        .map(_._1) shouldBe Seq(signatory)
+    }
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -3,18 +3,22 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.data.{TransactionView, ViewPosition}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallResponseRouter.ViewWithHostedParties
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.protocol.ExampleTransactionFactory.{signatory, submitter}
+import com.digitalasset.canton.topology.ParticipantId
+import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.version.ProtocolVersion
 import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
 
-/** Direct unit tests for [[ExternalCallResponseRouter]] and its routing collaborators
-  * ([[ExternalCallRoutingContext]], [[ExternalCallValidationRoutes]]).
+/** Direct unit tests for [[ExternalCallResponseRouter]]: the [[ExternalCallResponseRouter.check]]
+  * validation suite and its collaborators ([[ExternalCallResponseRouter.Result]],
+  * [[ExternalCallValidationRoutes]]).
   *
   * These exercise the router in isolation -- without going through
   * [[TransactionConfirmationResponsesFactory]] -- and assert on the router's own outputs
@@ -31,64 +35,250 @@ final class ExternalCallResponseRouterTest
   protected val factory: ExampleTransactionFactory =
     new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
 
-  private def router(
-      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator
-  ): ExternalCallResponseRouter =
-    new ExternalCallResponseRouter(
-      externalCallValidator,
-      PositiveInt.tryCreate(8),
-      loggerFactory,
-    )
-
   private val externalCallKey: DAMLe.ExternalCallKey =
     DAMLe.ExternalCallKey.fromResult(externalCallResult)
+
+  /** Resolves only `hostedParties` as hosted. */
+  private def hostingTopologySnapshot(hostedParties: Set[LfPartyId]): TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties.intersect(hostedParties))
+      }
+    snapshot
+  }
+
+  private def runCheck(
+      sut: ExternalCallResponseRouter,
+      views: Seq[(ViewPosition, TransactionView)],
+      conformanceErrors: Seq[ModelConformanceChecker.Error] = Seq.empty,
+      topologySnapshot: TopologySnapshot = identityTopologySnapshot,
+      runValidation: Boolean = true,
+  ): ExternalCallResponseRouter.Result =
+    sut
+      .check(
+        requestId,
+        views.map { case (viewPosition, view) => viewPosition -> participantView(view) }.toMap,
+        topologySnapshot,
+        FutureUnlessShutdown.pure(conformanceErrors),
+        runValidation,
+      )
+      .futureValueUS
 
   private def hostedView(
       viewPosition: ViewPosition,
       view: TransactionView,
       hostedConfirmingParties: Set[LfPartyId],
   ): ViewWithHostedParties =
-    ViewWithHostedParties(viewPosition, validationResult(view), hostedConfirmingParties)
+    ViewWithHostedParties(viewPosition, participantView(view), hostedConfirmingParties)
 
-  private def routingContext(
-      viewsWithHostedParties: Seq[ViewWithHostedParties],
-      recordedDisagreements: Seq[DAMLe.ExternalCallRecordedResultDisagreement] = Seq.empty,
-  ): ExternalCallRoutingContext =
-    new ExternalCallRoutingContext(
-      recordedDisagreements,
-      viewsWithHostedParties,
-      viewsWithHostedParties.map(view => view.viewPosition -> view.validationResult).toMap,
-    )
-
-  /** Mirrors the factory's `approvingViewPositions`: every hosted confirming party approves. */
-  private def approvingAll(
+  /** The recorded-consistency input of [[ExternalCallResponseRouter.validationOccurrences]], as
+    * [[ExternalCallResponseRouter.check]] computes it.
+    */
+  private def recordedConsistencyOf(
       viewsWithHostedParties: Seq[ViewWithHostedParties]
-  ): Map[ViewPosition, Set[LfPartyId]] =
-    viewsWithHostedParties.map(view => view.viewPosition -> view.hostedConfirmingParties).toMap
+  ): ExternalCallConsistencyChecker.Result =
+    ExternalCallConsistencyChecker.check(
+      viewsWithHostedParties.map(view => view.viewPosition -> view.view).toMap,
+      viewsWithHostedParties.flatMap(_.hostedConfirmingParties).toSet,
+    )
 
   /** Two views recording the same external call with disagreeing outputs, both seen by `submitter`.
     */
   private def conflictingViews(
-      hostedConfirmingParties: Set[LfPartyId]
-  ): Seq[ViewWithHostedParties] = {
+      confirmers: Set[LfPartyId] = Set(submitter, signatory)
+  ): Seq[(ViewPosition, TransactionView)] = {
     val example = factory.MultipleRoots
-    val confirmers = Set(submitter, signatory)
     val left = withExternalCallResults(
       withConfirmers(example.rootViews(4), confirmers),
       Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
     )
     val right = withExternalCallResults(
       withConfirmers(example.rootViews(5), confirmers),
-      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(submitter))),
+      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(submitter))),
     )
-    Seq(
-      hostedView(leftViewPosition, left, hostedConfirmingParties),
-      hostedView(rightViewPosition, right, hostedConfirmingParties),
-    )
+    Seq(leftViewPosition -> left, rightViewPosition -> right)
+  }
+
+  private def hostedConflictingViews(
+      hostedConfirmingParties: Set[LfPartyId]
+  ): Seq[ViewWithHostedParties] =
+    conflictingViews().map { case (viewPosition, view) =>
+      hostedView(viewPosition, view, hostedConfirmingParties)
+    }
+
+  "ExternalCallResponseRouter check" should {
+    "short-circuit to the empty result when no view records external-call results" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val view = withConfirmers(example.rootViews(4), confirmers)
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val failingTopologySnapshot = {
+        val snapshot = mock[TopologySnapshot]
+        when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+          .thenAnswer { (_: ParticipantId, _: Set[LfPartyId]) =>
+            fail("the fast path must not resolve hosted confirming parties")
+          }
+        snapshot
+      }
+
+      val result = externalCallRouter(validator)
+        .check(
+          requestId,
+          Map(leftViewPosition -> participantView(view)),
+          failingTopologySnapshot,
+          // The fast path must not await the model-conformance errors either.
+          FutureUnlessShutdown.failed(
+            new RuntimeException("the fast path must not await the conformance errors")
+          ),
+          runValidation = true,
+        )
+        .futureValueUS
+
+      result shouldBe ExternalCallResponseRouter.Result.empty
+      validator.observed shouldBe empty
+    }
+
+    "check recorded consistency, alarm, and skip re-validation of disagreeing results" in {
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        )
+      )
+      val sut = externalCallRouter(validator)
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(sut, conflictingViews())
+      }
+
+      // The visible recorded disagreement rejects the checking party...
+      result.recordedConsistency.hostedInconsistencies.keySet shouldBe Set(submitter)
+      result.recordedConsistency.visibleInconsistencies should have size 1
+      result
+        .inconsistenciesForView(leftViewPosition, Set(submitter, signatory))
+        .map(_._1) shouldBe Seq(submitter)
+
+      // ...so the disagreeing occurrences produce no re-validation work.
+      validator.observed shouldBe empty
+      result.validationRoutes shouldBe ExternalCallValidationRoutes.empty
+    }
+
+    "alarm on visible disagreements that affect no hosted party" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val sut = externalCallRouter(validator)
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(
+          sut,
+          conflictingViews(),
+          topologySnapshot = hostingTopologySnapshot(Set.empty),
+        )
+      }
+
+      result.recordedConsistency.hostedInconsistencies shouldBe empty
+      result.recordedConsistency.visibleInconsistencies should have size 1
+      // No hosted checking party, so nothing is re-validated.
+      validator.observed shouldBe empty
+      result.validationRoutes shouldBe ExternalCallValidationRoutes.empty
+    }
+
+    "skip re-validation when instructed while still checking and alarming" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val undisputed = withExternalCallResults(
+        withConfirmers(example.rootViews(3), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 2,
+            externalCallResult.copy(functionId = "undisputed-function"),
+            Set(submitter),
+          )
+        ),
+      )
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val sut = externalCallRouter(validator)
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(
+          sut,
+          conflictingViews() :+ (unrelatedViewPosition -> undisputed),
+          runValidation = false,
+        )
+      }
+
+      result.recordedConsistency.hostedInconsistencies.keySet shouldBe Set(submitter)
+      // The undisputed result would be re-validated, but re-validation is switched off.
+      validator.observed shouldBe empty
+      result.validationRoutes shouldBe ExternalCallValidationRoutes.empty
+    }
+
+    "not re-validate keys whose recorded outputs disagree across views with disjoint checking parties" in {
+      // The same call is recorded with disagreeing outputs in two views, each output checked by a
+      // different party: neither party is recorded-inconsistent on its own, but the key has
+      // disagreeing outputs across the request and is therefore not re-validated (independently
+      // of which views end up being approved); the disagreement itself is alarmed.
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
+      )
+      val validator = new RecordingExternalCallValidator(Map.empty)
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(
+          externalCallRouter(validator),
+          Seq(leftViewPosition -> left, rightViewPosition -> right),
+        )
+      }
+
+      result.recordedConsistency.hostedInconsistencies shouldBe empty
+      result.recordedConsistency.visibleInconsistencies should have size 1
+      validator.observed shouldBe empty
+      result.validationRoutes shouldBe ExternalCallValidationRoutes.empty
+    }
+
+    "route replay disagreements surfaced by the model-conformance errors" in {
+      val views = conflictingViews()
+      val leftViewHash = views.headOption.value._2.viewHash
+      val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
+        key = externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+      )
+      val sut = externalCallRouter()
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(
+          sut,
+          views,
+          conformanceErrors = Seq(ModelConformanceChecker.DAMLeError(disagreement, leftViewHash)),
+        )
+      }
+
+      // The replay disagreement is routed to the checking party, so a model-conformance error
+      // carrying it is routable and suppresses the would-be malformed model-conformance reject.
+      val routableError = ModelConformanceChecker.DAMLeError(disagreement, leftViewHash)
+      result.isRoutableModelConformanceError(routableError) shouldBe true
+
+      // An unrelated disagreement is not routable.
+      val unrelatedDisagreement = DAMLe.ExternalCallRecordedResultDisagreement(
+        key = DAMLe.ExternalCallKey.fromResult(externalCallResult.copy(functionId = "unrelated")),
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+      )
+      result.isRoutableModelConformanceError(
+        ModelConformanceChecker.DAMLeError(unrelatedDisagreement, leftViewHash)
+      ) shouldBe false
+    }
   }
 
   "ExternalCallResponseRouter local validation" should {
-    "reject locally validated output mismatches for otherwise approving hosted checking parties" in {
+    "reject locally validated output mismatches for hosted checking parties" in {
       val example = factory.MultipleRoots
       val confirmers = Set(submitter, signatory)
       val view = withExternalCallResults(
@@ -99,17 +289,16 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallResult.output,
+            computedOutput = otherExternalCallOutput.output,
             recordedOutput = externalCallResult.output,
           )
         )
       )
-      val sut = router(validator)
+      val sut = externalCallRouter(validator)
 
       val occurrences = sut.validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routingContext(viewsWithHostedParties),
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       // The checking party is the only affected party for the single recorded call.
       val occurrence = occurrences.loneElement
@@ -123,7 +312,7 @@ final class ExternalCallResponseRouterTest
       routes.rejects.keySet shouldBe Set(submitter)
       val inconsistency = routes.rejects(submitter).loneElement
       inconsistency.key shouldBe externalCallKey
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
       routes.abstains shouldBe empty
 
       // Routed to the affected view for the checking party only; the co-confirmer is left to approve.
@@ -145,12 +334,11 @@ final class ExternalCallResponseRouterTest
           )
         )
       )
-      val sut = router(validator)
+      val sut = externalCallRouter(validator)
 
       val occurrences = sut.validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routingContext(viewsWithHostedParties),
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       val routes = sut.validateExternalCalls(occurrences).futureValueUS
 
@@ -185,12 +373,11 @@ final class ExternalCallResponseRouterTest
           )
         )
       )
-      val sut = router(validator)
+      val sut = externalCallRouter(validator)
 
       val occurrences = sut.validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routingContext(viewsWithHostedParties),
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       // Only the left view carries an external call result.
       occurrences.loneElement.viewPosition shouldBe leftViewPosition
@@ -218,17 +405,16 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallResult.output,
+            computedOutput = otherExternalCallOutput.output,
             recordedOutput = externalCallResult.output,
           )
         )
       )
-      val sut = router(validator)
+      val sut = externalCallRouter(validator)
 
       val occurrences = sut.validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routingContext(viewsWithHostedParties),
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       occurrences shouldBe empty
 
@@ -257,17 +443,16 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallResult.output,
+            computedOutput = otherExternalCallOutput.output,
             recordedOutput = externalCallResult.output,
           )
         )
       )
-      val sut = router(validator)
+      val sut = externalCallRouter(validator)
 
       val occurrences = sut.validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routingContext(viewsWithHostedParties),
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       occurrences.map(_.viewPosition).toSet shouldBe Set(leftViewPosition, rightViewPosition)
 
@@ -287,43 +472,16 @@ final class ExternalCallResponseRouterTest
       routes.rejectsForView(rightViewPosition, confirmers).map(_._1) shouldBe Seq(submitter)
     }
 
-    "prefer recorded external-call disagreements over local external-call validation" in {
-      val viewsWithHostedParties = conflictingViews(Set(submitter, signatory))
-      val routing = routingContext(viewsWithHostedParties)
-      val validator = new RecordingExternalCallValidator(
-        Map(
-          externalCallKey -> ExternalCallValidator.UnableToValidate(
-            "extension service is not configured"
-          )
-        )
-      )
-      val sut = router(validator)
+    "exclude parties with recorded disagreements from re-validation" in {
+      val viewsWithHostedParties = hostedConflictingViews(Set(submitter, signatory))
 
-      // The visible recorded disagreement already rejects the checking party.
-      routing.recordedConsistencyResult.hostedInconsistencies.keySet shouldBe Set(submitter)
-      routing.recordedConsistencyResult.visibleInconsistencies should have size 1
-      routing
-        .inconsistenciesForView(leftViewPosition, Set(submitter, signatory))
-        .map(_._1) shouldBe Seq(submitter)
-
-      // Hence the locally-responsible party is already rejected and produces no validation work...
-      val occurrences = sut.validationOccurrences(
+      // The recorded disagreement already rejects the checking party, so its occurrences produce
+      // no re-validation work.
+      val occurrences = externalCallRouter().validationOccurrences(
         viewsWithHostedParties,
-        approvingAll(viewsWithHostedParties),
-        routing,
+        recordedConsistencyOf(viewsWithHostedParties),
       )
       occurrences shouldBe empty
-
-      val routes = sut.validateExternalCalls(occurrences).futureValueUS
-      // ...so the local external-call validator is never invoked.
-      validator.observed shouldBe empty
-      routes.rejects shouldBe empty
-      routes.abstains shouldBe empty
-
-      // The visible disagreement is still alarmed.
-      assertRecordedDisagreementAlarms() {
-        sut.reportVisibleRecordedDisagreementAlarms(requestId, routing.recordedConsistencyResult)
-      }
     }
   }
 
@@ -332,20 +490,21 @@ final class ExternalCallResponseRouterTest
       val example = factory.MultipleRoots
       val confirmers = Set(submitter, signatory)
       val unrelatedView = withConfirmers(example.rootViews(3), confirmers)
-      val viewsWithHostedParties =
-        conflictingViews(confirmers) :+
-          hostedView(unrelatedViewPosition, unrelatedView, confirmers)
-      val routing = routingContext(viewsWithHostedParties)
+      val views = conflictingViews() :+ (unrelatedViewPosition -> unrelatedView)
+
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(externalCallRouter(), views)
+      }
 
       // The conflicting views attribute the disagreement to the checking party.
-      routing
+      result
         .inconsistenciesForView(leftViewPosition, confirmers)
         .map(_._1) shouldBe Seq(submitter)
       // The unrelated view (no external call results) is not attributed any disagreement.
-      routing.inconsistenciesForView(unrelatedViewPosition, confirmers) shouldBe empty
+      result.inconsistenciesForView(unrelatedViewPosition, confirmers) shouldBe empty
     }
 
-    "emit external-call disagreement responses for every affected view" in {
+    "emit external-call disagreement inconsistencies for every affected view" in {
       val example = factory.MultipleRoots
       val confirmers = Set(submitter, signatory)
       val firstCall = externalCallResult.copy(functionId = "function-a")
@@ -363,26 +522,30 @@ final class ExternalCallResponseRouterTest
           Seq(externalCallViewResult(exerciseIndex = exerciseIndex, result, Set(submitter))),
         )
 
-      val viewsWithHostedParties = Seq(
-        hostedView(leftViewPosition, view(example.rootViews(4), firstCall, 0), confirmers),
-        hostedView(
-          rightViewPosition,
-          view(example.rootViews(5), firstCall.copy(output = Bytes.fromStringUtf8("other-a")), 1),
-          confirmers,
+      val views = Seq(
+        leftViewPosition -> view(example.rootViews(4), firstCall, 0),
+        rightViewPosition -> view(
+          example.rootViews(5),
+          firstCall.copy(output = Bytes.fromStringUtf8("other-a")),
+          1,
         ),
-        hostedView(unrelatedViewPosition, view(example.rootViews(4), secondCall, 2), confirmers),
-        hostedView(
-          secondRightViewPosition,
-          view(example.rootViews(5), secondCall.copy(output = Bytes.fromStringUtf8("other-b")), 3),
-          confirmers,
+        unrelatedViewPosition -> view(example.rootViews(4), secondCall, 2),
+        secondRightViewPosition -> view(
+          example.rootViews(5),
+          secondCall.copy(output = Bytes.fromStringUtf8("other-b")),
+          3,
         ),
       )
-      val routing = routingContext(viewsWithHostedParties)
 
-      // One visible disagreement per distinct external call, both routed to the checking party.
-      routing.recordedConsistencyResult.visibleInconsistencies should have size 2
-      routing.recordedConsistencyResult.hostedInconsistencies.keySet shouldBe Set(submitter)
-      routing.recordedConsistencyResult.hostedInconsistencies(submitter) should have size 2
+      // One visible disagreement per distinct external call, both alarmed and routed to the
+      // checking party.
+      val result = assertRecordedDisagreementAlarms(count = 2) {
+        runCheck(externalCallRouter(), views)
+      }
+
+      result.recordedConsistency.visibleInconsistencies should have size 2
+      result.recordedConsistency.hostedInconsistencies.keySet shouldBe Set(submitter)
+      result.recordedConsistency.hostedInconsistencies(submitter) should have size 2
 
       // Each affected view rejects the checking party with the inconsistency for its own call.
       val expectedKeyByView = Map(
@@ -392,48 +555,10 @@ final class ExternalCallResponseRouterTest
         secondRightViewPosition -> secondKey,
       )
       expectedKeyByView.foreach { case (viewPosition, expectedKey) =>
-        val routed = routing.inconsistenciesForView(viewPosition, confirmers)
+        val routed = result.inconsistenciesForView(viewPosition, confirmers)
         routed.map(_._1) shouldBe Seq(submitter)
         routed.loneElement._2.key shouldBe expectedKey
       }
-
-      assertRecordedDisagreementAlarms(count = 2) {
-        router().reportVisibleRecordedDisagreementAlarms(
-          requestId,
-          routing.recordedConsistencyResult,
-        )
-      }
-    }
-
-    "route recorded external-call result disagreements by checking party" in {
-      val confirmers = Set(submitter, signatory)
-      val viewsWithHostedParties = conflictingViews(confirmers)
-      val leftViewHash =
-        viewsWithHostedParties.head.validationResult.view.unwrap.viewHash
-      val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
-        key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
-      )
-      val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
-
-      // The recorded disagreement is attributed to the checking party only.
-      routing
-        .inconsistenciesForView(leftViewPosition, confirmers)
-        .map(_._1) shouldBe Seq(submitter)
-
-      // A model-conformance error carrying this disagreement is routable, so the factory
-      // suppresses the would-be malformed model-conformance reject.
-      val routableError = ModelConformanceChecker.DAMLeError(disagreement, leftViewHash)
-      routing.isRoutableModelConformanceError(routableError) shouldBe true
-
-      // An unrelated disagreement is not routable.
-      val unrelatedDisagreement = DAMLe.ExternalCallRecordedResultDisagreement(
-        key = DAMLe.ExternalCallKey.fromResult(externalCallResult.copy(functionId = "unrelated")),
-        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
-      )
-      routing.isRoutableModelConformanceError(
-        ModelConformanceChecker.DAMLeError(unrelatedDisagreement, leftViewHash)
-      ) shouldBe false
     }
 
     "route recorded external-call replay ambiguity for disjoint checking parties" in {
@@ -446,41 +571,47 @@ final class ExternalCallResponseRouterTest
       val right = withExternalCallResults(
         withConfirmers(example.rootViews(5), confirmers),
         // Same semantic key, different output, seen by a disjoint checking party.
-        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(signatory))),
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
       )
-      val viewsWithHostedParties = Seq(
-        hostedView(leftViewPosition, left, confirmers),
-        hostedView(rightViewPosition, right, confirmers),
-      )
+      val leftViewHash = left.viewHash
       val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
+        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
       )
-      val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
 
-      // No single hosted party sees both outputs, so the visible (hosted) consistency check finds
-      // nothing -- but the disagreement is still globally visible and therefore alarmed.
-      routing.recordedConsistencyResult.hostedInconsistencies shouldBe empty
-      routing.recordedConsistencyResult.visibleInconsistencies should have size 1
+      // No single hosted party sees both outputs, so the hosted consistency check finds nothing --
+      // but the disagreement is still globally visible and therefore alarmed.
+      val result = assertRecordedDisagreementAlarms() {
+        runCheck(
+          externalCallRouter(),
+          Seq(leftViewPosition -> left, rightViewPosition -> right),
+          conformanceErrors = Seq(ModelConformanceChecker.DAMLeError(disagreement, leftViewHash)),
+        )
+      }
+
+      result.recordedConsistency.hostedInconsistencies shouldBe empty
+      result.recordedConsistency.visibleInconsistencies should have size 1
 
       // The replay disagreement routes to each checking party for the occurrence they can see.
-      val routed = ExternalCallResponseRouter.recordedExternalCallDisagreementInconsistencies(
-        Seq(disagreement),
-        viewsWithHostedParties,
-      )
-      routed.keySet shouldBe Set(submitter, signatory)
-      routed(submitter).loneElement._2.occurrences.map(_.viewPosition) shouldBe Set(
-        leftViewPosition
-      )
-      routed(signatory).loneElement._2.occurrences.map(_.viewPosition) shouldBe Set(
-        rightViewPosition
-      )
+      result.replayDisagreementInconsistencies.keySet shouldBe Set(submitter, signatory)
+      result
+        .replayDisagreementInconsistencies(submitter)
+        .loneElement
+        ._2
+        .occurrences
+        .map(_.viewPosition) shouldBe Set(leftViewPosition)
+      result
+        .replayDisagreementInconsistencies(signatory)
+        .loneElement
+        ._2
+        .occurrences
+        .map(_.viewPosition) shouldBe Set(rightViewPosition)
 
       // Integrated per-view routing: left -> submitter, right -> signatory.
-      routing
+      result
         .inconsistenciesForView(leftViewPosition, confirmers)
         .map(_._1) shouldBe Seq(submitter)
-      routing
+      result
         .inconsistenciesForView(rightViewPosition, confirmers)
         .map(_._1) shouldBe Seq(signatory)
     }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -78,7 +78,7 @@ final class ExternalCallResponseRouterTest
     )
     val right = withExternalCallResults(
       withConfirmers(example.rootViews(5), confirmers),
-      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(submitter))),
+      Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(submitter))),
     )
     Seq(
       hostedView(leftViewPosition, left, hostedConfirmingParties),
@@ -98,7 +98,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -122,7 +122,7 @@ final class ExternalCallResponseRouterTest
       routes.rejects.keySet shouldBe Set(submitter)
       val inconsistency = routes.rejects(submitter).loneElement
       inconsistency.key shouldBe externalCallKey
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
       routes.abstains shouldBe empty
 
       // Routed to the affected view for the checking party only; the co-confirmer is left to approve.
@@ -217,7 +217,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -256,7 +256,7 @@ final class ExternalCallResponseRouterTest
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )
@@ -411,7 +411,7 @@ final class ExternalCallResponseRouterTest
         viewsWithHostedParties.head.validationResult.view.unwrap.viewHash
       val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
       val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
 
@@ -428,7 +428,7 @@ final class ExternalCallResponseRouterTest
       // An unrelated disagreement is not routable.
       val unrelatedDisagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = DAMLe.ExternalCallKey.fromResult(externalCallResult.copy(functionId = "unrelated")),
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
       routing.isRoutableModelConformanceError(
         ModelConformanceChecker.DAMLeError(unrelatedDisagreement, leftViewHash)
@@ -445,7 +445,7 @@ final class ExternalCallResponseRouterTest
       val right = withExternalCallResults(
         withConfirmers(example.rootViews(5), confirmers),
         // Same semantic key, different output, seen by a disjoint checking party.
-        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallOutput, Set(signatory))),
+        Seq(externalCallViewResult(exerciseIndex = 1, otherExternalCallResult, Set(signatory))),
       )
       val viewsWithHostedParties = Seq(
         hostedView(leftViewPosition, left, confirmers),
@@ -453,7 +453,7 @@ final class ExternalCallResponseRouterTest
       )
       val disagreement = DAMLe.ExternalCallRecordedResultDisagreement(
         key = externalCallKey,
-        outputs = Set(externalCallResult.output, otherExternalCallOutput.output),
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
       )
       val routing = routingContext(viewsWithHostedParties, Seq(disagreement))
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -161,7 +161,7 @@ final class ExternalCallResponseRouterTest
       abstain.reason should include("extension service is not configured")
 
       routes
-        .abstainsForView(leftViewPosition, confirmers, rejectedParties = Set.empty)
+        .abstainsForView(leftViewPosition, confirmers)
         .map(_._1) shouldBe Seq(submitter)
     }
 
@@ -199,11 +199,11 @@ final class ExternalCallResponseRouterTest
       validator.observed shouldBe Seq(externalCallKey -> externalCallResult.output)
       routes.abstains(submitter).loneElement.viewPosition shouldBe leftViewPosition
       routes
-        .abstainsForView(leftViewPosition, confirmers, rejectedParties = Set.empty)
+        .abstainsForView(leftViewPosition, confirmers)
         .map(_._1) shouldBe Seq(submitter)
       // The abstain does not leak into the unaffected view.
       routes
-        .abstainsForView(rightViewPosition, confirmers, rejectedParties = Set.empty) shouldBe empty
+        .abstainsForView(rightViewPosition, confirmers) shouldBe empty
     }
 
     "not locally validate external calls when no hosted confirmer is a checking party" in {

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -5,7 +5,10 @@ package com.digitalasset.canton.participant.protocol.validation
 
 import com.digitalasset.canton.data.{TransactionView, ViewPosition}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
-import com.digitalasset.canton.participant.protocol.validation.ExternalCallResponseRouter.ViewWithHostedParties
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallResponseRouter.{
+  ExternalCallValidationRoutes,
+  ViewWithHostedParties,
+}
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.protocol.ExampleTransactionFactory.{signatory, submitter}
@@ -37,16 +40,6 @@ final class ExternalCallResponseRouterTest
 
   private val externalCallKey: DAMLe.ExternalCallKey =
     DAMLe.ExternalCallKey.fromResult(externalCallResult)
-
-  /** Resolves only `hostedParties` as hosted. */
-  private def hostingTopologySnapshot(hostedParties: Set[LfPartyId]): TopologySnapshot = {
-    val snapshot = mock[TopologySnapshot]
-    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
-      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
-        FutureUnlessShutdown.pure(parties.intersect(hostedParties))
-      }
-    snapshot
-  }
 
   private def runCheck(
       sut: ExternalCallResponseRouter,
@@ -85,10 +78,9 @@ final class ExternalCallResponseRouterTest
 
   /** Two views recording the same external call with disagreeing outputs, both seen by `submitter`.
     */
-  private def conflictingViews(
-      confirmers: Set[LfPartyId] = Set(submitter, signatory)
-  ): Seq[(ViewPosition, TransactionView)] = {
+  private def conflictingViews(): Seq[(ViewPosition, TransactionView)] = {
     val example = factory.MultipleRoots
+    val confirmers = Set(submitter, signatory)
     val left = withExternalCallResults(
       withConfirmers(example.rootViews(4), confirmers),
       Seq(externalCallViewResult(exerciseIndex = 0, externalCallResult, Set(submitter))),
@@ -554,7 +546,7 @@ final class ExternalCallResponseRouterTest
         unrelatedViewPosition -> secondKey,
         secondRightViewPosition -> secondKey,
       )
-      expectedKeyByView.foreach { case (viewPosition, expectedKey) =>
+      forEvery(expectedKeyByView) { case (viewPosition, expectedKey) =>
         val routed = result.inconsistenciesForView(viewPosition, confirmers)
         routed.map(_._1) shouldBe Seq(submitter)
         routed.loneElement._2.key shouldBe expectedKey

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallResponseRouterTest.scala
@@ -28,7 +28,7 @@ final class ExternalCallResponseRouterTest
     with HasExecutionContext
     with ExternalCallValidationTestUtil {
 
-  protected val factory =
+  protected val factory: ExampleTransactionFactory =
     new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
 
   private def router(
@@ -40,7 +40,8 @@ final class ExternalCallResponseRouterTest
       loggerFactory,
     )
 
-  private val externalCallKey = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+  private val externalCallKey: DAMLe.ExternalCallKey =
+    DAMLe.ExternalCallKey.fromResult(externalCallResult)
 
   private def hostedView(
       viewPosition: ViewPosition,

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
-import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
 import com.digitalasset.canton.data.{
   CantonTimestamp,
   ParticipantTransactionView,
@@ -18,6 +18,8 @@ import com.digitalasset.canton.logging.LogEntry
 import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.topology.ParticipantId
+import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.{BaseTest, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
@@ -88,6 +90,26 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
   }
 
+  protected def externalCallRouter(
+      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator
+  ): ExternalCallResponseRouter =
+    new ExternalCallResponseRouter(
+      ExampleTransactionFactory.submittingParticipant,
+      externalCallValidator,
+      PositiveInt.tryCreate(8),
+      loggerFactory,
+    )
+
+  /** Resolves every confirming party as hosted. */
+  protected lazy val identityTopologySnapshot: TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties)
+      }
+    snapshot
+  }
+
   /** Distinct view positions with values matching their names; ordered `left < unrelated < right <
     * secondRight` under [[ViewPosition.orderViewPosition]].
     */
@@ -147,6 +169,9 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       )(view)
   }
 
+  protected def participantView(view: TransactionView): ParticipantTransactionView =
+    ParticipantTransactionView.tryCreate(view)
+
   protected def validationResult(
       view: TransactionView,
       activenessResult: ViewActivenessResult = ViewActivenessResult(
@@ -156,7 +181,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       ),
   ): ViewValidationResult =
     ViewValidationResult(
-      ParticipantTransactionView.tryCreate(view),
+      participantView(view),
       activenessResult,
     )
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -20,11 +20,13 @@ import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.topology.ParticipantId
 import com.digitalasset.canton.topology.client.TopologySnapshot
+import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.{BaseTest, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
 import com.digitalasset.nonempty.NonEmpty
 
+import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 
 /** Shared fixtures for the external-call validation tests.
@@ -39,7 +41,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
   /** Provided by the mixing test, where an implicit `ExecutionContext` is available to build it. */
   protected def factory: ExampleTransactionFactory
 
-  def externalCallViewResult(
+  protected def externalCallViewResult(
       exerciseIndex: Int,
       result: ExternalCallResult,
       checkingParties: Set[LfPartyId],
@@ -52,7 +54,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       checkingParties = checkingParties,
     )
 
-  def withExternalCallResults(
+  protected def withExternalCallResults(
       view: TransactionView,
       results: Seq[ViewParticipantData.ViewExternalCallResult],
   ): TransactionView =
@@ -63,7 +65,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
   ) extends ExternalCallValidator {
     private val observedKeys =
-      new java.util.concurrent.ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
+      new ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
 
     def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq
 
@@ -71,7 +73,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
         key: DAMLe.ExternalCallKey,
         recordedOutput: Bytes,
     )(implicit
-        traceContext: com.digitalasset.canton.tracing.TraceContext
+        traceContext: TraceContext
     ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
       observedKeys.add(key -> recordedOutput)
       FutureUnlessShutdown.pure(
@@ -85,7 +87,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
         key: DAMLe.ExternalCallKey,
         recordedOutput: Bytes,
     )(implicit
-        traceContext: com.digitalasset.canton.tracing.TraceContext
+        traceContext: TraceContext
     ): FutureUnlessShutdown[ExternalCallValidator.Result] =
       FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
   }
@@ -99,6 +101,16 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       PositiveInt.tryCreate(8),
       loggerFactory,
     )
+
+  /** Resolves only `hostedParties` as hosted. */
+  protected def hostingTopologySnapshot(hostedParties: Set[LfPartyId]): TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties.intersect(hostedParties))
+      }
+    snapshot
+  }
 
   /** Resolves every confirming party as hosted. */
   protected lazy val identityTopologySnapshot: TopologySnapshot = {

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -7,6 +7,7 @@ import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.{
   CantonTimestamp,
   ParticipantTransactionView,
+  PathRollbackContextFactory,
   TransactionView,
   ViewConfirmationParameters,
   ViewParticipantData,
@@ -14,14 +15,14 @@ import com.digitalasset.canton.data.{
 }
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
-import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.{BaseTest, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
+import com.digitalasset.nonempty.NonEmpty
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 
 /** Shared fixtures for the external-call validation tests.
@@ -36,7 +37,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
   /** Provided by the mixing test, where an implicit `ExecutionContext` is available to build it. */
   protected def factory: ExampleTransactionFactory
 
-  protected def externalCallViewResult(
+  def externalCallViewResult(
       exerciseIndex: Int,
       result: ExternalCallResult,
       checkingParties: Set[LfPartyId],
@@ -49,7 +50,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       checkingParties = checkingParties,
     )
 
-  protected def withExternalCallResults(
+  def withExternalCallResults(
       view: TransactionView,
       results: Seq[ViewParticipantData.ViewExternalCallResult],
   ): TransactionView =
@@ -60,7 +61,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
       results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
   ) extends ExternalCallValidator {
     private val observedKeys =
-      new ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
+      new java.util.concurrent.ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
 
     def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq
 
@@ -68,7 +69,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
         key: DAMLe.ExternalCallKey,
         recordedOutput: Bytes,
     )(implicit
-        traceContext: TraceContext
+        traceContext: com.digitalasset.canton.tracing.TraceContext
     ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
       observedKeys.add(key -> recordedOutput)
       FutureUnlessShutdown.pure(
@@ -82,7 +83,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
         key: DAMLe.ExternalCallKey,
         recordedOutput: Bytes,
     )(implicit
-        traceContext: TraceContext
+        traceContext: com.digitalasset.canton.tracing.TraceContext
     ): FutureUnlessShutdown[ExternalCallValidator.Result] =
       FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
   }
@@ -157,6 +158,40 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
     ViewValidationResult(
       ParticipantTransactionView.tryCreate(view),
       activenessResult,
+    )
+
+  protected def defaultModelConformanceResult: ModelConformanceChecker.Result = {
+    val example = factory.MultipleRoots
+    ModelConformanceChecker.Result(
+      example.updateId,
+      WellFormedTransaction.checkOrThrow(
+        example.versionedSuffixedTransaction,
+        example.metadata,
+        WellFormedTransaction.WithSuffixesAndMerged,
+        PathRollbackContextFactory,
+      ),
+      unmergedTransactionsWithoutTopLevelRollbackNodes = Seq.empty,
+    )
+  }
+
+  protected def modelConformanceRecordedDisagreement(
+      view: TransactionView,
+      result: ExternalCallResult,
+      conflictingOutput: Bytes = otherExternalCallOutput.output,
+  ): ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect] =
+    ModelConformanceChecker.ErrorWithSubTransaction(
+      NonEmpty(
+        Seq,
+        ModelConformanceChecker.DAMLeError(
+          DAMLe.ExternalCallRecordedResultDisagreement(
+            key = DAMLe.ExternalCallKey.fromResult(result),
+            outputs = Set(result.output, conflictingOutput),
+          ),
+          view.viewHash,
+        ),
+      ),
+      validSubTransactionO = None,
+      validSubViewEffects = Seq.empty,
     )
 
   protected def assertRecordedDisagreementAlarms[A](count: Int = 1)(within: => A): A =

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -214,7 +214,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
   protected def modelConformanceRecordedDisagreement(
       view: TransactionView,
       result: ExternalCallResult,
-      conflictingOutput: Bytes = otherExternalCallOutput.output,
+      conflictingOutput: Bytes = otherExternalCallResult.output,
   ): ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect] =
     ModelConformanceChecker.ErrorWithSubTransaction(
       NonEmpty(

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -3,24 +3,40 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
-import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.{
+  CantonTimestamp,
   ParticipantTransactionView,
   TransactionView,
+  ViewConfirmationParameters,
   ViewParticipantData,
+  ViewPosition,
 }
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.{BaseTest, LfPartyId}
 import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.transaction.ExternalCallResult
 
-/** Shared fixtures for the external-call validation tests. */
-private[validation] trait ExternalCallValidationTestUtil {
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters.*
+
+/** Shared fixtures for the external-call validation tests.
+  *
+  * Mixed into the test bases so that fixtures depending on `loggerFactory` (and other [[BaseTest]]
+  * facilities) can live alongside the pure builders.
+  */
+private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
+
+  protected val requestId: RequestId = RequestId(CantonTimestamp.Epoch)
 
   /** Provided by the mixing test, where an implicit `ExecutionContext` is available to build it. */
   protected def factory: ExampleTransactionFactory
 
-  def externalCallViewResult(
+  protected def externalCallViewResult(
       exerciseIndex: Int,
       result: ExternalCallResult,
       checkingParties: Set[LfPartyId],
@@ -33,12 +49,77 @@ private[validation] trait ExternalCallValidationTestUtil {
       checkingParties = checkingParties,
     )
 
-  def withExternalCallResults(
+  protected def withExternalCallResults(
       view: TransactionView,
       results: Seq[ViewParticipantData.ViewExternalCallResult],
   ): TransactionView =
     TransactionView.Optics.viewParticipantDataUnsafe
       .modify(vpd => vpd.tryUnwrap.copy(externalCallResults = results))(view)
+
+  protected final class RecordingExternalCallValidator(
+      results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
+  ) extends ExternalCallValidator {
+    private val observedKeys =
+      new ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
+
+    def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq
+
+    override def validate(
+        key: DAMLe.ExternalCallKey,
+        recordedOutput: Bytes,
+    )(implicit
+        traceContext: TraceContext
+    ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
+      observedKeys.add(key -> recordedOutput)
+      FutureUnlessShutdown.pure(
+        results.getOrElse(key, ExternalCallValidator.Matched)
+      )
+    }
+  }
+
+  protected val matchingExternalCallValidator: ExternalCallValidator = new ExternalCallValidator {
+    override def validate(
+        key: DAMLe.ExternalCallKey,
+        recordedOutput: Bytes,
+    )(implicit
+        traceContext: TraceContext
+    ): FutureUnlessShutdown[ExternalCallValidator.Result] =
+      FutureUnlessShutdown.pure(ExternalCallValidator.Matched)
+  }
+
+  /** Distinct view positions with values matching their names; ordered `left < unrelated < right <
+    * secondRight` under [[ViewPosition.orderViewPosition]].
+    */
+  protected val leftViewPosition: ViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Left)))
+    )
+  protected val rightViewPosition: ViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+    )
+  protected val unrelatedViewPosition: ViewPosition =
+    ViewPosition(
+      List(
+        ViewPosition.MerkleSeqIndex(
+          List(
+            ViewPosition.MerkleSeqIndex.Direction.Left,
+            ViewPosition.MerkleSeqIndex.Direction.Left,
+          )
+        )
+      )
+    )
+  protected val secondRightViewPosition: ViewPosition =
+    ViewPosition(
+      List(
+        ViewPosition.MerkleSeqIndex(
+          List(
+            ViewPosition.MerkleSeqIndex.Direction.Left,
+            ViewPosition.MerkleSeqIndex.Direction.Right,
+          )
+        )
+      )
+    )
 
   protected val externalCallResult: ExternalCallResult = ExternalCallResult(
     extensionId = "extension",
@@ -51,6 +132,20 @@ private[validation] trait ExternalCallValidationTestUtil {
   protected val otherExternalCallOutput: ExternalCallResult =
     externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
 
+  protected def withConfirmers(
+      view: TransactionView,
+      confirmers: Set[LfPartyId],
+  ): TransactionView = {
+    val confirmationParameters = ViewConfirmationParameters.create(
+      informees = confirmers.map(_ -> NonNegativeInt.one).toMap,
+      threshold = NonNegativeInt.tryCreate(confirmers.size),
+    )
+    TransactionView.Optics.viewCommonDataUnsafe
+      .modify(commonData =>
+        commonData.tryUnwrap.copy(viewConfirmationParameters = confirmationParameters)
+      )(view)
+  }
+
   protected def validationResult(
       view: TransactionView,
       activenessResult: ViewActivenessResult = ViewActivenessResult(
@@ -62,5 +157,16 @@ private[validation] trait ExternalCallValidationTestUtil {
     ViewValidationResult(
       ParticipantTransactionView.tryCreate(view),
       activenessResult,
+    )
+
+  protected def assertRecordedDisagreementAlarms[A](count: Int = 1)(within: => A): A =
+    loggerFactory.assertLogs(
+      within,
+      Seq.fill(count) { (logEntry: LogEntry) =>
+        logEntry.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        )
+        logEntry.mdc should contain("requestId" -> requestId.toString)
+      }*
     )
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -64,7 +64,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
   protected final class RecordingExternalCallValidator(
       results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
   ) extends ExternalCallValidator {
-    private val observedKeys =
+    private val observedKeys: ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)] =
       new ConcurrentLinkedQueue[(DAMLe.ExternalCallKey, Bytes)]
 
     def observed: Seq[(DAMLe.ExternalCallKey, Bytes)] = observedKeys.asScala.toSeq

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -129,7 +129,7 @@ private[validation] trait ExternalCallValidationTestUtil { self: BaseTest =>
     output = Bytes.fromStringUtf8("output"),
   )
 
-  protected val otherExternalCallOutput: ExternalCallResult =
+  protected val otherExternalCallResult: ExternalCallResult =
     externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
 
   protected def withConfirmers(

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
@@ -1,0 +1,502 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import cats.data.EitherT
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.ViewPosition
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
+import com.digitalasset.canton.participant.protocol.ProtocolProcessor
+import com.digitalasset.canton.participant.protocol.conflictdetection.ConflictDetectionHelpers
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.protocol.ExampleTransactionFactory.{
+  signatory,
+  submitter,
+  submittingParticipant,
+}
+import com.digitalasset.canton.protocol.messages.{
+  ConfirmationResponse,
+  LocalAbstain,
+  LocalApprove,
+  LocalReject,
+}
+import com.digitalasset.canton.topology.ParticipantId
+import com.digitalasset.canton.topology.client.TopologySnapshot
+import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}
+
+final class TransactionConfirmationResponsesFactoryExternalCallTest
+    extends BaseTestWordSpec
+    with HasExecutionContext
+    with ExternalCallValidationTestUtil {
+
+  protected val factory =
+    new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
+
+  private lazy val sut =
+    responseFactory(ProtocolVersion.dev)
+
+  private def responseFactory(
+      protocolVersion: ProtocolVersion,
+      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator,
+  ): TransactionConfirmationResponsesFactory =
+    new TransactionConfirmationResponsesFactory(
+      submittingParticipant,
+      factory.psid.copy(protocolVersion = protocolVersion),
+      externalCallValidator,
+      PositiveInt.tryCreate(8),
+      loggerFactory,
+    )
+
+  private val defaultTopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties)
+      }
+    snapshot
+  }
+
+  private def transactionValidationResult(
+      viewValidationResults: Map[ViewPosition, ViewValidationResult],
+      authorizationResult: Map[ViewPosition, String] = Map.empty,
+      modelConformanceResultE: Either[
+        ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect],
+        ModelConformanceChecker.Result,
+      ] = Right(defaultModelConformanceResult),
+  ): TransactionValidationResult =
+    TransactionValidationResult(
+      updateId = defaultModelConformanceResult.updateId,
+      submitterMetadataO = None,
+      workflowIdO = None,
+      contractConsistencyResultE = Right(()),
+      authenticationResult = Map.empty,
+      authorizationResult = authorizationResult,
+      modelConformanceResultET = EitherT.fromEither[FutureUnlessShutdown](modelConformanceResultE),
+      internalConsistencyResultET = EitherT
+        .rightT[FutureUnlessShutdown, InternalConsistencyChecker.ErrorWithInternalConsistencyCheck](
+          ()
+        ),
+      consumedInputsOfHostedParties = Map.empty,
+      witnessed = Map.empty,
+      createdContracts = Map.empty,
+      transient = Map.empty,
+      activenessResult = ConflictDetectionHelpers.mkActivenessResult(),
+      viewValidationResults = viewValidationResults,
+      timeValidationResultE = Right(()),
+      hostedWitnesses = Set.empty,
+      replayCheckResult = None,
+      validatedExternalTransactionHash = None,
+      commitAfterFailedActivenessCheck = false,
+    )
+
+  private def createResponses(
+      transactionValidationResult: TransactionValidationResult,
+      responseFactory: TransactionConfirmationResponsesFactory = sut,
+      topologySnapshot: TopologySnapshot = defaultTopologySnapshot,
+      malformedPayloads: Seq[ProtocolProcessor.MalformedPayload] = Seq.empty,
+  ): Seq[ConfirmationResponse] =
+    responseFactory
+      .createConfirmationResponses(
+        requestId,
+        malformedPayloads,
+        transactionValidationResult,
+        topologySnapshot,
+      )
+      .futureValueUS
+      .value
+      .responses
+
+  private def conflictingExternalCallViews: Map[ViewPosition, ViewValidationResult] = {
+    val example = factory.MultipleRoots
+    val confirmers = Set(submitter, signatory)
+    val left = withExternalCallResults(
+      withConfirmers(example.rootViews(4), confirmers),
+      Seq(
+        externalCallViewResult(
+          exerciseIndex = 0,
+          result = externalCallResult,
+          checkingParties = Set(submitter),
+        )
+      ),
+    )
+    val right = withExternalCallResults(
+      withConfirmers(example.rootViews(5), confirmers),
+      Seq(
+        externalCallViewResult(
+          exerciseIndex = 1,
+          result = otherExternalCallOutput,
+          checkingParties = Set(submitter),
+        )
+      ),
+    )
+
+    Map(
+      leftViewPosition -> validationResult(left),
+      rightViewPosition -> validationResult(right),
+    )
+  }
+
+  "TransactionConfirmationResponsesFactory" should {
+    "split external-call disagreements from the general verdict by party" in {
+      val responses =
+        assertRecordedDisagreementAlarms() {
+          createResponses(transactionValidationResult(conflictingExternalCallViews))
+        }
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+
+      leftResponses should have size 2
+      inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(leftResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
+    }
+
+    "alarm on visible recorded external-call disagreements without hosted confirmers" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(signatory),
+          )
+        ),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = otherExternalCallOutput,
+            checkingParties = Set(signatory),
+          )
+        ),
+      )
+      val noHostedConfirmersTopologySnapshot = {
+        val snapshot = mock[TopologySnapshot]
+        when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+          .thenReturn(FutureUnlessShutdown.pure(Set.empty))
+        snapshot
+      }
+
+      val responsesO = assertRecordedDisagreementAlarms() {
+        sut
+          .createConfirmationResponses(
+            requestId,
+            Seq.empty,
+            transactionValidationResult(
+              Map(
+                leftViewPosition -> validationResult(left),
+                rightViewPosition -> validationResult(right),
+              )
+            ),
+            noHostedConfirmersTopologySnapshot,
+          )
+          .futureValueUS
+      }
+
+      responsesO shouldBe None
+    }
+
+    "alarm on visible recorded external-call disagreements with malformed payloads" in {
+      val responses = loggerFactory.assertLogs(
+        createResponses(
+          transactionValidationResult(conflictingExternalCallViews),
+          malformedPayloads = Seq(ProtocolProcessor.IncompleteLightViewTree(ViewPosition.root)),
+        ),
+        { (logEntry: LogEntry) =>
+          logEntry.shouldBeCantonErrorCode(
+            ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+          )
+          logEntry.mdc should contain("requestId" -> requestId.toString)
+        },
+        { (logEntry: LogEntry) =>
+          logEntry.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.Payloads)
+          logEntry.mdc should contain("requestId" -> requestId.toString)
+        },
+      )
+
+      responses should have size 1
+      inside(responses.loneElement) {
+        case ConfirmationResponse(None, reject: LocalReject, parties) =>
+          reject.isMalformed shouldBe true
+          parties shouldBe Set.empty
+      }
+    }
+
+    "abstain when locally responsible validation cannot obtain comparable output bytes" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val key = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+      val validator = new RecordingExternalCallValidator(
+        Map(key -> ExternalCallValidator.UnableToValidate("extension service is not configured"))
+      )
+
+      val responses = createResponses(
+        transactionValidationResult(Map(leftViewPosition -> validationResult(view))),
+        responseFactory = responseFactory(ProtocolVersion.dev, validator),
+      )
+
+      validator.observed shouldBe Seq(key -> externalCallResult.output)
+      inside(responses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, abstain: LocalAbstain, _) =>
+          abstain.reason.message should include("Cannot perform all validations")
+          abstain.reason.message should include("extension service is not configured")
+      }
+      inside(responses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
+    }
+
+    "not run local external-call validation when a malformed verdict already wins" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter)
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val key = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+      val validator = new RecordingExternalCallValidator(
+        Map(key -> ExternalCallValidator.UnableToValidate("extension service is not configured"))
+      )
+
+      val responses = loggerFactory.assertLogs(
+        createResponses(
+          transactionValidationResult(
+            Map(leftViewPosition -> validationResult(view)),
+            authorizationResult = Map(leftViewPosition -> "authorization failure"),
+          ),
+          responseFactory = responseFactory(ProtocolVersion.dev, validator),
+        ),
+        _.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.MalformedRequest),
+      )
+
+      validator.observed shouldBe Seq.empty
+      inside(responses.loneElement) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
+        reject.isMalformed shouldBe true
+        parties shouldBe Set.empty
+      }
+    }
+
+    "preserve recorded external-call disagreements over ordinary non-malformed rejects" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 1,
+            result = otherExternalCallOutput,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val inactiveInput = left.viewParticipantData.tryUnwrap.coreInputs.keySet.headOption.value
+      val key = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+      val validator = new RecordingExternalCallValidator(
+        Map(key -> ExternalCallValidator.UnableToValidate("extension service is not configured"))
+      )
+
+      val responses = assertRecordedDisagreementAlarms() {
+        createResponses(
+          transactionValidationResult(
+            Map(
+              leftViewPosition -> validationResult(
+                left,
+                ViewActivenessResult(
+                  inactiveContracts = Set(inactiveInput),
+                  alreadyLockedContracts = Set.empty,
+                  existingContracts = Set.empty,
+                ),
+              ),
+              rightViewPosition -> validationResult(right),
+            )
+          ),
+          responseFactory = responseFactory(ProtocolVersion.dev, validator),
+        )
+      }
+
+      validator.observed shouldBe Seq.empty
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+      leftResponses should have size 2
+      inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(leftResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should not include "inconsistent external call results"
+      }
+      responses.exists {
+        case ConfirmationResponse(_, reject: LocalReject, parties) =>
+          reject.isMalformed && parties.isEmpty
+        case _ => false
+      } shouldBe false
+    }
+
+    "prefer malformed verdicts over external-call disagreement responses" in {
+      val responses = loggerFactory.assertLogs(
+        createResponses(
+          transactionValidationResult(
+            conflictingExternalCallViews,
+            authorizationResult = Map(leftViewPosition -> "authorization failure"),
+          )
+        ),
+        _.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        ),
+        _.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.MalformedRequest),
+      )
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+
+      inside(leftResponses.loneElement) {
+        case ConfirmationResponse(_, reject: LocalReject, confirmingParties) =>
+          reject.isMalformed shouldBe true
+          confirmingParties shouldBe Set.empty
+      }
+    }
+
+    "route recorded external-call result disagreements by checking party" in {
+      val viewValidationResults = conflictingExternalCallViews
+      val leftView = viewValidationResults(leftViewPosition).view.unwrap
+
+      val responses = assertRecordedDisagreementAlarms() {
+        createResponses(
+          transactionValidationResult(
+            viewValidationResults,
+            modelConformanceResultE =
+              Left(modelConformanceRecordedDisagreement(leftView, externalCallResult)),
+          )
+        )
+      }
+
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+      leftResponses should have size 2
+      inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(leftResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
+      responses.exists {
+        case ConfirmationResponse(_, reject: LocalReject, confirmingParties) =>
+          reject.isMalformed && confirmingParties.isEmpty
+        case _ => false
+      } shouldBe false
+    }
+
+    "route recorded external-call replay ambiguity for disjoint checking parties" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val left = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val right = withExternalCallResults(
+        withConfirmers(example.rootViews(5), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 1,
+            result = otherExternalCallOutput,
+            checkingParties = Set(signatory),
+          )
+        ),
+      )
+
+      val responses = assertRecordedDisagreementAlarms() {
+        createResponses(
+          transactionValidationResult(
+            Map(
+              leftViewPosition -> validationResult(left),
+              rightViewPosition -> validationResult(right),
+            ),
+            modelConformanceResultE = Left(
+              modelConformanceRecordedDisagreement(left, externalCallResult)
+            ),
+          )
+        )
+      }
+
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+      leftResponses should have size 2
+      inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(leftResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
+
+      val rightResponses = responses.filter(_.viewPositionO.contains(rightViewPosition))
+      rightResponses should have size 2
+      inside(rightResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(rightResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
+
+      responses.exists {
+        case ConfirmationResponse(_, reject: LocalReject, confirmingParties) =>
+          reject.isMalformed && confirmingParties.isEmpty
+        case _ => false
+      } shouldBe false
+    }
+
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
@@ -23,10 +23,10 @@ import com.digitalasset.canton.protocol.messages.{
   LocalApprove,
   LocalReject,
 }
-import com.digitalasset.canton.topology.ParticipantId
 import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.version.ProtocolVersion
-import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}
+import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext}
+import org.scalatest.Assertion
 
 final class TransactionConfirmationResponsesFactoryExternalCallTest
     extends BaseTestWordSpec
@@ -37,14 +37,9 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
     new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
 
   private lazy val sut: TransactionConfirmationResponsesFactory =
-    responseFactory(ProtocolVersion.dev)
-
-  private def responseFactory(
-      protocolVersion: ProtocolVersion
-  ): TransactionConfirmationResponsesFactory =
     new TransactionConfirmationResponsesFactory(
       submittingParticipant,
-      factory.psid.copy(protocolVersion = protocolVersion),
+      factory.psid.copy(protocolVersion = ProtocolVersion.dev),
       loggerFactory,
     )
 
@@ -102,11 +97,10 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
 
   private def createResponses(
       transactionValidationResult: TransactionValidationResult,
-      responseFactory: TransactionConfirmationResponsesFactory = sut,
       topologySnapshot: TopologySnapshot = identityTopologySnapshot,
       malformedPayloads: Seq[ProtocolProcessor.MalformedPayload] = Seq.empty,
   ): Seq[ConfirmationResponse] =
-    responseFactory
+    sut
       .createConfirmationResponses(
         requestId,
         malformedPayloads,
@@ -116,6 +110,13 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       .futureValueUS
       .value
       .responses
+
+  private def assertNoMalformedResponses(responses: Seq[ConfirmationResponse]): Assertion =
+    responses.filter {
+      case ConfirmationResponse(_, reject: LocalReject, parties) =>
+        reject.isMalformed && parties.isEmpty
+      case _ => false
+    } shouldBe empty
 
   private def conflictingExternalCallViews: Map[ViewPosition, ViewValidationResult] = {
     val example = factory.MultipleRoots
@@ -190,12 +191,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
           )
         ),
       )
-      val noHostedConfirmersTopologySnapshot = {
-        val snapshot = mock[TopologySnapshot]
-        when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
-          .thenReturn(FutureUnlessShutdown.pure(Set.empty))
-        snapshot
-      }
+      val noHostedConfirmersTopologySnapshot = hostingTopologySnapshot(Set.empty)
 
       val responsesO = assertRecordedDisagreementAlarms() {
         sut
@@ -369,7 +365,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       }
 
       // The disagreeing occurrences are excluded from re-validation entirely.
-      validator.observed shouldBe Seq.empty
+      validator.observed shouldBe empty
       val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
       leftResponses should have size 2
       inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
@@ -382,11 +378,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
           reject.isMalformed shouldBe false
           reject.reason.message should not include "inconsistent external call results"
       }
-      responses.exists {
-        case ConfirmationResponse(_, reject: LocalReject, parties) =>
-          reject.isMalformed && parties.isEmpty
-        case _ => false
-      } shouldBe false
+      assertNoMalformedResponses(responses)
     }
 
     "prefer malformed verdicts over external-call disagreement responses" in {
@@ -436,11 +428,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         case ConfirmationResponse(_, LocalApprove(), _) =>
           succeed
       }
-      responses.exists {
-        case ConfirmationResponse(_, reject: LocalReject, confirmingParties) =>
-          reject.isMalformed && confirmingParties.isEmpty
-        case _ => false
-      } shouldBe false
+      assertNoMalformedResponses(responses)
     }
 
     "route recorded external-call replay ambiguity for disjoint checking parties" in {
@@ -505,11 +493,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
           succeed
       }
 
-      responses.exists {
-        case ConfirmationResponse(_, reject: LocalReject, confirmingParties) =>
-          reject.isMalformed && confirmingParties.isEmpty
-        case _ => false
-      } shouldBe false
+      assertNoMalformedResponses(responses)
     }
 
     "prefer replay disagreements over concurrent re-validation mismatches for the same party and view" in {

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.canton.participant.protocol.validation
 
 import cats.data.EitherT
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.data.ViewPosition
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.LogEntry
@@ -34,33 +33,25 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
     with HasExecutionContext
     with ExternalCallValidationTestUtil {
 
-  protected val factory =
+  protected val factory: ExampleTransactionFactory =
     new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))()
 
-  private lazy val sut =
+  private lazy val sut: TransactionConfirmationResponsesFactory =
     responseFactory(ProtocolVersion.dev)
 
   private def responseFactory(
-      protocolVersion: ProtocolVersion,
-      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator,
+      protocolVersion: ProtocolVersion
   ): TransactionConfirmationResponsesFactory =
     new TransactionConfirmationResponsesFactory(
       submittingParticipant,
       factory.psid.copy(protocolVersion = protocolVersion),
-      externalCallValidator,
-      PositiveInt.tryCreate(8),
       loggerFactory,
     )
 
-  private val defaultTopologySnapshot = {
-    val snapshot = mock[TopologySnapshot]
-    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
-      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
-        FutureUnlessShutdown.pure(parties)
-      }
-    snapshot
-  }
-
+  /** Builds the transaction validation result the way `doParallelChecks` does: the external-call
+    * check runs over the given views (eagerly, so its alarms are emitted here) and its outcome is
+    * embedded as precomputed data for the factory.
+    */
   private def transactionValidationResult(
       viewValidationResults: Map[ViewPosition, ViewValidationResult],
       authorizationResult: Map[ViewPosition, String] = Map.empty,
@@ -68,7 +59,20 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         ModelConformanceChecker.ErrorWithSubTransaction[ViewAbsoluteLedgerEffect],
         ModelConformanceChecker.Result,
       ] = Right(defaultModelConformanceResult),
-  ): TransactionValidationResult =
+      externalCallValidator: ExternalCallValidator = matchingExternalCallValidator,
+      topologySnapshot: TopologySnapshot = identityTopologySnapshot,
+      runValidation: Boolean = true,
+  ): TransactionValidationResult = {
+    val externalCallValidationResult = externalCallRouter(externalCallValidator)
+      .check(
+        requestId,
+        viewValidationResults.view.mapValues(_.view).toMap,
+        topologySnapshot,
+        FutureUnlessShutdown.pure(modelConformanceResultE.swap.toSeq.flatMap(_.nonAbortErrors)),
+        runValidation,
+      )
+      .futureValueUS
+
     TransactionValidationResult(
       updateId = defaultModelConformanceResult.updateId,
       submitterMetadataO = None,
@@ -81,6 +85,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         .rightT[FutureUnlessShutdown, InternalConsistencyChecker.ErrorWithInternalConsistencyCheck](
           ()
         ),
+      externalCallValidationResultF = FutureUnlessShutdown.pure(externalCallValidationResult),
       consumedInputsOfHostedParties = Map.empty,
       witnessed = Map.empty,
       createdContracts = Map.empty,
@@ -93,11 +98,12 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       validatedExternalTransactionHash = None,
       commitAfterFailedActivenessCheck = false,
     )
+  }
 
   private def createResponses(
       transactionValidationResult: TransactionValidationResult,
       responseFactory: TransactionConfirmationResponsesFactory = sut,
-      topologySnapshot: TopologySnapshot = defaultTopologySnapshot,
+      topologySnapshot: TopologySnapshot = identityTopologySnapshot,
       malformedPayloads: Seq[ProtocolProcessor.MalformedPayload] = Seq.empty,
   ): Seq[ConfirmationResponse] =
     responseFactory
@@ -200,7 +206,8 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
               Map(
                 leftViewPosition -> validationResult(left),
                 rightViewPosition -> validationResult(right),
-              )
+              ),
+              topologySnapshot = noHostedConfirmersTopologySnapshot,
             ),
             noHostedConfirmersTopologySnapshot,
           )
@@ -213,7 +220,9 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
     "alarm on visible recorded external-call disagreements with malformed payloads" in {
       val responses = loggerFactory.assertLogs(
         createResponses(
-          transactionValidationResult(conflictingExternalCallViews),
+          // Mirrors doParallelChecks: with malformed payloads, the external-call check still
+          // runs (and alarms), but skips the re-validation.
+          transactionValidationResult(conflictingExternalCallViews, runValidation = false),
           malformedPayloads = Seq(ProtocolProcessor.IncompleteLightViewTree(ViewPosition.root)),
         ),
         { (logEntry: LogEntry) =>
@@ -255,8 +264,10 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       )
 
       val responses = createResponses(
-        transactionValidationResult(Map(leftViewPosition -> validationResult(view))),
-        responseFactory = responseFactory(ProtocolVersion.dev, validator),
+        transactionValidationResult(
+          Map(leftViewPosition -> validationResult(view)),
+          externalCallValidator = validator,
+        )
       )
 
       validator.observed shouldBe Seq(key -> externalCallResult.output)
@@ -271,7 +282,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       }
     }
 
-    "not run local external-call validation when a malformed verdict already wins" in {
+    "produce only the malformed verdict although re-validation ran concurrently" in {
       val example = factory.MultipleRoots
       val confirmers = Set(submitter)
       val view = withExternalCallResults(
@@ -294,13 +305,15 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
           transactionValidationResult(
             Map(leftViewPosition -> validationResult(view)),
             authorizationResult = Map(leftViewPosition -> "authorization failure"),
-          ),
-          responseFactory = responseFactory(ProtocolVersion.dev, validator),
+            externalCallValidator = validator,
+          )
         ),
         _.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.MalformedRequest),
       )
 
-      validator.observed shouldBe Seq.empty
+      // Re-validation runs concurrently with the other checks and cannot know that a malformed
+      // verdict will win; its outcome is simply not routed into the malformed response.
+      validator.observed shouldBe Seq(key -> externalCallResult.output)
       inside(responses.loneElement) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
         reject.isMalformed shouldBe true
         parties shouldBe Set.empty
@@ -349,12 +362,13 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
                 ),
               ),
               rightViewPosition -> validationResult(right),
-            )
-          ),
-          responseFactory = responseFactory(ProtocolVersion.dev, validator),
+            ),
+            externalCallValidator = validator,
+          )
         )
       }
 
+      // The disagreeing occurrences are excluded from re-validation entirely.
       validator.observed shouldBe Seq.empty
       val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
       leftResponses should have size 2
@@ -496,6 +510,59 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
           reject.isMalformed && confirmingParties.isEmpty
         case _ => false
       } shouldBe false
+    }
+
+    "prefer replay disagreements over concurrent re-validation mismatches for the same party and view" in {
+      val example = factory.MultipleRoots
+      val confirmers = Set(submitter, signatory)
+      val view = withExternalCallResults(
+        withConfirmers(example.rootViews(4), confirmers),
+        Seq(
+          externalCallViewResult(
+            exerciseIndex = 0,
+            result = externalCallResult,
+            checkingParties = Set(submitter),
+          )
+        ),
+      )
+      val key = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+      // Re-validation cannot know about the replay disagreement (it runs concurrently with the
+      // reinterpretation), so the same occurrence yields both a replay disagreement and a
+      // re-validation mismatch for the checking party.
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          key -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallOutput.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+
+      val responses = createResponses(
+        transactionValidationResult(
+          Map(leftViewPosition -> validationResult(view)),
+          modelConformanceResultE = Left(
+            modelConformanceRecordedDisagreement(view, externalCallResult)
+          ),
+          externalCallValidator = validator,
+        )
+      )
+
+      // The occurrence was re-validated, but the disagreement rejection takes precedence: the
+      // checking party receives exactly one external-call rejection for the view.
+      validator.observed shouldBe Seq(key -> externalCallResult.output)
+      val leftResponses = responses.filter(_.viewPositionO.contains(leftViewPosition))
+      leftResponses should have size 2
+      leftResponses.count(_.confirmingParties == Set(submitter)) shouldBe 1
+      inside(leftResponses.find(_.confirmingParties == Set(submitter)).value) {
+        case ConfirmationResponse(_, reject: LocalReject, _) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message should include("inconsistent external call results")
+      }
+      inside(leftResponses.find(_.confirmingParties == Set(signatory)).value) {
+        case ConfirmationResponse(_, LocalApprove(), _) =>
+          succeed
+      }
     }
 
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactoryExternalCallTest.scala
@@ -136,7 +136,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       Seq(
         externalCallViewResult(
           exerciseIndex = 1,
-          result = otherExternalCallOutput,
+          result = otherExternalCallResult,
           checkingParties = Set(submitter),
         )
       ),
@@ -186,7 +186,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         Seq(
           externalCallViewResult(
             exerciseIndex = 0,
-            result = otherExternalCallOutput,
+            result = otherExternalCallResult,
             checkingParties = Set(signatory),
           )
         ),
@@ -334,7 +334,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         Seq(
           externalCallViewResult(
             exerciseIndex = 1,
-            result = otherExternalCallOutput,
+            result = otherExternalCallResult,
             checkingParties = Set(submitter),
           )
         ),
@@ -449,7 +449,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
         Seq(
           externalCallViewResult(
             exerciseIndex = 1,
-            result = otherExternalCallOutput,
+            result = otherExternalCallResult,
             checkingParties = Set(signatory),
           )
         ),
@@ -516,7 +516,7 @@ final class TransactionConfirmationResponsesFactoryExternalCallTest
       val validator = new RecordingExternalCallValidator(
         Map(
           key -> ExternalCallValidator.Mismatched(
-            computedOutput = otherExternalCallOutput.output,
+            computedOutput = otherExternalCallResult.output,
             recordedOutput = externalCallResult.output,
           )
         )


### PR DESCRIPTION
## Summary

This is the concluding PR (8 of 8) in the external-call runtime-integration series tracked in #513, stacked on PR 7.

The external-call stack (#513): #506 added the transaction-side representation for recording external-call results; #514 added the LF `EXTERNAL_CALL` builtin surface; #518 wired it into Speedy and the LF engine; #522 added transaction protobuf encoding/decoding; #526 added Canton protocol serialization for recorded results; #537 added the participant-side extension-service client. #541 implemented the remaining runtime integration as one PR; this series splits #541 into 8 independently reviewable PRs (each < 1000 lines) and supersedes it.

This PR runs external-call validation as one of the parallel validation suites of transaction processing and translates its outcome into confirmation responses — completing the Canton-side runtime integration.

## Scope

This PR adds:

- the external-call validation suite: `ExternalCallResponseRouter.check` is invoked from `doParallelChecks` in `TransactionProcessingSteps`, following the `ModelConformanceChecker.check` pattern (kicked off there, awaited when responses are created). It resolves the hosted confirming parties, checks recorded-result consistency (`ExternalCallConsistencyChecker`), alarms on visible disagreements, re-validates undisputed recorded results against the extension service concurrently with the reinterpretation, and routes replay disagreements chained on the model-conformance errors. Requests without recorded external-call results short-circuit without topology lookups. The precomputed result travels through `TransactionValidationResult`.
- external-call handling in `TransactionConfirmationResponsesFactory`, which stays a pure translation layer: one nested def splits a view's verdict per party from the precomputed result (disagreement rejections, re-validation rejections, abstentions, remainder verdict), with rejections taking precedence per party and view.
- the validator wiring that activates external-call validation in transaction processing (`TransactionProcessor` → `TransactionProcessingSteps`, `ConnectedSynchronizer`, `CantonSyncService`, `SynchronizerConnectionsManager`, and the `ParticipantNode` validator binding)
- tests: the router check-suite tests and the confirmation-responses factory translation tests

## Out of scope

Nothing further in the Canton-side stack — this PR completes it. The feature remains `ProtocolVersion.dev`-gated and is inert unless an extension service is configured.

## Coordination

This series supersedes #541. #537 is merged; merge this series in order PR 1 → PR 8 (each rebased onto `main` as the previous lands).

Companion Daml PR: https://github.com/digital-asset/daml/pull/23099. It can remain open for parallel review, but after this Canton series lands it must be amended to pin a normal Canton snapshot/artifact containing these runtime constants and error contracts, with Daml verification rerun against that published artifact before it merges.

## Stacking & review

This PR is stacked on PR 7, so its diff against `main` is **cumulative** — it shows the whole feature. The incremental change for this PR alone:
https://github.com/digital-asset/canton/compare/zenith-network:angelol/external-call-06-split-pr7-router...zenith-network:angelol/external-call-06-split-pr8-factory

Note: rebased onto main HEAD (post-#552); the temporary cherry-picks of PR 6 / PR 7 review fixes are gone (their content now reaches this branch through the stack).

Refs #513.
