### PR TITLE
feat(external-call): minimal protocol integration

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/ParticipantNode.scala
@@ -35,7 +35,10 @@ import com.digitalasset.canton.participant.admin.*
 import com.digitalasset.canton.participant.admin.grpc.*
 import com.digitalasset.canton.participant.admin.party.{PartyReplicationEndpoints, PartyReplicator}
 import com.digitalasset.canton.participant.config.*
-import com.digitalasset.canton.participant.extension.ExtensionServiceManager
+import com.digitalasset.canton.participant.extension.{
+  ExtensionServiceExternalCallValidator,
+  ExtensionServiceManager,
+}
 import com.digitalasset.canton.participant.health.admin.ParticipantStatus
 import com.digitalasset.canton.participant.ledger.api.{
   AcsCommitmentPublicationPostProcessor,
@@ -49,6 +52,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
   CommandDeduplicatorImpl,
   InFlightSubmissionTracker,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.{AcsCommitmentProcessor, PruningProcessor}
 import com.digitalasset.canton.participant.replica.ParticipantReplicaManager
 import com.digitalasset.canton.participant.scheduler.{
@@ -774,6 +778,9 @@ class ParticipantNodeBootstrap(
             )
         )
 
+        externalCallValidator: ExternalCallValidator =
+          ExtensionServiceExternalCallValidator.create(extensionServiceManagerO)
+
         // Sync Service
         sync = CantonSyncService.create(
           participantId,
@@ -804,6 +811,7 @@ class ParticipantNodeBootstrap(
           connectedSynchronizersLookupContainer,
           () => triggerDeclarativeChange(),
           trafficEnforcementBackendO,
+          externalCallValidator,
         )
 
         _ <-

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -927,8 +927,10 @@ class TransactionProcessingSteps(
           if (malformedPayloads.nonEmpty) {
             // With malformed payloads, the responses factory takes the
             // constructResponsesForMalformedPayloads path and never awaits the check (only its
-            // alarms matter there); drain it so that failures are logged rather than silently
-            // discarded.
+            // alarms matter there). The check is currently synchronous in that case (it makes no
+            // validator calls without runValidation), so the drain only matters should the check
+            // ever become asynchronous there; it stays so that failures would be logged rather
+            // than silently discarded.
             FutureUnlessShutdownUtil.doNotAwaitUnlessShutdown(
               checkResultF,
               "external-call check failed for a request with malformed payloads",

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -94,7 +94,13 @@ import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.topology.{ParticipantId, PhysicalSynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
-import com.digitalasset.canton.util.{EitherTUtil, ErrorUtil, LoggerUtil, RoseTree}
+import com.digitalasset.canton.util.{
+  EitherTUtil,
+  ErrorUtil,
+  FutureUnlessShutdownUtil,
+  LoggerUtil,
+  RoseTree,
+}
 import com.digitalasset.canton.version.ProtocolVersion
 import com.digitalasset.canton.{
   LedgerSubmissionId,
@@ -131,6 +137,7 @@ class TransactionProcessingSteps(
     createNodeEnricher: ContractEnricher,
     authorizationValidator: AuthorizationValidator,
     internalConsistencyChecker: InternalConsistencyChecker,
+    externalCallCheck: ExternalCallCheck,
     tracker: CommandProgressTracker,
     protected val loggerFactory: NamedLoggerFactory,
     futureSupervisor: FutureSupervisor,
@@ -898,12 +905,44 @@ class TransactionProcessingSteps(
             }
         )
 
+        // The external-call check re-validates recorded external-call results against the
+        // extension service. Like the model conformance check, it is kicked off here and only
+        // awaited when the confirmation responses are created, so that its network I/O runs
+        // concurrently with the remaining checks.
+        externalCallCheckResultF = {
+          val participantViews = parsedRequest.rootViewTrees.forgetNE
+            .flatMap(viewTree => viewTree.view.allSubviewsWithPosition(viewTree.viewPosition))
+            .map { case (view, viewPosition) =>
+              // The represented view of each root view tree is fully unblinded
+              // (FullTransactionViewTree invariant), so tryCreate cannot throw for it or any of
+              // its subviews (computeValidationResult below relies on the same invariant).
+              viewPosition -> checked(ParticipantTransactionView.tryCreate(view))
+            }
+            .toMap
+          val checkResultF = externalCallCheck.check(
+            requestId,
+            participantViews,
+            runValidation = malformedPayloads.isEmpty,
+          )
+          if (malformedPayloads.nonEmpty) {
+            // Responses for malformed requests are constructed without awaiting the check
+            // (only its alarms matter there); drain it so that failures are logged rather
+            // than silently discarded.
+            FutureUnlessShutdownUtil.doNotAwaitUnlessShutdown(
+              checkResultF,
+              "external-call check failed for a request with malformed payloads",
+            )
+          }
+          checkResultF
+        }
+
       } yield ParallelChecksResult(
         authenticationResult,
         consistencyResultE,
         authorizationResult,
         conformanceResultET,
         internalConsistencyResultET,
+        externalCallCheckResultF,
         timeValidationE,
         replayCheckResult,
       )
@@ -976,6 +1015,7 @@ class TransactionProcessingSteps(
         authorizationResult = parallelChecksResult.authorizationResult,
         modelConformanceResultET = parallelChecksResult.conformanceResultET,
         internalConsistencyResultET = parallelChecksResult.internalConsistencyResultET,
+        externalCallCheckResultF = parallelChecksResult.externalCallCheckResultF,
         consumedInputsOfHostedParties = usedAndCreated.contracts.consumedInputsOfHostedStakeholders,
         witnessed = usedAndCreated.contracts.witnessed,
         createdContracts = usedAndCreated.contracts.created,
@@ -1637,6 +1677,7 @@ object TransactionProcessingSteps {
         ErrorWithInternalConsistencyCheck,
         Unit,
       ],
+      externalCallCheckResultF: FutureUnlessShutdown[ExternalCallCheck.Result],
       timeValidationResultE: Either[TimeCheckFailure, Unit],
       replayCheckResult: Option[String],
   ) {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -925,9 +925,10 @@ class TransactionProcessingSteps(
             runValidation = malformedPayloads.isEmpty,
           )
           if (malformedPayloads.nonEmpty) {
-            // Responses for malformed requests are constructed without awaiting the check
-            // (only its alarms matter there); drain it so that failures are logged rather
-            // than silently discarded.
+            // With malformed payloads, the responses factory takes the
+            // constructResponsesForMalformedPayloads path and never awaits the check (only its
+            // alarms matter there); drain it so that failures are logged rather than silently
+            // discarded.
             FutureUnlessShutdownUtil.doNotAwaitUnlessShutdown(
               checkResultF,
               "external-call check failed for a request with malformed payloads",

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
@@ -41,6 +41,8 @@ import com.digitalasset.canton.participant.protocol.submission.{
 }
 import com.digitalasset.canton.participant.protocol.validation.{
   AuthorizationValidator,
+  ExternalCallCheck,
+  ExternalCallValidator,
   InternalConsistencyChecker,
   ModelConformanceChecker,
   TransactionConfirmationResponsesFactory,
@@ -87,6 +89,7 @@ class TransactionProcessor(
     promiseFactory: PromiseUnlessShutdownFactory,
     participantNodeParameters: ParticipantNodeParameters,
     trafficEnforcementBackendO: Option[TrafficEnforcementBackend],
+    externalCallValidator: ExternalCallValidator,
 )(implicit val ec: ExecutionContext)
     extends ProtocolProcessor[
       TransactionProcessingSteps.SubmissionParam,
@@ -125,6 +128,11 @@ class TransactionProcessor(
         InternalConsistencyChecker(
           participantId,
           staticSynchronizerParameters.protocolVersion,
+          loggerFactory,
+        ),
+        new ExternalCallCheck(
+          externalCallValidator,
+          participantNodeParameters.general.batchingConfig.parallelism,
           loggerFactory,
         ),
         commandProgressTracker,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -23,15 +23,16 @@ import scala.concurrent.ExecutionContext
   *
   * The check has two parts:
   *   - consistency: whether occurrences of the same external call recorded across the request agree
-  *     on their output ([[ExternalCallConsistencyChecker]]); every visible disagreement is alarmed,
+  *     on their output ([[ExternalCallConsistencyChecker]]),
   *   - re-validation: whether the (undisputed) recorded outputs agree with the extension service,
   *     re-executing each distinct call once ([[ExternalCallValidator]]).
   *
-  * The outcome is a single per-request `ExternalCallCheck.Result`: a disagreement from either part
-  * rejects the request on behalf of all hosted confirming parties, and a recorded result that
-  * cannot be re-validated leads to an abstention instead of an approval (see
-  * [[TransactionConfirmationResponsesFactory]]). Disagreements within the replay data of a single
-  * reinterpretation already surface as model-conformance errors independently of this check.
+  * Every disagreement found by either part is alarmed. The outcome is a single per-request
+  * `ExternalCallCheck.Result`: a disagreement from either part rejects the request on behalf of all
+  * hosted confirming parties, and a recorded result that cannot be re-validated leads to an
+  * abstention instead of an approval (see [[TransactionConfirmationResponsesFactory]]).
+  * Disagreements within the replay data of a single reinterpretation already surface as
+  * model-conformance errors independently of this check.
   *
   * @param externalCallValidator
   *   The validator used to re-run external calls against the extension service.
@@ -81,11 +82,9 @@ class ExternalCallCheck(
       // rejects the request, so only the party-independent visible inconsistencies are consulted.
       val consistency = ExternalCallConsistencyChecker.check(views, Set.empty)
 
-      consistency.visibleInconsistencies.foreach { inconsistency =>
-        ExternalCallValidationError.ExternalCallResultDisagreementAlarm
-          .Warn(s"Observed inconsistent external call results: ${inconsistency.description}")
-          .logWithContext(Map("requestId" -> requestId.toString))
-      }
+      // Every visible inconsistency is alarmed: only the first one is propagated into the
+      // rejection, so the confirmation-responses factory reports just that one.
+      consistency.visibleInconsistencies.foreach(alarmDisagreement(requestId, _))
 
       // The checker sorts the inconsistencies, so the reported disagreement is deterministic.
       consistency.visibleInconsistencies.headOption match {
@@ -94,7 +93,7 @@ class ExternalCallCheck(
         case None if !runValidation =>
           FutureUnlessShutdown.pure(Passed)
         case None =>
-          validateRecordedResults(recordedResults)
+          validateRecordedResults(requestId, recordedResults)
       }
     }
   }
@@ -106,7 +105,8 @@ class ExternalCallCheck(
     * deterministic.
     */
   private def validateRecordedResults(
-      recordedResults: Seq[(ViewPosition, ViewParticipantData.ViewExternalCallResult)]
+      requestId: RequestId,
+      recordedResults: Seq[(ViewPosition, ViewParticipantData.ViewExternalCallResult)],
   )(implicit
       traceContext: TraceContext,
       ec: ExecutionContext,
@@ -132,20 +132,25 @@ class ExternalCallCheck(
             .map(outcome => (key, occurrencesAndOutputs, recordedOutput, outcome))
       }
       .map { outcomes =>
-        val rejectionO = outcomes.collectFirst {
+        val mismatches = outcomes.collect {
           case (
                 key,
                 occurrencesAndOutputs,
                 recordedOutput,
                 validated: ExternalCallValidator.Mismatched,
               ) =>
-            val inconsistency = Inconsistency(
+            Inconsistency(
               key,
               Set(validated.computedOutput, recordedOutput),
               occurrencesAndOutputs.map { case (occurrence, _) => occurrence }.toSet,
             )
-            Rejected(inconsistency.description)
         }
+        // Mirrors the visible-inconsistency alarms in check: every disagreement with the
+        // extension service is suspicious, not only the first one.
+        mismatches.foreach(alarmDisagreement(requestId, _))
+
+        val rejectionO =
+          mismatches.headOption.map(inconsistency => Rejected(inconsistency.description))
         val abstentionO = outcomes.collectFirst {
           case (_, _, _, ExternalCallValidator.UnableToValidate(reason)) =>
             CannotValidate(reason)
@@ -153,6 +158,13 @@ class ExternalCallCheck(
         rejectionO.orElse(abstentionO).getOrElse(Passed)
       }
   }
+
+  private def alarmDisagreement(requestId: RequestId, inconsistency: Inconsistency)(implicit
+      traceContext: TraceContext
+  ): Unit =
+    ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+      .Warn(s"Observed inconsistent external call results: ${inconsistency.description}")
+      .logWithContext(Map("requestId" -> requestId.toString))
 }
 
 object ExternalCallCheck {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.data.{ParticipantTransactionView, ViewParticipantData, ViewPosition}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsistencyChecker.{
+  ExternalCallOccurrence,
+  Inconsistency,
+}
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.RequestId
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.{ErrorUtil, MonadUtil}
+
+import scala.concurrent.ExecutionContext
+
+/** Checks the external-call results recorded in the views of a transaction request, as one of the
+  * parallel validation suites invoked from `TransactionProcessingSteps.doParallelChecks`.
+  *
+  * The check has two parts:
+  *   - consistency: whether occurrences of the same external call recorded across the request agree
+  *     on their output ([[ExternalCallConsistencyChecker]]); every visible disagreement is alarmed,
+  *   - re-validation: whether the (undisputed) recorded outputs agree with the extension service,
+  *     re-executing each distinct call once ([[ExternalCallValidator]]).
+  *
+  * The outcome is a single per-request `ExternalCallCheck.Result`: a disagreement from either part
+  * rejects the request on behalf of all hosted confirming parties, and a recorded result that
+  * cannot be re-validated leads to an abstention instead of an approval (see
+  * [[TransactionConfirmationResponsesFactory]]). Distinguishing the affected checking parties per
+  * view is a tracked follow-up; disagreements within the replay data of a single reinterpretation
+  * already surface as model-conformance errors independently of this check.
+  *
+  * @param externalCallValidator
+  *   The validator used to re-run external calls against the extension service.
+  * @param externalCallValidationParallelism
+  *   Bounds the number of concurrent validator calls.
+  */
+class ExternalCallCheck(
+    externalCallValidator: ExternalCallValidator,
+    externalCallValidationParallelism: PositiveInt,
+    protected val loggerFactory: NamedLoggerFactory,
+) extends NamedLogging {
+
+  import ExternalCallCheck.*
+
+  /** Checks consistency of the recorded external-call results and re-validates them against the
+    * extension service. The network I/O runs concurrently with the other validation suites; the
+    * returned future completes once all validator calls have.
+    *
+    * If no view records an external-call result -- in particular, always, on protocol versions
+    * without external-call support -- the check short-circuits to `ExternalCallCheck.Passed`.
+    *
+    * @param requestId
+    *   The request under validation, used to correlate logs and alarms.
+    * @param views
+    *   All views of the request received by this participant, by position.
+    * @param runValidation
+    *   Whether to re-validate recorded results. False for requests with malformed payloads, which
+    *   are rejected wholesale: only the alarms are of interest there.
+    */
+  def check(
+      requestId: RequestId,
+      views: Map[ViewPosition, ParticipantTransactionView],
+      runValidation: Boolean,
+  )(implicit
+      traceContext: TraceContext,
+      ec: ExecutionContext,
+  ): FutureUnlessShutdown[Result] = {
+    val recordedResults = views.toSeq
+      .sortBy { case (viewPosition, _) => viewPosition }(ViewPosition.orderViewPosition.toOrdering)
+      .flatMap { case (viewPosition, view) =>
+        view.viewParticipantData.externalCallResults.map(viewPosition -> _)
+      }
+
+    if (recordedResults.isEmpty)
+      FutureUnlessShutdown.pure(Passed)
+    else {
+      // Hosted parties are irrelevant for the request-level outcome: any visible disagreement
+      // rejects the request, so only the party-independent visible inconsistencies are consulted.
+      val consistency = ExternalCallConsistencyChecker.check(views, Set.empty)
+
+      consistency.visibleInconsistencies.foreach { inconsistency =>
+        ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+          .Warn(s"Observed inconsistent external call results: ${inconsistency.description}")
+          .logWithContext(Map("requestId" -> requestId.toString))
+      }
+
+      // The checker sorts the inconsistencies, so the reported disagreement is deterministic.
+      consistency.visibleInconsistencies.headOption match {
+        case Some(inconsistency) =>
+          FutureUnlessShutdown.pure(Rejected(inconsistency.description))
+        case None if !runValidation =>
+          FutureUnlessShutdown.pure(Passed)
+        case None =>
+          validateRecordedResults(recordedResults)
+      }
+    }
+  }
+
+  /** Re-validates the recorded results, one validator call per distinct semantic call
+    * ([[com.digitalasset.canton.participant.util.DAMLe.ExternalCallKey]]). At this point every key
+    * has a single recorded output: a key with disagreeing outputs is a visible inconsistency and
+    * was rejected before re-validation. Outcomes are examined in key order, so the result is
+    * deterministic.
+    */
+  private def validateRecordedResults(
+      recordedResults: Seq[(ViewPosition, ViewParticipantData.ViewExternalCallResult)]
+  )(implicit
+      traceContext: TraceContext,
+      ec: ExecutionContext,
+  ): FutureUnlessShutdown[Result] = {
+    val occurrencesByKey = recordedResults
+      .groupMap { case (_, result) => DAMLe.ExternalCallKey.fromResult(result.result) } {
+        case (viewPosition, result) =>
+          ExternalCallOccurrence(viewPosition, result.exerciseIndex, result.callIndex) ->
+            result.result.output
+      }
+      .toSeq
+      .sortBy { case (key, _) => key }
+
+    MonadUtil
+      .parTraverseWithLimit(externalCallValidationParallelism)(occurrencesByKey) {
+        case (key, occurrencesAndOutputs) =>
+          // All occurrences of the key record the same output (see the method contract).
+          val recordedOutput = occurrencesAndOutputs.headOption
+            .map { case (_, output) => output }
+            .getOrElse(ErrorUtil.invalidState("a grouped key always has at least one occurrence"))
+          externalCallValidator
+            .validate(key, recordedOutput)
+            .map(outcome => (key, occurrencesAndOutputs, recordedOutput, outcome))
+      }
+      .map { outcomes =>
+        val rejectionO = outcomes.collectFirst {
+          case (
+                key,
+                occurrencesAndOutputs,
+                recordedOutput,
+                validated: ExternalCallValidator.Mismatched,
+              ) =>
+            val inconsistency = Inconsistency(
+              key,
+              Set(validated.computedOutput, recordedOutput),
+              occurrencesAndOutputs.map { case (occurrence, _) => occurrence }.toSet,
+            )
+            Rejected(inconsistency.description)
+        }
+        val abstentionO = outcomes.collectFirst {
+          case (_, _, _, ExternalCallValidator.UnableToValidate(reason)) =>
+            CannotValidate(reason)
+        }
+        rejectionO.orElse(abstentionO).getOrElse(Passed)
+      }
+  }
+}
+
+object ExternalCallCheck {
+
+  /** Per-request outcome of the external-call check, consumed by
+    * `TransactionConfirmationResponsesFactory` as pure data.
+    */
+  sealed trait Result extends Product with Serializable
+
+  /** All recorded results agree with each other and with the extension service (or there are none).
+    */
+  case object Passed extends Result
+
+  /** Recorded results disagree with each other, or with the extension service. The request is
+    * rejected on behalf of all hosted confirming parties.
+    */
+  final case class Rejected(description: String) extends Result
+
+  /** A recorded result could not be re-validated (for example, no extension service is configured).
+    * Views that would otherwise be approved are abstained from instead.
+    */
+  final case class CannotValidate(reason: String) extends Result
+}

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -30,9 +30,8 @@ import scala.concurrent.ExecutionContext
   * The outcome is a single per-request `ExternalCallCheck.Result`: a disagreement from either part
   * rejects the request on behalf of all hosted confirming parties, and a recorded result that
   * cannot be re-validated leads to an abstention instead of an approval (see
-  * [[TransactionConfirmationResponsesFactory]]). Distinguishing the affected checking parties per
-  * view is a tracked follow-up; disagreements within the replay data of a single reinterpretation
-  * already surface as model-conformance errors independently of this check.
+  * [[TransactionConfirmationResponsesFactory]]). Disagreements within the replay data of a single
+  * reinterpretation already surface as model-conformance errors independently of this check.
   *
   * @param externalCallValidator
   *   The validator used to re-run external calls against the extension service.
@@ -48,8 +47,7 @@ class ExternalCallCheck(
   import ExternalCallCheck.*
 
   /** Checks consistency of the recorded external-call results and re-validates them against the
-    * extension service. The network I/O runs concurrently with the other validation suites; the
-    * returned future completes once all validator calls have.
+    * extension service.
     *
     * If no view records an external-call result -- in particular, always, on protocol versions
     * without external-call support -- the check short-circuits to `ExternalCallCheck.Passed`.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -6,7 +6,7 @@ package com.digitalasset.canton.participant.protocol.validation
 import cats.Order
 import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
-import com.digitalasset.canton.data.ViewPosition
+import com.digitalasset.canton.data.{ParticipantTransactionView, ViewPosition}
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.participant.util.ExternalCallPayloadDescription.{
@@ -147,24 +147,23 @@ object ExternalCallConsistencyChecker {
   }
 
   private def visibleOccurrences(
-      viewValidationResults: Map[ViewPosition, ViewValidationResult]
+      views: Map[ViewPosition, ParticipantTransactionView]
   ): Seq[VisibleExternalCallOccurrence] =
-    viewValidationResults.toSeq
+    views.toSeq
       .sortBy(_._1)(ViewPosition.orderViewPosition.toOrdering)
-      .flatMap { case (viewPosition, viewValidationResult) =>
-        viewValidationResult.view.viewParticipantData.externalCallResults.map {
-          externalCallResult =>
-            val occurrence = ExternalCallOccurrence(
-              viewPosition,
-              externalCallResult.exerciseIndex,
-              externalCallResult.callIndex,
-            )
-            VisibleExternalCallOccurrence(
-              DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
-              externalCallResult.result.output,
-              occurrence,
-              externalCallResult.checkingParties,
-            )
+      .flatMap { case (viewPosition, view) =>
+        view.viewParticipantData.externalCallResults.map { externalCallResult =>
+          val occurrence = ExternalCallOccurrence(
+            viewPosition,
+            externalCallResult.exerciseIndex,
+            externalCallResult.callIndex,
+          )
+          VisibleExternalCallOccurrence(
+            DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
+            externalCallResult.result.output,
+            occurrence,
+            externalCallResult.checkingParties,
+          )
         }
       }
 
@@ -204,10 +203,10 @@ object ExternalCallConsistencyChecker {
     * [[Result]] for how the two differ.
     */
   def check(
-      viewValidationResults: Map[ViewPosition, ViewValidationResult],
+      views: Map[ViewPosition, ParticipantTransactionView],
       hostedConfirmingParties: Set[LfPartyId],
   ): Result = {
-    val occurrences = visibleOccurrences(viewValidationResults)
+    val occurrences = visibleOccurrences(views)
     Result(
       hostedInconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
       visibleInconsistencies = visibleInconsistencies(occurrences),

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -139,6 +139,8 @@ class TransactionConfirmationResponsesFactory(
 
         internalConsistencyResultE <- transactionValidationResult.internalConsistencyResultET.value
 
+        externalCallCheckResult <- transactionValidationResult.externalCallCheckResultF
+
         // Rejections due to a failed model conformance check
         // Aborts are logged by the Engine callback when the abort happens
         modelConformanceRejections =
@@ -244,13 +246,31 @@ class TransactionConfirmationResponsesFactory(
                   ).toLocalReject(protocolVersion)
                 )
 
+              // Rejections due to recorded external-call results that disagree (with each other
+              // across the request, or with the extension service on re-validation). The request
+              // is rejected on behalf of all hosted confirming parties; the rejections rank with
+              // the other consistency rejections, ahead of the authentication and conformance
+              // rejections.
+              val externalCallRejections =
+                externalCallCheckResult match {
+                  case ExternalCallCheck.Rejected(description) =>
+                    Some(
+                      logged(
+                        requestId,
+                        LocalRejectError.ConsistencyRejections.ExternalCallResultDisagreement
+                          .Reject(description),
+                      ).toLocalReject(protocolVersion)
+                    )
+                  case _ => None
+                }
+
               // Approve if the consistency check succeeded, reject otherwise.
               val consistencyVerdicts =
                 verdictsForView(viewValidationResult, hostedConfirmingParties)
 
               val localVerdicts: Seq[LocalVerdict] =
                 consistencyVerdicts.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
-                  authenticationRejections ++ authorizationRejections ++
+                  externalCallRejections ++ authenticationRejections ++ authorizationRejections ++
                   modelConformanceRejections ++ internalConsistencyRejections ++
                   replayRejections
 
@@ -266,7 +286,25 @@ class TransactionConfirmationResponsesFactory(
                   )
                 )
 
-              localVerdictAndPartiesO.map { case (localVerdict, parties) =>
+              // A recorded external-call result that could not be re-validated downgrades an
+              // approval to an abstention: the participant cannot vouch for the recorded result,
+              // but the request is not provably wrong either.
+              val localVerdictAndPartiesWithAbstentionO = localVerdictAndPartiesO.map {
+                case (approve: LocalApprove, parties) =>
+                  externalCallCheckResult match {
+                    case ExternalCallCheck.CannotValidate(reason) =>
+                      logged(
+                        requestId,
+                        LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
+                      ).toLocalAbstain(protocolVersion) -> parties
+                    case _ => approve -> parties
+                  }
+                case other => other
+              }
+
+              localVerdictAndPartiesWithAbstentionO.map { case (localVerdict, parties) =>
+                // The abstention above preserves the tryCreate invariant: it is not malformed,
+                // and it keeps the approval's non-empty party set.
                 checked(
                   ConfirmationResponse
                     .tryCreate(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -264,6 +264,22 @@ class TransactionConfirmationResponsesFactory(
                   case ExternalCallCheck.Passed | ExternalCallCheck.CannotValidate(_) => None
                 }
 
+              // Abstentions due to a recorded external-call result that could not be
+              // re-validated: the participant cannot vouch for the recorded result, but the
+              // request is not provably wrong either. Appended last to the verdicts below so that
+              // every rejection takes precedence over the abstention.
+              val externalCallAbstentions =
+                externalCallCheckResult match {
+                  case ExternalCallCheck.CannotValidate(reason) =>
+                    Some(
+                      logged(
+                        requestId,
+                        LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
+                      ).toLocalAbstain(protocolVersion)
+                    )
+                  case ExternalCallCheck.Passed | ExternalCallCheck.Rejected(_) => None
+                }
+
               // Approve if the consistency check succeeded, reject otherwise.
               val consistencyVerdicts =
                 verdictsForView(viewValidationResult, hostedConfirmingParties)
@@ -272,13 +288,13 @@ class TransactionConfirmationResponsesFactory(
                 consistencyVerdicts.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
                   externalCallRejections ++ authenticationRejections ++ authorizationRejections ++
                   modelConformanceRejections ++ internalConsistencyRejections ++
-                  replayRejections
+                  replayRejections ++ externalCallAbstentions
 
               val localVerdictAndPartiesO = localVerdicts
                 .collectFirst[(LocalVerdict, Set[LfPartyId])] {
                   case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
-                  case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
-                    localReject -> hostedConfirmingParties
+                  case nonPositive: NonPositiveLocalVerdict if hostedConfirmingParties.nonEmpty =>
+                    nonPositive -> hostedConfirmingParties
                 }
                 .orElse(
                   Option.when(hostedConfirmingParties.nonEmpty)(
@@ -286,25 +302,7 @@ class TransactionConfirmationResponsesFactory(
                   )
                 )
 
-              // A recorded external-call result that could not be re-validated downgrades an
-              // approval to an abstention: the participant cannot vouch for the recorded result,
-              // but the request is not provably wrong either.
-              val localVerdictAndPartiesWithAbstentionO = localVerdictAndPartiesO.map {
-                case (approve: LocalApprove, parties) =>
-                  externalCallCheckResult match {
-                    case ExternalCallCheck.CannotValidate(reason) =>
-                      logged(
-                        requestId,
-                        LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
-                      ).toLocalAbstain(protocolVersion) -> parties
-                    case _ => approve -> parties
-                  }
-                case other => other
-              }
-
-              localVerdictAndPartiesWithAbstentionO.map { case (localVerdict, parties) =>
-                // The abstention above preserves the tryCreate invariant: it is not malformed,
-                // and it keeps the approval's non-empty party set.
+              localVerdictAndPartiesO.map { case (localVerdict, parties) =>
                 checked(
                   ConfirmationResponse
                     .tryCreate(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -189,8 +189,7 @@ class TransactionConfirmationResponsesFactory(
                       requestId,
                       // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
                       // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
-                      // ensures that this rejection, something at least as strong, or the external-call
-                      // abstention (which ranks earlier in the verdicts below) will make it to the mediator.
+                      // ensures that this rejection or something at least as strong will make it to the mediator.
                       LocalRejectError.MalformedRejects.MalformedRequest.Reject(
                         err.format(viewPosition)
                       ),
@@ -283,12 +282,20 @@ class TransactionConfirmationResponsesFactory(
                   modelConformanceRejections ++ internalConsistencyRejections ++
                   replayRejections
 
+              // Any rejection, wherever it ranks in the verdicts, takes precedence over the
+              // abstention.
               val localVerdictAndPartiesO = localVerdicts
                 .collectFirst[(LocalVerdict, Set[LfPartyId])] {
                   case malformed: LocalReject if malformed.isMalformed => malformed -> Set.empty
-                  case nonPositive: NonPositiveLocalVerdict if hostedConfirmingParties.nonEmpty =>
-                    nonPositive -> hostedConfirmingParties
+                  case localReject: LocalReject if hostedConfirmingParties.nonEmpty =>
+                    localReject -> hostedConfirmingParties
                 }
+                .orElse(
+                  localVerdicts.collectFirst[(LocalVerdict, Set[LfPartyId])] {
+                    case abstain: LocalAbstain if hostedConfirmingParties.nonEmpty =>
+                      abstain -> hostedConfirmingParties
+                  }
+                )
                 .orElse(
                   Option.when(hostedConfirmingParties.nonEmpty)(
                     LocalApprove(protocolVersion) -> hostedConfirmingParties

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -189,7 +189,8 @@ class TransactionConfirmationResponsesFactory(
                       requestId,
                       // Conceptually, a normal LocalReject for the admin party should suffice for rejecting replays.
                       // However, we nevertheless use a `Malformed` rejection here so that the rejection preference sorting
-                      // ensures that this rejection or something at least as strong will make it to the mediator.
+                      // ensures that this rejection, something at least as strong, or the external-call
+                      // abstention (which ranks earlier in the verdicts below) will make it to the mediator.
                       LocalRejectError.MalformedRejects.MalformedRequest.Reject(
                         err.format(viewPosition)
                       ),
@@ -246,12 +247,13 @@ class TransactionConfirmationResponsesFactory(
                   ).toLocalReject(protocolVersion)
                 )
 
-              // Rejections due to recorded external-call results that disagree (with each other
-              // across the request, or with the extension service on re-validation). The request
-              // is rejected on behalf of all hosted confirming parties; the rejections rank with
-              // the other consistency rejections, ahead of the authentication and conformance
-              // rejections.
-              val externalCallRejections =
+              // Verdicts due to the external-call check: recorded results that disagree (with
+              // each other across the request, or with the extension service on re-validation)
+              // reject the request on behalf of all hosted confirming parties; a recorded result
+              // that could not be re-validated abstains instead of approving, as the participant
+              // cannot vouch for the recorded result while the request is not provably wrong
+              // either.
+              val externalCallVerdicts =
                 externalCallCheckResult match {
                   case ExternalCallCheck.Rejected(description) =>
                     Some(
@@ -261,15 +263,6 @@ class TransactionConfirmationResponsesFactory(
                           .Reject(description),
                       ).toLocalReject(protocolVersion)
                     )
-                  case ExternalCallCheck.Passed | ExternalCallCheck.CannotValidate(_) => None
-                }
-
-              // Abstentions due to a recorded external-call result that could not be
-              // re-validated: the participant cannot vouch for the recorded result, but the
-              // request is not provably wrong either. Appended last to the verdicts below so that
-              // every rejection takes precedence over the abstention.
-              val externalCallAbstentions =
-                externalCallCheckResult match {
                   case ExternalCallCheck.CannotValidate(reason) =>
                     Some(
                       logged(
@@ -277,7 +270,7 @@ class TransactionConfirmationResponsesFactory(
                         LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
                       ).toLocalAbstain(protocolVersion)
                     )
-                  case ExternalCallCheck.Passed | ExternalCallCheck.Rejected(_) => None
+                  case ExternalCallCheck.Passed => None
                 }
 
               // Approve if the consistency check succeeded, reject otherwise.
@@ -286,9 +279,9 @@ class TransactionConfirmationResponsesFactory(
 
               val localVerdicts: Seq[LocalVerdict] =
                 consistencyVerdicts.toList ++ timeValidationRejections ++ contractConsistencyRejections ++
-                  externalCallRejections ++ authenticationRejections ++ authorizationRejections ++
+                  externalCallVerdicts ++ authenticationRejections ++ authorizationRejections ++
                   modelConformanceRejections ++ internalConsistencyRejections ++
-                  replayRejections ++ externalCallAbstentions
+                  replayRejections
 
               val localVerdictAndPartiesO = localVerdicts
                 .collectFirst[(LocalVerdict, Set[LfPartyId])] {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -261,7 +261,7 @@ class TransactionConfirmationResponsesFactory(
                           .Reject(description),
                       ).toLocalReject(protocolVersion)
                     )
-                  case _ => None
+                  case ExternalCallCheck.Passed | ExternalCallCheck.CannotValidate(_) => None
                 }
 
               // Approve if the consistency check succeeded, reject otherwise.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
@@ -33,6 +33,7 @@ final case class TransactionValidationResult(
       ErrorWithInternalConsistencyCheck,
       Unit,
     ],
+    externalCallCheckResultF: FutureUnlessShutdown[ExternalCallCheck.Result],
     consumedInputsOfHostedParties: Map[LfContractId, Set[LfPartyId]],
     witnessed: Map[LfContractId, GenContractInstance],
     createdContracts: Map[LfContractId, NewContractInstance],

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/CantonSyncService.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/CantonSyncService.scala
@@ -77,6 +77,7 @@ import com.digitalasset.canton.participant.protocol.submission.routing.{
   RoutingSynchronizerStateFactory,
   TransactionRoutingProcessor,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.PruningProcessor
 import com.digitalasset.canton.participant.replica.ParticipantReplicaManager
 import com.digitalasset.canton.participant.store.*
@@ -180,6 +181,7 @@ class CantonSyncService(
     val ledgerApiIndexer: LifeCycleContainer[LedgerApiIndexer],
     trafficEnforcementBackendO: Option[Eval[TrafficEnforcementBackend]],
     connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContextExecutor, mat: Materializer, val tracer: Tracer)
     extends state.SyncService
     with ParticipantPruningSyncService
@@ -234,6 +236,7 @@ class CantonSyncService(
     testingConfig,
     ledgerApiIndexer,
     connectedSynchronizersLookupContainer,
+    externalCallValidator,
   )
 
   private def connectedSynchronizersLookup: ConnectedSynchronizersLookup =
@@ -1850,6 +1853,7 @@ object CantonSyncService {
       connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
       triggerDeclarativeChange: () => Unit,
       trafficEnforcementBackendO: Option[Eval[TrafficEnforcementBackend]],
+      externalCallValidator: ExternalCallValidator,
   )(implicit ec: ExecutionContextExecutor, mat: Materializer, tracer: Tracer): CantonSyncService = {
 
     // Set initial replica state
@@ -1887,6 +1891,7 @@ object CantonSyncService {
         ledgerApiIndexer,
         trafficEnforcementBackendO,
         connectedSynchronizersLookupContainer,
+        externalCallValidator,
       )
     syncService
   }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/ConnectedSynchronizer.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/ConnectedSynchronizer.scala
@@ -51,6 +51,7 @@ import com.digitalasset.canton.participant.protocol.submission.{
   SeedGenerator,
   TransactionConfirmationRequestFactory,
 }
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.{
   AcsCommitmentProcessor,
   JournalGarbageCollector,
@@ -177,6 +178,7 @@ class ConnectedSynchronizer(
     futureSupervisor: FutureSupervisor,
     override protected val loggerFactory: NamedLoggerFactory,
     testingConfig: TestingConfigInternal,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContext, tracer: Tracer)
     extends NamedLogging
     with FlagCloseableAsync
@@ -294,6 +296,7 @@ class ConnectedSynchronizer(
     promiseUSFactory,
     parameters,
     trafficEnforcementBackendO.map(_.value),
+    externalCallValidator,
   )
 
   private val unassignmentProcessor: UnassignmentProcessor = new UnassignmentProcessor(
@@ -1253,6 +1256,7 @@ object ConnectedSynchronizer {
         futureSupervisor: FutureSupervisor,
         loggerFactory: NamedLoggerFactory,
         testingConfig: TestingConfigInternal,
+        externalCallValidator: ExternalCallValidator,
     )(implicit ec: ExecutionContext, mat: Materializer, tracer: Tracer): FutureUnlessShutdown[T]
   }
 
@@ -1281,6 +1285,7 @@ object ConnectedSynchronizer {
         futureSupervisor: FutureSupervisor,
         loggerFactory: NamedLoggerFactory,
         testingConfig: TestingConfigInternal,
+        externalCallValidator: ExternalCallValidator,
     )(implicit
         ec: ExecutionContext,
         mat: Materializer,
@@ -1393,6 +1398,7 @@ object ConnectedSynchronizer {
           futureSupervisor,
           loggerFactory,
           testingConfig,
+          externalCallValidator,
         )
       }
     }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/SynchronizerConnectionsManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/sync/SynchronizerConnectionsManager.scala
@@ -40,6 +40,7 @@ import com.digitalasset.canton.participant.admin.party.{
 import com.digitalasset.canton.participant.ledger.api.LedgerApiIndexer
 import com.digitalasset.canton.participant.metrics.ParticipantMetrics
 import com.digitalasset.canton.participant.protocol.reassignment.ReassignmentCoordination
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
 import com.digitalasset.canton.participant.pruning.AcsCommitmentProcessor
 import com.digitalasset.canton.participant.store.*
 import com.digitalasset.canton.participant.store.SynchronizerConnectionConfigStore.UnknownAlias
@@ -147,6 +148,7 @@ private[sync] class SynchronizerConnectionsManager(
     testingConfig: TestingConfigInternal,
     ledgerApiIndexer: LifeCycleContainer[LedgerApiIndexer],
     connectedSynchronizersLookupContainer: ConnectedSynchronizersLookupContainer,
+    externalCallValidator: ExternalCallValidator,
 )(implicit ec: ExecutionContextExecutor, mat: Materializer, val tracer: Tracer)
     extends FlagCloseable
     with Spanning
@@ -1227,6 +1229,7 @@ private[sync] class SynchronizerConnectionsManager(
               futureSupervisor,
               synchronizerLoggerFactory,
               testingConfig,
+              externalCallValidator,
             )
           )
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -24,15 +24,15 @@ class ExternalCallConsistencyCheckerTest
 
   protected val factory: ExampleTransactionFactory = new ExampleTransactionFactory()()
 
-  private val partyA = ExampleTransactionFactory.signatory
-  private val partyB = ExampleTransactionFactory.submitter
-  private val partyC = ExampleTransactionFactory.observer
+  private val partyA: LfPartyId = ExampleTransactionFactory.signatory
+  private val partyB: LfPartyId = ExampleTransactionFactory.submitter
+  private val partyC: LfPartyId = ExampleTransactionFactory.observer
 
   private def check(
       leftCheckingParties: Set[LfPartyId],
       rightCheckingParties: Set[LfPartyId],
       hostedParties: Set[LfPartyId],
-      rightResult: ExternalCallResult = otherExternalCallOutput,
+      rightResult: ExternalCallResult = otherExternalCallResult,
   ): ExternalCallConsistencyChecker.Result = {
     val example = factory.MultipleRoots
     val left = withExternalCallResults(
@@ -58,11 +58,11 @@ class ExternalCallConsistencyCheckerTest
 
     ExternalCallConsistencyChecker.check(
       Map(
-        ViewPosition.root -> validationResult(left),
+        ViewPosition.root -> participantView(left),
         ViewPosition(
           List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
         ) ->
-          validationResult(right),
+          participantView(right),
       ),
       hostedParties,
     )
@@ -102,7 +102,7 @@ class ExternalCallConsistencyCheckerTest
       val visibleInconsistency = result.visibleInconsistencies.loneElement
       visibleInconsistency.outputs shouldBe Set(
         externalCallResult.output,
-        otherExternalCallOutput.output,
+        otherExternalCallResult.output,
       )
     }
 
@@ -122,7 +122,7 @@ class ExternalCallConsistencyCheckerTest
         leftCheckingParties = Set(partyA),
         rightCheckingParties = Set(partyA),
         hostedParties = Set(partyA),
-        rightResult = otherExternalCallOutput.copy(functionId = "other-function"),
+        rightResult = otherExternalCallResult.copy(functionId = "other-function"),
       )
 
       result.inconsistentParties shouldBe Set.empty
@@ -141,7 +141,7 @@ class ExternalCallConsistencyCheckerTest
           ),
           externalCallViewResult(
             exerciseIndex = 0,
-            result = otherExternalCallOutput,
+            result = otherExternalCallResult,
             checkingParties = Set(partyA),
             callIndex = 1,
           ),
@@ -149,13 +149,13 @@ class ExternalCallConsistencyCheckerTest
       )
 
       val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> validationResult(view)),
+        Map(ViewPosition.root -> participantView(view)),
         Set(partyA),
       )
 
       result.inconsistentParties shouldBe Set(partyA)
       val inconsistency = result.hostedInconsistencies(partyA).loneElement
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallOutput.output)
+      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
       inconsistency.occurrences.map(occurrence =>
         occurrence.exerciseIndex -> occurrence.callIndex
       ) shouldBe Set(
@@ -201,11 +201,11 @@ class ExternalCallConsistencyCheckerTest
 
       val result = ExternalCallConsistencyChecker.check(
         Map(
-          ViewPosition.root -> validationResult(left),
+          ViewPosition.root -> participantView(left),
           ViewPosition(
             List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
           ) ->
-            validationResult(right),
+            participantView(right),
         ),
         Set(partyA),
       )
@@ -221,7 +221,7 @@ class ExternalCallConsistencyCheckerTest
       val example = factory.MultipleRoots
 
       val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> validationResult(example.rootViews(4))),
+        Map(ViewPosition.root -> participantView(example.rootViews(4))),
         Set(partyA),
       )
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -195,7 +195,7 @@ final class ExternalCallProtocolIntegrationTest
       validator.observed shouldBe empty
     }
 
-    "reject when re-validation returns a different output" in {
+    "reject and alarm when re-validation returns a different output" in {
       val validator = new RecordingExternalCallValidator(
         Map(
           externalCallKey -> ExternalCallValidator.Mismatched(
@@ -204,10 +204,12 @@ final class ExternalCallProtocolIntegrationTest
           )
         )
       )
-      val result = runCheck(
-        validator,
-        views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
-      )
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
+        )
+      }
 
       val expectedInconsistency = Inconsistency(
         externalCallKey,

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -36,8 +36,8 @@ import com.digitalasset.canton.protocol.messages.{
   LocalReject,
 }
 import com.digitalasset.canton.time.NonNegativeFiniteDuration
-import com.digitalasset.canton.topology.{ParticipantId, SynchronizerId, UniqueIdentifier}
 import com.digitalasset.canton.topology.client.TopologySnapshot
+import com.digitalasset.canton.topology.{ParticipantId, SynchronizerId, UniqueIdentifier}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.version.ProtocolVersion
 import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -35,6 +35,7 @@ import com.digitalasset.canton.protocol.messages.{
   LocalApprove,
   LocalReject,
 }
+import com.digitalasset.canton.time.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.{ParticipantId, SynchronizerId, UniqueIdentifier}
 import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.tracing.TraceContext
@@ -269,7 +270,8 @@ final class ExternalCallProtocolIntegrationTest
   }
 
   private def createResponses(
-      checkResult: ExternalCallCheck.Result
+      checkResult: ExternalCallCheck.Result,
+      timeValidationResultE: Either[TimeValidator.TimeCheckFailure, Unit] = Right(()),
   ): Seq[ConfirmationResponse] = {
     val example = factory.MultipleRoots
     val viewValidationResults = Map(
@@ -309,7 +311,7 @@ final class ExternalCallProtocolIntegrationTest
       transient = Map.empty,
       activenessResult = ConflictDetectionHelpers.mkActivenessResult(),
       viewValidationResults = viewValidationResults,
-      timeValidationResultE = Right(()),
+      timeValidationResultE = timeValidationResultE,
       hostedWitnesses = Set.empty,
       replayCheckResult = None,
       validatedExternalTransactionHash = None,
@@ -356,6 +358,30 @@ final class ExternalCallProtocolIntegrationTest
           abstain.reason.message shouldBe
             "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
             "Cannot perform all validations: extension service is not configured"
+          parties shouldBe confirmers
+        }
+      }
+    }
+
+    "prefer a rejection over the abstention when both apply" in {
+      val ledgerTime = CantonTimestamp.Epoch
+      val recordTime = CantonTimestamp.Epoch.plusSeconds(10)
+      val maxDelta = NonNegativeFiniteDuration.tryOfSeconds(1)
+      val responses = createResponses(
+        ExternalCallCheck.CannotValidate("extension service is not configured"),
+        timeValidationResultE = Left(
+          TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(ledgerTime, recordTime, maxDelta)
+        ),
+      )
+
+      responses should have size 2
+      forEvery(responses) { response =>
+        inside(response) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message shouldBe
+            "LOCAL_VERDICT_LEDGER_TIME_OUT_OF_BOUND(2,0): Rejected transaction as delta of " +
+            "the ledger time and the record time exceed the time tolerance " +
+            s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
           parties shouldBe confirmers
         }
       }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -272,6 +272,7 @@ final class ExternalCallProtocolIntegrationTest
   private def createResponses(
       checkResult: ExternalCallCheck.Result,
       timeValidationResultE: Either[TimeValidator.TimeCheckFailure, Unit] = Right(()),
+      authorizationResult: Map[ViewPosition, String] = Map.empty,
   ): Seq[ConfirmationResponse] = {
     val example = factory.MultipleRoots
     val viewValidationResults = Map(
@@ -295,7 +296,7 @@ final class ExternalCallProtocolIntegrationTest
       workflowIdO = None,
       contractConsistencyResultE = Right(()),
       authenticationResult = Map.empty,
-      authorizationResult = Map.empty,
+      authorizationResult = authorizationResult,
       modelConformanceResultET =
         EitherT.rightT[FutureUnlessShutdown, ModelConformanceChecker.ErrorWithSubTransaction[
           ViewAbsoluteLedgerEffect
@@ -363,7 +364,7 @@ final class ExternalCallProtocolIntegrationTest
       }
     }
 
-    "prefer a rejection over the abstention when both apply" in {
+    "prefer a rejection from an earlier validation suite over the abstention" in {
       val ledgerTime = CantonTimestamp.Epoch
       val recordTime = CantonTimestamp.Epoch.plusSeconds(10)
       val maxDelta = NonNegativeFiniteDuration.tryOfSeconds(1)
@@ -382,6 +383,27 @@ final class ExternalCallProtocolIntegrationTest
             "LOCAL_VERDICT_LEDGER_TIME_OUT_OF_BOUND(2,0): Rejected transaction as delta of " +
             "the ledger time and the record time exceed the time tolerance " +
             s"ledgerTime=$ledgerTime, recordTime=$recordTime, maxDelta=$maxDelta"
+          parties shouldBe confirmers
+        }
+      }
+    }
+
+    "prefer the abstention over a rejection from a later validation suite" in {
+      // The shadowed authorization rejection is still logged, as a malformed-request alarm.
+      val responses = loggerFactory.assertLogs(
+        createResponses(
+          ExternalCallCheck.CannotValidate("extension service is not configured"),
+          authorizationResult = Map(leftViewPosition -> "no authorization"),
+        ),
+        _.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.MalformedRequest),
+      )
+
+      responses should have size 2
+      forEvery(responses) { response =>
+        inside(response) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
+          abstain.reason.message shouldBe
+            "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
+            "Cannot perform all validations: extension service is not configured"
           parties shouldBe confirmers
         }
       }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.participant.protocol.validation
+
+import cats.data.EitherT
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
+import com.digitalasset.canton.data.{
+  CantonTimestamp,
+  ParticipantTransactionView,
+  PathRollbackContextFactory,
+  TransactionView,
+  ViewConfirmationParameters,
+  ViewParticipantData,
+  ViewPosition,
+}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.protocol.LedgerEffectAbsolutizer.ViewAbsoluteLedgerEffect
+import com.digitalasset.canton.participant.protocol.conflictdetection.ConflictDetectionHelpers
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsistencyChecker.{
+  ExternalCallOccurrence,
+  Inconsistency,
+}
+import com.digitalasset.canton.participant.util.DAMLe
+import com.digitalasset.canton.protocol.*
+import com.digitalasset.canton.protocol.ExampleTransactionFactory.{
+  signatory,
+  submitter,
+  submittingParticipant,
+}
+import com.digitalasset.canton.protocol.messages.{
+  ConfirmationResponse,
+  LocalAbstain,
+  LocalApprove,
+  LocalReject,
+}
+import com.digitalasset.canton.topology.{ParticipantId, SynchronizerId, UniqueIdentifier}
+import com.digitalasset.canton.topology.client.TopologySnapshot
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.canton.{BaseTestWordSpec, HasExecutionContext, LfPartyId}
+import com.digitalasset.daml.lf.data.Bytes
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters.*
+
+/** Basic coverage for the external-call protocol integration: the [[ExternalCallCheck]] outcomes
+  * and their translation into confirmation responses. Completing the coverage is a tracked
+  * post-merge task.
+  */
+final class ExternalCallProtocolIntegrationTest
+    extends BaseTestWordSpec
+    with HasExecutionContext
+    with ExternalCallValidationTestUtil {
+
+  protected val factory: ExampleTransactionFactory =
+    new ExampleTransactionFactory(versionOverride = Some(ProtocolVersion.dev))(
+      psid = SynchronizerId(
+        UniqueIdentifier.tryFromProtoPrimitive("example::default")
+      ).toPhysical.copy(protocolVersion = ProtocolVersion.dev)
+    )
+
+  private val requestId: RequestId = RequestId(CantonTimestamp.Epoch)
+
+  private val confirmers: Set[LfPartyId] = Set(submitter, signatory)
+
+  private val externalCallKey: DAMLe.ExternalCallKey =
+    DAMLe.ExternalCallKey.fromResult(externalCallResult)
+
+  private val leftViewPosition: ViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Left)))
+    )
+  private val rightViewPosition: ViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+    )
+
+  private final class RecordingExternalCallValidator(
+      results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
+  ) extends ExternalCallValidator {
+    private val observedKeys: ConcurrentLinkedQueue[DAMLe.ExternalCallKey] =
+      new ConcurrentLinkedQueue[DAMLe.ExternalCallKey]
+
+    def observed: Seq[DAMLe.ExternalCallKey] = observedKeys.asScala.toSeq
+
+    override def validate(
+        key: DAMLe.ExternalCallKey,
+        recordedOutput: Bytes,
+    )(implicit
+        traceContext: TraceContext
+    ): FutureUnlessShutdown[ExternalCallValidator.Result] = {
+      observedKeys.add(key)
+      FutureUnlessShutdown.pure(results.getOrElse(key, ExternalCallValidator.Matched))
+    }
+  }
+
+  private def externalCallCheck(validator: ExternalCallValidator): ExternalCallCheck =
+    new ExternalCallCheck(validator, PositiveInt.tryCreate(8), loggerFactory)
+
+  private def withConfirmers(
+      view: TransactionView,
+      confirmers: Set[LfPartyId],
+  ): TransactionView = {
+    val confirmationParameters = ViewConfirmationParameters.create(
+      informees = confirmers.map(_ -> NonNegativeInt.one).toMap,
+      threshold = NonNegativeInt.tryCreate(confirmers.size),
+    )
+    TransactionView.Optics.viewCommonDataUnsafe
+      .modify(commonData =>
+        commonData.tryUnwrap.copy(viewConfirmationParameters = confirmationParameters)
+      )(view)
+  }
+
+  private def views(
+      leftResults: Seq[ViewParticipantData.ViewExternalCallResult],
+      rightResults: Seq[ViewParticipantData.ViewExternalCallResult] = Seq.empty,
+  ): Map[ViewPosition, ParticipantTransactionView] = {
+    val example = factory.MultipleRoots
+    Map(
+      leftViewPosition -> participantView(
+        withExternalCallResults(withConfirmers(example.rootViews(4), confirmers), leftResults)
+      ),
+      rightViewPosition -> participantView(
+        withExternalCallResults(withConfirmers(example.rootViews(5), confirmers), rightResults)
+      ),
+    )
+  }
+
+  private def runCheck(
+      validator: ExternalCallValidator,
+      views: Map[ViewPosition, ParticipantTransactionView],
+      runValidation: Boolean = true,
+  ): ExternalCallCheck.Result =
+    externalCallCheck(validator).check(requestId, views, runValidation).futureValueUS
+
+  private def assertDisagreementAlarm[A](within: => A): A =
+    loggerFactory.assertLogs(
+      within,
+      (logEntry: LogEntry) => {
+        logEntry.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        )
+        logEntry.mdc should contain("requestId" -> requestId.toString)
+      },
+    )
+
+  "ExternalCallCheck" should {
+    "pass when no view records external-call results" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+
+      runCheck(validator, views(Seq.empty)) shouldBe ExternalCallCheck.Passed
+      validator.observed shouldBe empty
+    }
+
+    "pass when the recorded results agree and re-validation matches" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = runCheck(
+        validator,
+        views(
+          leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+          rightResults = Seq(externalCallViewResult(1, externalCallResult, Set(submitter))),
+        ),
+      )
+
+      result shouldBe ExternalCallCheck.Passed
+      // Re-validated once for the shared semantic key.
+      validator.observed shouldBe Seq(externalCallKey)
+    }
+
+    "reject and alarm when recorded results disagree across the request" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(externalCallViewResult(1, otherExternalCallResult, Set(submitter))),
+          ),
+        )
+      }
+
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
+        occurrences = Set(
+          ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero),
+          ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
+        ),
+      )
+      result shouldBe ExternalCallCheck.Rejected(expectedInconsistency.description)
+      // Disagreeing results are not re-validated.
+      validator.observed shouldBe empty
+    }
+
+    "reject when re-validation returns a different output" in {
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val result = runCheck(
+        validator,
+        views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
+      )
+
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(otherExternalCallResult.output, externalCallResult.output),
+        occurrences =
+          Set(ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero)),
+      )
+      result shouldBe ExternalCallCheck.Rejected(expectedInconsistency.description)
+      validator.observed shouldBe Seq(externalCallKey)
+    }
+
+    "report a recorded result that cannot be re-validated" in {
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.UnableToValidate(
+            "extension service is not configured"
+          )
+        )
+      )
+      val result = runCheck(
+        validator,
+        views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
+      )
+
+      result shouldBe ExternalCallCheck.CannotValidate(
+        "extension service is not configured"
+      )
+    }
+
+    "skip re-validation of consistent results when instructed" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = runCheck(
+        validator,
+        views(
+          leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+          rightResults = Seq(externalCallViewResult(1, externalCallResult, Set(submitter))),
+        ),
+        runValidation = false,
+      )
+
+      result shouldBe ExternalCallCheck.Passed
+      validator.observed shouldBe empty
+    }
+  }
+
+  private lazy val responsesFactory: TransactionConfirmationResponsesFactory =
+    new TransactionConfirmationResponsesFactory(
+      submittingParticipant,
+      factory.psid,
+      loggerFactory,
+    )
+
+  private val identityTopologySnapshot: TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties)
+      }
+    snapshot
+  }
+
+  private def createResponses(
+      checkResult: ExternalCallCheck.Result
+  ): Seq[ConfirmationResponse] = {
+    val example = factory.MultipleRoots
+    val viewValidationResults = Map(
+      leftViewPosition -> validationResult(withConfirmers(example.rootViews(4), confirmers)),
+      rightViewPosition -> validationResult(withConfirmers(example.rootViews(5), confirmers)),
+    )
+    val defaultModelConformance = ModelConformanceChecker.Result(
+      example.updateId,
+      WellFormedTransaction.checkOrThrow(
+        example.versionedSuffixedTransaction,
+        example.metadata,
+        WellFormedTransaction.WithSuffixesAndMerged,
+        PathRollbackContextFactory,
+      ),
+      unmergedTransactionsWithoutTopLevelRollbackNodes = Seq.empty,
+    )
+
+    val transactionValidationResult = TransactionValidationResult(
+      updateId = defaultModelConformance.updateId,
+      submitterMetadataO = None,
+      workflowIdO = None,
+      contractConsistencyResultE = Right(()),
+      authenticationResult = Map.empty,
+      authorizationResult = Map.empty,
+      modelConformanceResultET =
+        EitherT.rightT[FutureUnlessShutdown, ModelConformanceChecker.ErrorWithSubTransaction[
+          ViewAbsoluteLedgerEffect
+        ]](defaultModelConformance),
+      internalConsistencyResultET = EitherT
+        .rightT[FutureUnlessShutdown, InternalConsistencyChecker.ErrorWithInternalConsistencyCheck](
+          ()
+        ),
+      externalCallCheckResultF = FutureUnlessShutdown.pure(checkResult),
+      consumedInputsOfHostedParties = Map.empty,
+      witnessed = Map.empty,
+      createdContracts = Map.empty,
+      transient = Map.empty,
+      activenessResult = ConflictDetectionHelpers.mkActivenessResult(),
+      viewValidationResults = viewValidationResults,
+      timeValidationResultE = Right(()),
+      hostedWitnesses = Set.empty,
+      replayCheckResult = None,
+      validatedExternalTransactionHash = None,
+      commitAfterFailedActivenessCheck = false,
+    )
+
+    responsesFactory
+      .createConfirmationResponses(
+        requestId,
+        Seq.empty,
+        transactionValidationResult,
+        identityTopologySnapshot,
+      )
+      .futureValueUS
+      .value
+      .responses
+  }
+
+  "TransactionConfirmationResponsesFactory" should {
+    "reject every view on behalf of all hosted confirming parties on a rejected check" in {
+      val responses = createResponses(ExternalCallCheck.Rejected("disagreeing external call"))
+
+      responses should have size 2
+      forEvery(responses) { response =>
+        inside(response) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
+          reject.isMalformed shouldBe false
+          reject.reason.message shouldBe
+            "LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT(8,0): " +
+            "Rejected transaction due to inconsistent external call results: " +
+            "disagreeing external call"
+          parties shouldBe confirmers
+        }
+      }
+    }
+
+    "abstain instead of approving when the check cannot validate" in {
+      val responses = createResponses(
+        ExternalCallCheck.CannotValidate("extension service is not configured")
+      )
+
+      responses should have size 2
+      forEvery(responses) { response =>
+        inside(response) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
+          abstain.reason.message shouldBe
+            "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
+            "Cannot perform all validations: extension service is not configured"
+          parties shouldBe confirmers
+        }
+      }
+    }
+
+    "approve when the check passed" in {
+      val responses = createResponses(ExternalCallCheck.Passed)
+
+      responses should have size 2
+      forEvery(responses) { response =>
+        inside(response) { case ConfirmationResponse(_, LocalApprove(), parties) =>
+          parties shouldBe confirmers
+        }
+      }
+    }
+  }
+}

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -390,8 +390,7 @@ final class ExternalCallProtocolIntegrationTest
       }
     }
 
-    "prefer the abstention over a rejection from a later validation suite" in {
-      // The shadowed authorization rejection is still logged, as a malformed-request alarm.
+    "prefer a rejection from a later validation suite over the abstention" in {
       val responses = loggerFactory.assertLogs(
         createResponses(
           ExternalCallCheck.CannotValidate("extension service is not configured"),
@@ -401,13 +400,21 @@ final class ExternalCallProtocolIntegrationTest
       )
 
       responses should have size 2
-      forEvery(responses) { response =>
-        inside(response) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
-          abstain.reason.message shouldBe
-            "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
-            "Cannot perform all validations: extension service is not configured"
-          parties shouldBe confirmers
-        }
+      val leftResponse = responses.find(_.viewPositionO.contains(leftViewPosition)).value
+      inside(leftResponse) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
+        reject.isMalformed shouldBe true
+        // Malformed rejections carry a redacted reason on the wire.
+        reject.reason.message shouldBe
+          "An error occurred. Please contact the operator and inquire about the request " +
+          "<no-correlation-id> with tid <no-tid>"
+        parties shouldBe empty
+      }
+      val rightResponse = responses.find(_.viewPositionO.contains(rightViewPosition)).value
+      inside(rightResponse) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
+        abstain.reason.message shouldBe
+          "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
+          "Cannot perform all validations: extension service is not configured"
+        parties shouldBe confirmers
       }
     }
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidationTestUtil.scala
@@ -48,8 +48,11 @@ private[validation] trait ExternalCallValidationTestUtil {
     output = Bytes.fromStringUtf8("output"),
   )
 
-  protected val otherExternalCallOutput: ExternalCallResult =
+  protected val otherExternalCallResult: ExternalCallResult =
     externalCallResult.copy(output = Bytes.fromStringUtf8("other-output"))
+
+  protected def participantView(view: TransactionView): ParticipantTransactionView =
+    ParticipantTransactionView.tryCreate(view)
 
   protected def validationResult(
       view: TransactionView,
@@ -60,7 +63,7 @@ private[validation] trait ExternalCallValidationTestUtil {
       ),
   ): ViewValidationResult =
     ViewValidationResult(
-      ParticipantTransactionView.tryCreate(view),
+      participantView(view),
       activenessResult,
     )
 }


### PR DESCRIPTION
## Summary

This PR completes the minimal protocol integration of external calls (PR "6b" of the series tracked in #513, as agreed with @matthiasS-da): recorded external-call results are validated during transaction confirmation, and any disagreement rejects the request on behalf of all hosted confirming parties.

The external-call stack (#513): #506 added the transaction-side representation for recording external-call results; #514 added the LF `EXTERNAL_CALL` builtin surface; #518 wired it into Speedy and the LF engine; #522 added transaction protobuf encoding/decoding; #526 added Canton protocol serialization for recorded results; #537 added the participant-side extension-service client; #549–#554 added hashing (V4), the prepared-transaction codec, errors and the handler SPI, engine execution and the validation SPI, extension-service wiring, and the consistency checker. This PR adds the missing runtime consumer.

## Scope

- **`ExternalCallCheck`**: a validation suite invoked from `doParallelChecks` in `TransactionProcessingSteps`, following the `ModelConformanceChecker.check` pattern (kicked off there, awaited when confirmation responses are created, network I/O concurrent with the other suites). It checks consistency of the recorded results across the request (`ExternalCallConsistencyChecker`; every visible disagreement is alarmed) and re-validates undisputed recorded outputs against the configured extension service, once per distinct call.
- **Verdicts** (via the response factory's existing per-view verdict chain — its structure is unchanged): a disagreement from either part rejects each view on behalf of all its hosted confirming parties (`LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT`); a recorded result that cannot be re-validated (e.g. no extension service configured) downgrades approvals to `CANNOT_PERFORM_ALL_VALIDATIONS` abstentions. One consequence of keeping the factory's first-match chain: the new non-malformed rejection ranks with the other consistency rejections, so — like the pre-existing time and contract-consistency rejections — it is reported in preference to a co-occurring malformed rejection from the later suites (authentication, model conformance, internal consistency).
- The consistency checker now takes the participant views directly (view validation results do not exist yet at `doParallelChecks` time), and the `ExternalCallValidator` binding is threaded through the participant wiring.
- Basic test coverage for the check outcomes and their response translation; completing the coverage is tracked in #564.

Requests without recorded external-call results short-circuit before any topology or network access, so the feature remains inert on protocol versions without external-call support and unless an extension service is configured.

## Out of scope (deliberate, per the agreed short-cut)

- Per-party verdict routing (distinguishing the affected checking parties per view) — continues in #555/#556 as further improvements, in the context of the fail-fast refactor tracked in #565.
- Rejection deduplication.
- Full test coverage — tracked in #564.

Replay disagreements within a single reinterpretation already surface as model-conformance errors through the merged #552 machinery, independently of this check.

## Coordination

With this PR the feature is functional end-to-end on `ProtocolVersion.dev`. The Daml-side PR (https://github.com/digital-asset/daml/pull/23099) can proceed once a Canton snapshot/artifact containing this PR is published, per the coordination steps in #513.

Refs #513.
