### PR TITLE
refactor(external-call): move ExternalCallKey to community/base

### DIFF
--- a/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallKey.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallKey.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.data
+
+import com.digitalasset.canton.data.ExternalCallPayloadDescription.hexPayloadSize
+import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+
+/** Deterministic external-call identity. Config and input are engine-emitted canonical hex strings.
+  * The pretty-printed form deliberately shows only payload sizes, never the payloads.
+  */
+final case class ExternalCallKey(
+    extensionId: String,
+    functionId: String,
+    config: String,
+    input: String,
+) extends PrettyPrinting {
+  override protected def pretty: Pretty[ExternalCallKey] = prettyOfClass(
+    param("extension id", _.extensionId.doubleQuoted),
+    param("function id", _.functionId.doubleQuoted),
+    param("config bytes", key => hexPayloadSize(key.config).doubleQuoted),
+    param("input bytes", key => hexPayloadSize(key.input).doubleQuoted),
+  )
+}
+
+object ExternalCallKey {
+
+  /** Orders by the semantic identity fields, lexicographically. */
+  implicit val externalCallKeyOrdering: Ordering[ExternalCallKey] =
+    Ordering.by(key => (key.extensionId, key.functionId, key.config, key.input))
+
+  def fromResult(result: ExternalCallResult): ExternalCallKey =
+    ExternalCallKey(
+      result.extensionId,
+      result.functionId,
+      result.config.toHexString,
+      result.input.toHexString,
+    )
+}

--- a/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallPayloadDescription.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallPayloadDescription.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.digitalasset.canton.participant.util
+package com.digitalasset.canton.data
 
 import com.digitalasset.daml.lf.data.Bytes
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
@@ -3,9 +3,9 @@
 
 package com.digitalasset.canton.participant.extension
 
+import com.digitalasset.canton.data.ExternalCallKey
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.daml.lf.data.Bytes
@@ -18,7 +18,7 @@ class ExtensionServiceExternalCallValidator(
     extends ExternalCallValidator {
 
   override def validate(
-      key: DAMLe.ExternalCallKey,
+      key: ExternalCallKey,
       recordedOutput: Bytes,
   )(implicit traceContext: TraceContext): FutureUnlessShutdown[ExternalCallValidator.Result] =
     extensionServiceManager
@@ -65,7 +65,7 @@ object ExtensionServiceExternalCallValidator {
   private val unconfigured: ExternalCallValidator =
     new ExternalCallValidator {
       override def validate(
-          key: DAMLe.ExternalCallKey,
+          key: ExternalCallKey,
           recordedOutput: Bytes,
       )(implicit traceContext: TraceContext): FutureUnlessShutdown[ExternalCallValidator.Result] =
         FutureUnlessShutdown.pure(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -4,14 +4,18 @@
 package com.digitalasset.canton.participant.protocol.validation
 
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
-import com.digitalasset.canton.data.{ParticipantTransactionView, ViewParticipantData, ViewPosition}
+import com.digitalasset.canton.data.{
+  ExternalCallKey,
+  ParticipantTransactionView,
+  ViewParticipantData,
+  ViewPosition,
+}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsistencyChecker.{
   ExternalCallOccurrence,
   Inconsistency,
 }
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.RequestId
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.{ErrorUtil, MonadUtil}
@@ -99,10 +103,9 @@ class ExternalCallCheck(
   }
 
   /** Re-validates the recorded results, one validator call per distinct semantic call
-    * ([[com.digitalasset.canton.participant.util.DAMLe.ExternalCallKey]]). At this point every key
-    * has a single recorded output: a key with disagreeing outputs is a visible inconsistency and
-    * was rejected before re-validation. Outcomes are examined in key order, so the result is
-    * deterministic.
+    * ([[com.digitalasset.canton.data.ExternalCallKey]]). At this point every key has a single
+    * recorded output: a key with disagreeing outputs is a visible inconsistency and was rejected
+    * before re-validation. Outcomes are examined in key order, so the result is deterministic.
     */
   private def validateRecordedResults(
       requestId: RequestId,
@@ -112,7 +115,7 @@ class ExternalCallCheck(
       ec: ExecutionContext,
   ): FutureUnlessShutdown[Result] = {
     val occurrencesByKey = recordedResults
-      .groupMap { case (_, result) => DAMLe.ExternalCallKey.fromResult(result.result) } {
+      .groupMap { case (_, result) => ExternalCallKey.fromResult(result.result) } {
         case (viewPosition, result) =>
           ExternalCallOccurrence(viewPosition, result.exerciseIndex, result.callIndex) ->
             result.result.output

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -6,13 +6,9 @@ package com.digitalasset.canton.participant.protocol.validation
 import cats.Order
 import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
-import com.digitalasset.canton.data.{ParticipantTransactionView, ViewPosition}
+import com.digitalasset.canton.data.ExternalCallPayloadDescription.{byteCount, hexPayloadSize}
+import com.digitalasset.canton.data.{ExternalCallKey, ParticipantTransactionView, ViewPosition}
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
-import com.digitalasset.canton.participant.util.DAMLe
-import com.digitalasset.canton.participant.util.ExternalCallPayloadDescription.{
-  byteCount,
-  hexPayloadSize,
-}
 import com.digitalasset.canton.util.ByteStringUtil
 import com.digitalasset.daml.lf.data.Bytes
 import com.google.protobuf.ByteString
@@ -49,7 +45,7 @@ object ExternalCallConsistencyChecker {
       .orElseBy(_.callIndex.unwrap)
 
   final case class Inconsistency(
-      key: DAMLe.ExternalCallKey,
+      key: ExternalCallKey,
       outputs: Set[Bytes],
       occurrences: Set[ExternalCallOccurrence],
   ) extends PrettyPrinting {
@@ -108,7 +104,7 @@ object ExternalCallConsistencyChecker {
     *   [[com.digitalasset.canton.data.ViewParticipantData.ViewExternalCallResult]].
     */
   private final case class VisibleExternalCallOccurrence(
-      key: DAMLe.ExternalCallKey,
+      key: ExternalCallKey,
       output: Bytes,
       occurrence: ExternalCallOccurrence,
       checkingParties: Set[LfPartyId],
@@ -127,13 +123,13 @@ object ExternalCallConsistencyChecker {
     import scala.math.Ordering.Implicits.seqOrdering
     implicit val occurrenceOrdering: Ordering[ExternalCallOccurrence] = orderExternalCallOccurrence
     Ordering
-      .by[Inconsistency, DAMLe.ExternalCallKey](_.key)
+      .by[Inconsistency, ExternalCallKey](_.key)
       .orElseBy(_.outputs)(orderOutputSets)
       .orElseBy(_.occurrences.toSeq.sorted)
   }
 
   private def inconsistencyFor(
-      key: DAMLe.ExternalCallKey,
+      key: ExternalCallKey,
       outputsAndOccurrences: Seq[(Bytes, ExternalCallOccurrence)],
   ): Option[Inconsistency] = {
     val occurrencesByOutput = outputsAndOccurrences.groupMap(_._1)(_._2)
@@ -159,7 +155,7 @@ object ExternalCallConsistencyChecker {
             externalCallResult.callIndex,
           )
           VisibleExternalCallOccurrence(
-            DAMLe.ExternalCallKey.fromResult(externalCallResult.result),
+            ExternalCallKey.fromResult(externalCallResult.result),
             externalCallResult.result.output,
             occurrence,
             externalCallResult.checkingParties,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidator.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallValidator.scala
@@ -3,14 +3,14 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
+import com.digitalasset.canton.data.ExternalCallKey
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.daml.lf.data.Bytes
 
 trait ExternalCallValidator {
   def validate(
-      key: DAMLe.ExternalCallKey,
+      key: ExternalCallKey,
       recordedOutput: Bytes,
   )(implicit traceContext: TraceContext): FutureUnlessShutdown[ExternalCallValidator.Result]
 }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -5,7 +5,8 @@ package com.digitalasset.canton.participant.util
 
 import cats.data.EitherT
 import cats.syntax.either.*
-import com.digitalasset.canton.data.{CantonTimestamp, LedgerTimeBoundaries}
+import com.digitalasset.canton.data.ExternalCallPayloadDescription.{byteCount, byteSize}
+import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallKey, LedgerTimeBoundaries}
 import com.digitalasset.canton.interactive.InteractiveSubmissionEnricher
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdownImpl.*
@@ -14,11 +15,6 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.protocol.EngineController.GetEngineAbortStatus
 import com.digitalasset.canton.participant.store.ReplayContractLookup
 import com.digitalasset.canton.participant.util.DAMLe.*
-import com.digitalasset.canton.participant.util.ExternalCallPayloadDescription.{
-  byteCount,
-  byteSize,
-  hexPayloadSize,
-}
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.topology.ParticipantId
 import com.digitalasset.canton.topology.client.TopologySnapshot
@@ -154,38 +150,6 @@ object DAMLe {
     override protected def pretty: Pretty[ExternalCallReplayMissing] = prettyOfClass(
       param("key", _.key)
     )
-  }
-
-  /** Deterministic external-call identity. Config and input are engine-emitted canonical hex
-    * strings. The pretty-printed form deliberately shows only payload sizes, never the payloads.
-    */
-  final case class ExternalCallKey(
-      extensionId: String,
-      functionId: String,
-      config: String,
-      input: String,
-  ) extends PrettyPrinting {
-    override protected def pretty: Pretty[ExternalCallKey] = prettyOfClass(
-      param("extension id", _.extensionId.doubleQuoted),
-      param("function id", _.functionId.doubleQuoted),
-      param("config bytes", key => hexPayloadSize(key.config).doubleQuoted),
-      param("input bytes", key => hexPayloadSize(key.input).doubleQuoted),
-    )
-  }
-
-  object ExternalCallKey {
-
-    /** Orders by the semantic identity fields, lexicographically. */
-    implicit val externalCallKeyOrdering: Ordering[ExternalCallKey] =
-      Ordering.by(key => (key.extensionId, key.functionId, key.config, key.input))
-
-    def fromResult(result: ExternalCallResult): ExternalCallKey =
-      ExternalCallKey(
-        result.extensionId,
-        result.functionId,
-        result.config.toHexString,
-        result.input.toHexString,
-      )
   }
 
   /** External-call replay data: recorded outputs indexed by semantic key. Multiple outputs for one

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -5,9 +5,9 @@ package com.digitalasset.canton.participant.extension
 
 import com.digitalasset.canton.BaseTest
 import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.data.ExternalCallKey
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidator
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.Thereafter.syntax.*
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference
 class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseTest {
 
   private val externalCallKey =
-    DAMLe.ExternalCallKey(
+    ExternalCallKey(
       extensionId = "extension-id",
       functionId = "function-id",
       config = "00010203",

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -7,6 +7,7 @@ import cats.data.EitherT
 import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
 import com.digitalasset.canton.data.{
   CantonTimestamp,
+  ExternalCallKey,
   ParticipantTransactionView,
   PathRollbackContextFactory,
   TransactionView,
@@ -22,7 +23,6 @@ import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsi
   ExternalCallOccurrence,
   Inconsistency,
 }
-import com.digitalasset.canton.participant.util.DAMLe
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.protocol.ExampleTransactionFactory.{
   signatory,
@@ -66,8 +66,8 @@ final class ExternalCallProtocolIntegrationTest
 
   private val confirmers: Set[LfPartyId] = Set(submitter, signatory)
 
-  private val externalCallKey: DAMLe.ExternalCallKey =
-    DAMLe.ExternalCallKey.fromResult(externalCallResult)
+  private val externalCallKey: ExternalCallKey =
+    ExternalCallKey.fromResult(externalCallResult)
 
   private val leftViewPosition: ViewPosition =
     ViewPosition(
@@ -79,15 +79,15 @@ final class ExternalCallProtocolIntegrationTest
     )
 
   private final class RecordingExternalCallValidator(
-      results: Map[DAMLe.ExternalCallKey, ExternalCallValidator.Result]
+      results: Map[ExternalCallKey, ExternalCallValidator.Result]
   ) extends ExternalCallValidator {
-    private val observedKeys: ConcurrentLinkedQueue[DAMLe.ExternalCallKey] =
-      new ConcurrentLinkedQueue[DAMLe.ExternalCallKey]
+    private val observedKeys: ConcurrentLinkedQueue[ExternalCallKey] =
+      new ConcurrentLinkedQueue[ExternalCallKey]
 
-    def observed: Seq[DAMLe.ExternalCallKey] = observedKeys.asScala.toSeq
+    def observed: Seq[ExternalCallKey] = observedKeys.asScala.toSeq
 
     override def validate(
-        key: DAMLe.ExternalCallKey,
+        key: ExternalCallKey,
         recordedOutput: Bytes,
     )(implicit
         traceContext: TraceContext

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/util/DAMLeExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/util/DAMLeExternalCallTest.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.canton.participant.util
 
-import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallKey}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.participant.protocol.EngineController.EngineAbortStatus
 import com.digitalasset.canton.participant.store.ReplayContractLookup
@@ -79,7 +79,7 @@ final class DAMLeExternalCallTest
   )
   private val defaultReplayData =
     DAMLe.ExternalCallReplayData.fromResults(Seq(externalCallResult))
-  private val externalCallKey = DAMLe.ExternalCallKey.fromResult(externalCallResult)
+  private val externalCallKey = ExternalCallKey.fromResult(externalCallResult)
 
   private val packageResolver = new PackageResolver {
     override protected def resolveInternal(packageId: PackageId)(implicit


### PR DESCRIPTION
Pure move, no behavior change: relocate `ExternalCallKey` and the `ExternalCallPayloadDescription` payload-size helper from the participant `DAMLe` engine wrapper into `community/base` (`com.digitalasset.canton.data`).

## Why

`ExternalCallKey` is a protocol-data identity (four canonical strings plus an ordering) derived from `ViewParticipantData.ViewExternalCallResult`, which already lives in `base`. Moving it there lets `TransactionView.validated` fail fast on a recorded-result disagreement in the follow-up — the centralization requested at https://github.com/digital-asset/canton/pull/552#discussion_r3506482637 — and keeps the "same external call" identity in one place rather than split across `DAMLe` and the participant validators.

## On the target package (r3506626583)

The suggestion at https://github.com/digital-asset/canton/pull/552#discussion_r3506626583 was to give `ExternalCallKey` its own file under `com.digitalasset.canton.participant.protocol.validation`. This PR instead puts it in `com.digitalasset.canton.data` (base), because the fail-fast centralization (r3506482637) requires `TransactionView.validated` — which lives in `community/base` — to compute `ExternalCallReplayData` keyed by `ExternalCallKey`. `base` cannot depend on `participant`, so the key has to live in `base` for that step to be possible. This honors the encapsulation intent of the original comment (own file, no longer buried in `DAMLe`) at the location the architectural change dictates. Nesting the key privately inside `ExternalCallReplayData` is not viable — the consistency checker and validators group and order by it.

`ExternalCallReplayData` and its `ReinterpretationError`-typed disagreement stay in `DAMLe` for now; they move to `base` (collapsed to a single output per key) in the fail-fast change.

## Scope

- New `community/base/.../data/ExternalCallKey.scala` and `.../data/ExternalCallPayloadDescription.scala` (verbatim moves; `private[canton]` visibility preserved).
- References repointed in `DAMLe`, `ExternalCallCheck`, `ExternalCallConsistencyChecker`, `ExternalCallValidator`, `ExtensionServiceExternalCallValidator`, and their tests.

## Testing

`community-participant/Test/compile` green; external-call suites green at `CANTON_PROTOCOL_VERSION=dev` (`DAMLeExternalCallTest`, `ExternalCallConsistencyCheckerTest`, `ExtensionServiceExternalCallValidatorTest`, `ExternalCallProtocolIntegrationTest` — 29/0/0).

Part of the #565 post-merge cleanup. Refs #565.
