### PR TITLE
feat(external-call): fail fast on recorded-result disagreements in TransactionView

### DIFF
--- a/community/app/src/test/scala/com/digitalasset/canton/participant/util/DAMLeTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/participant/util/DAMLeTest.scala
@@ -5,7 +5,7 @@ package com.digitalasset.canton.participant.util
 
 import cats.data.EitherT
 import cats.syntax.either.*
-import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallReplayData}
 import com.digitalasset.canton.examples.java.cycle.Cycle
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdownImpl.*
@@ -101,7 +101,7 @@ class DAMLeTest
           packageResolution = Map.empty,
           expectFailure = false,
           getEngineAbortStatus = getEngineAbortStatus,
-          externalCallReplayData = () => DAMLe.ExternalCallReplayData.empty,
+          externalCallReplayData = () => ExternalCallReplayData.empty,
         )
 
     def createCycleContract(): (LfNodeCreate, LfHash, GenContractInstance) = {

--- a/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.data
+
+import cats.syntax.either.*
+import com.digitalasset.canton.data.ExternalCallPayloadDescription.{byteCount, byteSize}
+import com.digitalasset.canton.util.collection.MapsUtil
+import com.digitalasset.daml.lf.data.Bytes
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+
+/** External-call replay data: the single recorded output per semantic call, indexed by
+  * [[ExternalCallKey]].
+  *
+  * Constructed only via [[ExternalCallReplayData.fromResults]], which fails if a key is recorded
+  * with more than one distinct output. A value of this type therefore always maps a key to the one
+  * unambiguous output to replay, which is why [[outputFor]] returns a plain `Option`.
+  */
+final case class ExternalCallReplayData private (
+    outputsByKey: Map[ExternalCallKey, Bytes]
+) {
+  def outputFor(key: ExternalCallKey): Option[Bytes] = outputsByKey.get(key)
+}
+
+object ExternalCallReplayData {
+  val empty: ExternalCallReplayData = ExternalCallReplayData(Map.empty)
+
+  /** Indexes the recorded results by their semantic [[ExternalCallKey]]. Identical results recorded
+    * in several occurrences collapse to a single entry; a key recorded with more than one distinct
+    * output yields a `Left` describing the conflict by payload size only, never the payload bytes.
+    */
+  def fromResults(
+      results: Iterable[ExternalCallResult]
+  ): Either[String, ExternalCallReplayData] =
+    MapsUtil
+      .toNonConflictingMap(results.map(result => ExternalCallKey.fromResult(result) -> result.output))
+      .leftMap(conflictMessage)
+      .map(ExternalCallReplayData(_))
+
+  private def conflictMessage(conflicts: Map[ExternalCallKey, Set[Bytes]]): String = {
+    val details = conflicts.toSeq
+      .sortBy { case (key, _) => key }
+      .map { case (key, outputs) =>
+        s"$key with outputs ${outputs.toSeq.sortBy(byteCount).map(byteSize).mkString("[", ", ", "]")}"
+      }
+    s"externalCallResults records conflicting outputs for the same external call: ${details.mkString("; ")}"
+  }
+}

--- a/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
@@ -32,9 +32,20 @@ object ExternalCallReplayData {
   def fromResults(
       results: Iterable[ExternalCallResult]
   ): Either[String, ExternalCallReplayData] =
+    merge(Seq.empty, results)
+
+  /** Combines already-indexed subview replay data with a view's own recorded results. Reusing the
+    * subviews' data means the keys of a result are derived only once, at the view that records it,
+    * and a conflict is reported at the lowest view whose subtree contains it.
+    */
+  def merge(
+      subviewData: Iterable[ExternalCallReplayData],
+      ownResults: Iterable[ExternalCallResult],
+  ): Either[String, ExternalCallReplayData] =
     MapsUtil
       .toNonConflictingMap(
-        results.map(result => ExternalCallKey.fromResult(result) -> result.output)
+        subviewData.flatMap(_.outputsByKey) ++
+          ownResults.map(result => ExternalCallKey.fromResult(result) -> result.output)
       )
       .leftMap(conflictMessage)
       .map(ExternalCallReplayData(_))

--- a/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/ExternalCallReplayData.scala
@@ -33,7 +33,9 @@ object ExternalCallReplayData {
       results: Iterable[ExternalCallResult]
   ): Either[String, ExternalCallReplayData] =
     MapsUtil
-      .toNonConflictingMap(results.map(result => ExternalCallKey.fromResult(result) -> result.output))
+      .toNonConflictingMap(
+        results.map(result => ExternalCallKey.fromResult(result) -> result.output)
+      )
       .leftMap(conflictMessage)
       .map(ExternalCallReplayData(_))
 

--- a/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
@@ -241,7 +241,8 @@ final case class TransactionView private (
   /** The single recorded output per external-call key, aggregated over this view and its subviews.
     *
     * @throws java.lang.IllegalStateException
-    *   if the same key was recorded with conflicting outputs, which a validated view cannot contain
+    *   if the [[ViewParticipantData]] of this view or any subview is blinded, or if the same key
+    *   was recorded with conflicting outputs, which a validated view cannot contain
     */
   def externalCallReplayData(implicit
       loggingContext: NamedLoggingContext
@@ -254,10 +255,25 @@ final case class TransactionView private (
     inputsAndCreatedE.map(_._2)
 
   private lazy val externalCallReplayDataE: Either[String, ExternalCallReplayData] =
-    // Recurses via the subviews' memoized values, so the aggregation costs each view only its
-    // direct children plus its own results, and stays trivial for views without any results.
+    for {
+      vpd <- unblindViewParticipantData("External-call replay data")
+      _ <- subviews.allUnblinded(hash =>
+        s"External-call replay data of view $viewHash can be computed only if all subviews are unblinded, but $hash is blinded"
+      )
+      subviewData <- subviews.unblindedElements.traverse(_.externalCallReplayDataE)
+      merged <- ExternalCallReplayData.merge(subviewData, vpd.externalCallResults.map(_.result))
+    } yield merged
+
+  /** Conflict check for `validated` over the visible parts of the subtree: blinded participant data
+    * and blinded subviews contribute no results, like the other `validated` checks, which also skip
+    * blinded data — `validated` runs while blinding, so it must tolerate blinded parts.
+    * [[externalCallReplayDataE]] instead reports blinded data as an error, so replay never runs on
+    * silently-partial data. Both recurse via the subviews' memoized values, so the aggregation
+    * costs each view only its direct children plus its own results.
+    */
+  private lazy val visibleExternalCallReplayDataE: Either[String, ExternalCallReplayData] =
     subviews.unblindedElements
-      .traverse(_.externalCallReplayDataE)
+      .traverse(_.visibleExternalCallReplayDataE)
       .flatMap(subviewData =>
         ExternalCallReplayData.merge(
           subviewData,
@@ -384,7 +400,7 @@ final case class TransactionView private (
       // Grouped with the participant-data validation above: a key recorded with conflicting
       // outputs across this view's subtree makes the view malformed, because reinterpretation
       // cannot proceed on an ambiguous recorded result.
-      _ <- externalCallReplayDataE
+      _ <- visibleExternalCallReplayDataE
       _ <- viewCommonData.unwrap match {
         case Left(_) => Either.unit
         case Right(d) => validateViewCommonData(d, childCommonData)

--- a/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
@@ -244,7 +244,7 @@ final case class TransactionView private (
     *   if the [[ViewParticipantData]] of this view or any subview is blinded, or if the same key
     *   was recorded with conflicting outputs, which a validated view cannot contain
     */
-  def externalCallReplayData(implicit
+  def tryExternalCallReplayData(implicit
       loggingContext: NamedLoggingContext
   ): ExternalCallReplayData = getOrError(externalCallReplayDataE)
 

--- a/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
@@ -238,11 +238,27 @@ final case class TransactionView private (
       loggingContext: NamedLoggingContext
   ): Map[LfContractId, CreatedContractInView] = getOrError(createdContractsE)
 
+  /** The single recorded output per external-call key, aggregated over this view and its subviews.
+    *
+    * @throws java.lang.IllegalStateException
+    *   if the same key was recorded with conflicting outputs, which a validated view cannot contain
+    */
+  def externalCallReplayData(implicit
+      loggingContext: NamedLoggingContext
+  ): ExternalCallReplayData = getOrError(externalCallReplayDataE)
+
   private def inputContractsE: Either[String, Map[LfContractId, InputContract]] =
     inputsAndCreatedE.map(_._1)
 
   private def createdContractsE: Either[String, Map[LfContractId, CreatedContractInView]] =
     inputsAndCreatedE.map(_._2)
+
+  private lazy val externalCallReplayDataE: Either[String, ExternalCallReplayData] =
+    ExternalCallReplayData.fromResults(
+      flatten
+        .flatMap(_.viewParticipantData.unwrap.toOption.toList.flatMap(_.externalCallResults))
+        .map(_.result)
+    )
 
   private lazy val inputsAndCreatedE: Either[
     String,
@@ -358,6 +374,10 @@ final case class TransactionView private (
         case Right(d) =>
           validateViewParticipantData(d, childParticipantData, inputContractsO)
       }
+      // Grouped with the participant-data validation above: a key recorded with conflicting
+      // outputs across this view's subtree makes the view malformed, because reinterpretation
+      // cannot proceed on an ambiguous recorded result.
+      _ <- externalCallReplayDataE
       _ <- viewCommonData.unwrap match {
         case Left(_) => Either.unit
         case Right(d) => validateViewCommonData(d, childCommonData)

--- a/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/TransactionView.scala
@@ -254,11 +254,18 @@ final case class TransactionView private (
     inputsAndCreatedE.map(_._2)
 
   private lazy val externalCallReplayDataE: Either[String, ExternalCallReplayData] =
-    ExternalCallReplayData.fromResults(
-      flatten
-        .flatMap(_.viewParticipantData.unwrap.toOption.toList.flatMap(_.externalCallResults))
-        .map(_.result)
-    )
+    // Recurses via the subviews' memoized values, so the aggregation costs each view only its
+    // direct children plus its own results, and stays trivial for views without any results.
+    subviews.unblindedElements
+      .traverse(_.externalCallReplayDataE)
+      .flatMap(subviewData =>
+        ExternalCallReplayData.merge(
+          subviewData,
+          viewParticipantData.unwrap.toOption.toList
+            .flatMap(_.externalCallResults)
+            .map(_.result),
+        )
+      )
 
   private lazy val inputsAndCreatedE: Either[
     String,

--- a/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
@@ -46,7 +46,10 @@ class ExternalCallReplayDataTest extends AnyWordSpec with BaseTest {
 
     "reject a key recorded with conflicting outputs without leaking the payloads" in {
       val error =
-        ExternalCallReplayData.fromResults(Seq(result("output-one"), result("output-two"))).left.value
+        ExternalCallReplayData
+          .fromResults(Seq(result("output-one"), result("output-two")))
+          .left
+          .value
       error should startWith(
         "externalCallResults records conflicting outputs for the same external call:"
       )

--- a/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
@@ -50,13 +50,44 @@ class ExternalCallReplayDataTest extends AnyWordSpec with BaseTest {
           .fromResults(Seq(result("output-one"), result("output-two")))
           .left
           .value
-      error should startWith(
-        "externalCallResults records conflicting outputs for the same external call:"
-      )
-      error should not include "output-one"
-      error should not include "output-two"
+      error shouldBe conflictMessageFor("function")
+      // Payloads would surface as hex renderings of the bytes, never as the raw strings.
+      error should not include Bytes.fromStringUtf8("output-one").toHexString
+      error should not include Bytes.fromStringUtf8("output-two").toHexString
       error should not include Bytes.fromStringUtf8("config").toHexString
       error should not include Bytes.fromStringUtf8("input").toHexString
     }
   }
+
+  "ExternalCallReplayData.merge" should {
+
+    "combine subview data with own results" in {
+      val subview = ExternalCallReplayData.fromResults(Seq(result("out-a"))).value
+      val merged = ExternalCallReplayData
+        .merge(Seq(subview), Seq(result("out-b", functionId = "other")))
+        .value
+      merged.outputsByKey should have size 2
+    }
+
+    "collapse identical entries across subviews and own results" in {
+      val subview = ExternalCallReplayData.fromResults(Seq(result("output"))).value
+      ExternalCallReplayData
+        .merge(Seq(subview, subview), Seq(result("output")))
+        .value shouldBe subview
+    }
+
+    "reject conflicting outputs across subviews" in {
+      val subviewA = ExternalCallReplayData.fromResults(Seq(result("output-one"))).value
+      val subviewB = ExternalCallReplayData.fromResults(Seq(result("output-two"))).value
+      ExternalCallReplayData
+        .merge(Seq(subviewA, subviewB), Seq.empty)
+        .left
+        .value shouldBe conflictMessageFor("function")
+    }
+  }
+
+  private def conflictMessageFor(functionId: String): String =
+    "externalCallResults records conflicting outputs for the same external call: " +
+      s"""ExternalCallKey(extension id = "extension", function id = "$functionId", """ +
+      """config bytes = "6 bytes", input bytes = "5 bytes") with outputs [10 bytes, 10 bytes]"""
 }

--- a/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/ExternalCallReplayDataTest.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.data
+
+import com.digitalasset.canton.BaseTest
+import com.digitalasset.daml.lf.data.Bytes
+import com.digitalasset.daml.lf.transaction.ExternalCallResult
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExternalCallReplayDataTest extends AnyWordSpec with BaseTest {
+
+  private def result(output: String, functionId: String = "function"): ExternalCallResult =
+    ExternalCallResult(
+      extensionId = "extension",
+      functionId = functionId,
+      config = Bytes.fromStringUtf8("config"),
+      input = Bytes.fromStringUtf8("input"),
+      output = Bytes.fromStringUtf8(output),
+    )
+
+  "ExternalCallReplayData.fromResults" should {
+
+    "index a single output per key" in {
+      val data = ExternalCallReplayData.fromResults(Seq(result("output"))).value
+      data.outputFor(ExternalCallKey.fromResult(result("output"))) shouldBe
+        Some(Bytes.fromStringUtf8("output"))
+    }
+
+    "collapse identical results recorded in several occurrences" in {
+      val data =
+        ExternalCallReplayData.fromResults(Seq(result("output"), result("output"))).value
+      data.outputsByKey should have size 1
+    }
+
+    "keep distinct keys apart" in {
+      val data = ExternalCallReplayData
+        .fromResults(Seq(result("out-a"), result("out-b", functionId = "other")))
+        .value
+      data.outputsByKey should have size 2
+    }
+
+    "return empty replay data for no results" in {
+      ExternalCallReplayData.fromResults(Seq.empty).value shouldBe ExternalCallReplayData.empty
+    }
+
+    "reject a key recorded with conflicting outputs without leaking the payloads" in {
+      val error =
+        ExternalCallReplayData.fromResults(Seq(result("output-one"), result("output-two"))).left.value
+      error should startWith(
+        "externalCallResults records conflicting outputs for the same external call:"
+      )
+      error should not include "output-one"
+      error should not include "output-two"
+      error should not include Bytes.fromStringUtf8("config").toHexString
+      error should not include Bytes.fromStringUtf8("input").toHexString
+    }
+  }
+}

--- a/community/common/src/test/scala/com/digitalasset/canton/data/GeneratorsData.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/GeneratorsData.scala
@@ -182,21 +182,23 @@ final class GeneratorsData(
           exerciseIndex,
           checkingParties,
         )
-      }.map(results =>
-        // Distinct semantic keys only: a key recorded with conflicting outputs makes the view
-        // malformed (rejected by TransactionView.validated), which must not be generated here.
-        results
-          .distinctBy { case (result, _, _) => ExternalCallKey.fromResult(result) }
-          .zipWithIndex
-          .map { case ((result, exerciseIndex, checkingParties), callIndex) =>
-            ViewParticipantData.ViewExternalCallResult(
-              result = result,
-              exerciseIndex = exerciseIndex,
-              callIndex = NonNegativeInt.tryCreate(callIndex),
-              checkingParties = checkingParties,
-            )
-          }
-      )
+      }.map { results =>
+        // A key recorded with conflicting outputs makes the view malformed (rejected by
+        // TransactionView.validated) and must not be generated. Several occurrences recording
+        // the same output for one key are legal, so they keep their multiplicity and only the
+        // outputs are canonicalized per key.
+        val canonicalOutputByKey = results.groupMapReduce { case (result, _, _) =>
+          ExternalCallKey.fromResult(result)
+        } { case (result, _, _) => result.output }((first, _) => first)
+        results.zipWithIndex.map { case ((result, exerciseIndex, checkingParties), callIndex) =>
+          ViewParticipantData.ViewExternalCallResult(
+            result = result.copy(output = canonicalOutputByKey(ExternalCallKey.fromResult(result))),
+            exerciseIndex = exerciseIndex,
+            callIndex = NonNegativeInt.tryCreate(callIndex),
+            checkingParties = checkingParties,
+          )
+        }
+      }
     } else Gen.const(Seq.empty)
 
   val createViewParticipantDataArb: Arbitrary[ViewParticipantData] = Arbitrary(

--- a/community/common/src/test/scala/com/digitalasset/canton/data/GeneratorsData.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/GeneratorsData.scala
@@ -183,14 +183,19 @@ final class GeneratorsData(
           checkingParties,
         )
       }.map(results =>
-        results.zipWithIndex.map { case ((result, exerciseIndex, checkingParties), callIndex) =>
-          ViewParticipantData.ViewExternalCallResult(
-            result = result,
-            exerciseIndex = exerciseIndex,
-            callIndex = NonNegativeInt.tryCreate(callIndex),
-            checkingParties = checkingParties,
-          )
-        }
+        // Distinct semantic keys only: a key recorded with conflicting outputs makes the view
+        // malformed (rejected by TransactionView.validated), which must not be generated here.
+        results
+          .distinctBy { case (result, _, _) => ExternalCallKey.fromResult(result) }
+          .zipWithIndex
+          .map { case ((result, exerciseIndex, checkingParties), callIndex) =>
+            ViewParticipantData.ViewExternalCallResult(
+              result = result,
+              exerciseIndex = exerciseIndex,
+              callIndex = NonNegativeInt.tryCreate(callIndex),
+              checkingParties = checkingParties,
+            )
+          }
       )
     } else Gen.const(Seq.empty)
 

--- a/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
@@ -7,6 +7,7 @@ import cats.syntax.either.*
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.crypto.{HashOps, Salt, TestSalt}
 import com.digitalasset.canton.data.ViewParticipantData.InvalidViewParticipantData
+import com.digitalasset.canton.logging.NamedLoggingContext
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.protocol.v30.ActionDescription.FetchActionDescription
 import com.digitalasset.canton.util.ShowUtil.*
@@ -634,6 +635,60 @@ class TransactionViewTest
         )
         error should not include externalCallResult.output.toHexString
         error should not include Bytes.fromStringUtf8("other-output").toHexString
+      }
+    }
+
+    "parts of the view are blinded" must {
+      // Blinding legitimately constructs views with blinded participant data or subviews (and
+      // `validated` runs on them), so validation must tolerate blinded parts; the replay-data
+      // accessor must instead refuse them, so replay never runs on silently-partial data.
+      "validate the view but refuse to compute the replay data" in {
+        implicit val namedLoggingContext: NamedLoggingContext =
+          NamedLoggingContext(loggerFactory, traceContext)
+        val view = factory.SingleExercise(seed = ExampleTransactionFactory.lfHash(3)).view0
+        val child = TransactionView.Optics.viewCommonDataUnsafe
+          .andThen(MerkleTree.Optics.unblinded[ViewCommonData])
+          .modify(_.copy(salt = TestSalt.generateSalt(1)))
+          .apply(view)
+        val subviews =
+          TransactionSubviews(Seq(child.blindFully))(testedProtocolVersion, factory.cryptoOps)
+
+        val created = TransactionView
+          .create(hashOps)(
+            view.viewCommonData,
+            view.viewParticipantData,
+            subviews,
+            testedProtocolVersion,
+          )
+          .value
+
+        val blindedHash = created.subviews.blindedElements.loneElement
+        loggerFactory.assertInternalError[IllegalStateException](
+          created.externalCallReplayData,
+          _.getMessage shouldBe s"External-call replay data of view ${created.viewHash} can be" +
+            s" computed only if all subviews are unblinded, but $blindedHash is blinded",
+        )
+      }
+
+      "validate a view whose own participant data is blinded but refuse the replay data" in {
+        implicit val namedLoggingContext: NamedLoggingContext =
+          NamedLoggingContext(loggerFactory, traceContext)
+        val view = factory.SingleExercise(seed = ExampleTransactionFactory.lfHash(3)).view0
+        val subviews = TransactionSubviews(Seq.empty)(testedProtocolVersion, factory.cryptoOps)
+        val created = TransactionView
+          .create(hashOps)(
+            view.viewCommonData,
+            view.viewParticipantData.blindFully,
+            subviews,
+            testedProtocolVersion,
+          )
+          .value
+
+        loggerFactory.assertInternalError[IllegalStateException](
+          created.externalCallReplayData,
+          _.getMessage shouldBe s"External-call replay data of view ${created.viewHash} can be" +
+            s" computed only if the view participant data is unblinded",
+        )
       }
     }
 

--- a/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
@@ -592,9 +592,9 @@ class TransactionViewTest
     }
 
     "the same external call is recorded with conflicting outputs across a view and its subview" must {
-      // The aggregation spans the whole subtree (`flatten`): a key recorded in the parent core
-      // and again, differently, in a subview core is a disagreement even though neither view's
-      // participant data conflicts on its own.
+      // The aggregation spans the whole subtree: a key recorded in the parent core and again,
+      // differently, in a subview core is a disagreement even though neither view's participant
+      // data conflicts on its own.
       "reject the parent view as malformed" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
         val view = factory.SingleExercise(seed = ExampleTransactionFactory.lfHash(3)).view0
         def withCall(output: String): TransactionView =
@@ -611,7 +611,13 @@ class TransactionViewTest
           )(view)
 
         val parent = withCall("output")
-        val child = withCall("other-output")
+        // A distinct salt keeps the child's viewCommonData different from the parent's, so the
+        // fixture stays valid for the equal-viewCommonData check and this test isolates the
+        // external-call disagreement.
+        val child = TransactionView.Optics.viewCommonDataUnsafe
+          .andThen(MerkleTree.Optics.unblinded[ViewCommonData])
+          .modify(_.copy(salt = TestSalt.generateSalt(1)))
+          .apply(withCall("other-output"))
         val subviews = TransactionSubviews(Seq(child))(testedProtocolVersion, factory.cryptoOps)
 
         val error = TransactionView

--- a/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
@@ -664,7 +664,7 @@ class TransactionViewTest
 
         val blindedHash = created.subviews.blindedElements.loneElement
         loggerFactory.assertInternalError[IllegalStateException](
-          created.externalCallReplayData,
+          created.tryExternalCallReplayData,
           _.getMessage shouldBe s"External-call replay data of view ${created.viewHash} can be" +
             s" computed only if all subviews are unblinded, but $blindedHash is blinded",
         )
@@ -685,7 +685,7 @@ class TransactionViewTest
           .value
 
         loggerFactory.assertInternalError[IllegalStateException](
-          created.externalCallReplayData,
+          created.tryExternalCallReplayData,
           _.getMessage shouldBe s"External-call replay data of view ${created.viewHash} can be" +
             s" computed only if the view participant data is unblinded",
         )

--- a/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
+++ b/community/common/src/test/scala/com/digitalasset/canton/data/TransactionViewTest.scala
@@ -556,6 +556,81 @@ class TransactionViewTest
       }
     }
 
+    "the same external call is recorded with conflicting outputs in one view" must {
+      // Distinct occurrences share a semantic key but record different outputs: the participant
+      // data is well-formed on its own; the disagreement is caught when the view is validated.
+      "reject the view as malformed without leaking the payloads" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+        val vpd = create(
+          actionDescription = exerciseActionDescription,
+          coreInputs = exerciseCoreInputs,
+          externalCallResults = Seq(
+            viewExternalCallResult(exerciseIndex = 7, callIndex = 0),
+            viewExternalCallResult(
+              exerciseIndex = 7,
+              callIndex = 1,
+              result = externalCallResult.copy(output = Bytes.fromStringUtf8("other-output")),
+            ),
+          ),
+        ).value
+
+        val commonData =
+          factory.SingleExercise(seed = ExampleTransactionFactory.lfHash(3)).view0.viewCommonData
+        val subviews = TransactionSubviews(Seq.empty)(testedProtocolVersion, factory.cryptoOps)
+
+        val error = TransactionView
+          .create(hashOps)(commonData, vpd, subviews, testedProtocolVersion)
+          .left
+          .value
+        error should startWith(
+          "externalCallResults records conflicting outputs for the same external call:"
+        )
+        error should not include externalCallResult.output.toHexString
+        error should not include Bytes.fromStringUtf8("other-output").toHexString
+        error should not include externalCallResult.config.toHexString
+        error should not include externalCallResult.input.toHexString
+      }
+    }
+
+    "the same external call is recorded with conflicting outputs across a view and its subview" must {
+      // The aggregation spans the whole subtree (`flatten`): a key recorded in the parent core
+      // and again, differently, in a subview core is a disagreement even though neither view's
+      // participant data conflicts on its own.
+      "reject the parent view as malformed" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+        val view = factory.SingleExercise(seed = ExampleTransactionFactory.lfHash(3)).view0
+        def withCall(output: String): TransactionView =
+          TransactionView.Optics.viewParticipantDataUnsafe.modify(vpd =>
+            vpd.tryUnwrap.copy(externalCallResults =
+              Seq(
+                viewExternalCallResult(
+                  exerciseIndex = 7,
+                  callIndex = 0,
+                  result = externalCallResult.copy(output = Bytes.fromStringUtf8(output)),
+                )
+              )
+            )
+          )(view)
+
+        val parent = withCall("output")
+        val child = withCall("other-output")
+        val subviews = TransactionSubviews(Seq(child))(testedProtocolVersion, factory.cryptoOps)
+
+        val error = TransactionView
+          .create(hashOps)(
+            parent.viewCommonData,
+            parent.viewParticipantData,
+            subviews,
+            testedProtocolVersion,
+          )
+          .left
+          .value
+        error should startWith(
+          "externalCallResults records conflicting outputs for the same external call:"
+        )
+        error should not include externalCallResult.output.toHexString
+        error should not include Bytes.fromStringUtf8("other-output").toHexString
+      }
+    }
+
     "external call results on a non-dev protocol version" must {
       "reject creation" onlyRunWithOrLessThan ProtocolVersion.v35 in {
         create(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactory.scala
@@ -113,10 +113,6 @@ class NextGenTransactionTreeFactory(
       )
 
     for {
-      _ <- EitherT.fromEither[FutureUnlessShutdown](
-        checkExternalCallResultConsistency(transaction)
-      )
-
       submitterMetadata <- SubmitterMetadata
         .fromSubmitterInfo(cryptoOps)(
           submitterActAs = submitterInfo.actAs,
@@ -465,18 +461,20 @@ class NextGenTransactionTreeFactory(
         externalCallResults,
       )
 
-    } yield {
-      // Compute the result
-      val subviews = TransactionSubviews(childViews)(protocolVersion, cryptoOps)
-      val transactionView =
-        TransactionView.tryCreate(cryptoOps)(
-          viewCommonData,
-          viewParticipantData,
-          subviews,
-          protocolVersion,
-        )
-      transactionView
-    }
+      // A soft error rather than tryCreate: view validation can fail on submitted data (e.g.
+      // conflicting recorded external-call outputs, reachable from a crafted execute request or
+      // a non-deterministic extension service), which must reject the submission gracefully.
+      transactionView <- EitherT.fromEither[FutureUnlessShutdown](
+        TransactionView
+          .create(cryptoOps)(
+            viewCommonData,
+            viewParticipantData,
+            TransactionSubviews(childViews)(protocolVersion, cryptoOps),
+            protocolVersion,
+          )
+          .leftMap[TransactionTreeConversionError](InvalidTransactionViewError.apply)
+      )
+    } yield transactionView
   }
 
   private def updateStateWithContractCreation(
@@ -854,24 +852,6 @@ class NextGenTransactionTreeFactory(
 }
 
 object NextGenTransactionTreeFactory {
-
-  /** A transaction that records conflicting outputs for the same external call cannot form a valid
-    * transaction tree: `TransactionView.validated` fails any view whose subtree contains the
-    * conflict. Reject the transaction with a typed error before view construction instead of
-    * hitting the factory's view-invariant check.
-    */
-  private[submission] def checkExternalCallResultConsistency(
-      transaction: WellFormedTransaction[WithoutSuffixes]
-  ): Either[TransactionTreeConversionError, Unit] =
-    ExternalCallReplayData
-      .fromResults(
-        transaction.unwrap.nodes.values.toSeq.flatMap {
-          case exercise: LfNodeExercises => exercise.externalCallResults.toSeq
-          case _ => Seq.empty
-        }
-      )
-      .leftMap(ConflictingExternalCallResultsError.apply)
-      .map(_ => ())
 
   private[submission] def externalCallResultsFromCoreNode(
       exerciseIndex: NonNegativeInt,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactory.scala
@@ -113,6 +113,10 @@ class NextGenTransactionTreeFactory(
       )
 
     for {
+      _ <- EitherT.fromEither[FutureUnlessShutdown](
+        checkExternalCallResultConsistency(transaction)
+      )
+
       submitterMetadata <- SubmitterMetadata
         .fromSubmitterInfo(cryptoOps)(
           submitterActAs = submitterInfo.actAs,
@@ -850,6 +854,24 @@ class NextGenTransactionTreeFactory(
 }
 
 object NextGenTransactionTreeFactory {
+
+  /** A transaction that records conflicting outputs for the same external call cannot form a valid
+    * transaction tree: `TransactionView.validated` fails any view whose subtree contains the
+    * conflict. Reject the transaction with a typed error before view construction instead of
+    * hitting the factory's view-invariant check.
+    */
+  private[submission] def checkExternalCallResultConsistency(
+      transaction: WellFormedTransaction[WithoutSuffixes]
+  ): Either[TransactionTreeConversionError, Unit] =
+    ExternalCallReplayData
+      .fromResults(
+        transaction.unwrap.nodes.values.toSeq.flatMap {
+          case exercise: LfNodeExercises => exercise.externalCallResults.toSeq
+          case _ => Seq.empty
+        }
+      )
+      .leftMap(ConflictingExternalCallResultsError.apply)
+      .map(_ => ())
 
   private[submission] def externalCallResultsFromCoreNode(
       exerciseIndex: NonNegativeInt,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactory.scala
@@ -208,6 +208,16 @@ object TransactionTreeFactory {
     }
   }
 
+  /** Indicates that the submitted transaction records conflicting outputs for the same external
+    * call, so no valid transaction tree can be formed from it.
+    */
+  final case class ConflictingExternalCallResultsError(message: String)
+      extends TransactionTreeConversionError {
+    override protected def pretty: Pretty[ConflictingExternalCallResultsError] = prettyOfClass(
+      unnamedParam(_.message.unquoted)
+    )
+  }
+
   final case class ContractIdAbsolutizationError(message: String)
       extends TransactionTreeConversionError {
     override protected def pretty: Pretty[ContractIdAbsolutizationError] = prettyOfClass(

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/submission/TransactionTreeFactory.scala
@@ -208,12 +208,12 @@ object TransactionTreeFactory {
     }
   }
 
-  /** Indicates that the submitted transaction records conflicting outputs for the same external
-    * call, so no valid transaction tree can be formed from it.
+  /** Indicates that a constructed view failed validation, e.g. because the submitted transaction
+    * records conflicting outputs for the same external call.
     */
-  final case class ConflictingExternalCallResultsError(message: String)
+  final case class InvalidTransactionViewError(message: String)
       extends TransactionTreeConversionError {
-    override protected def pretty: Pretty[ConflictingExternalCallResultsError] = prettyOfClass(
+    override protected def pretty: Pretty[InvalidTransactionViewError] = prettyOfClass(
       unnamedParam(_.message.unquoted)
     )
   }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -35,8 +35,8 @@ import scala.concurrent.ExecutionContext
   * `ExternalCallCheck.Result`: a disagreement from either part rejects the request on behalf of all
   * hosted confirming parties, and a recorded result that cannot be re-validated leads to an
   * abstention instead of an approval (see [[TransactionConfirmationResponsesFactory]]).
-  * Disagreements within the replay data of a single reinterpretation already surface as
-  * model-conformance errors independently of this check.
+  * Disagreements among the recorded results within a single view's subtree are rejected earlier, as
+  * a malformed view when the view is validated, independently of this check.
   *
   * @param externalCallValidator
   *   The validator used to re-run external calls against the extension service.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
@@ -311,7 +311,7 @@ class ModelConformanceChecker(
           packagePreference,
           failed,
           getEngineAbortStatus,
-          () => view.externalCallReplayData,
+          () => view.tryExternalCallReplayData,
         )(traceContext)
         .leftMap(DAMLeError(_, view.viewHash))
         .leftWiden[Error]

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
@@ -271,26 +271,6 @@ class ModelConformanceChecker(
       } yield nameBindings
     })
 
-  private def externalCallReplayDataFor(
-      view: TransactionView
-  )(implicit
-      traceContext: TraceContext
-  ): ExternalCallReplayData = {
-    val externalCallResults = view.flatten.flatMap { currentView =>
-      currentView.viewParticipantData.unwrap match {
-        case Right(vpd) => vpd.externalCallResults
-        case _ => Seq.empty
-      }
-    }
-    val replayData = ExternalCallReplayData.fromResults(externalCallResults.map(_.result))
-
-    logger.debug(
-      s"reInterpret: Aggregated ${replayData.size} external call result keys"
-    )
-
-    replayData
-  }
-
   def reInterpret(
       view: TransactionView,
       ledgerTime: CantonTimestamp,
@@ -314,8 +294,7 @@ class ModelConformanceChecker(
       view.viewParticipantData.tryUnwrap.keyResolution.fmap(_.unversioned.contracts),
     )
 
-    lazy val externalCallReplayData: ExternalCallReplayData =
-      externalCallReplayDataFor(view)
+    lazy val externalCallReplayData = view.externalCallReplayData
 
     for {
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ModelConformanceChecker.scala
@@ -294,8 +294,6 @@ class ModelConformanceChecker(
       view.viewParticipantData.tryUnwrap.keyResolution.fmap(_.unversioned.contracts),
     )
 
-    lazy val externalCallReplayData = view.externalCallReplayData
-
     for {
 
       packagePreference <- buildPackageNameMap(packageIdPreference, topologySnapshot, ledgerTime)
@@ -313,7 +311,7 @@ class ModelConformanceChecker(
           packagePreference,
           failed,
           getEngineAbortStatus,
-          () => externalCallReplayData,
+          () => view.externalCallReplayData,
         )(traceContext)
         .leftMap(DAMLeError(_, view.viewHash))
         .leftWiden[Error]

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/util/DAMLe.scala
@@ -5,8 +5,12 @@ package com.digitalasset.canton.participant.util
 
 import cats.data.EitherT
 import cats.syntax.either.*
-import com.digitalasset.canton.data.ExternalCallPayloadDescription.{byteCount, byteSize}
-import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallKey, LedgerTimeBoundaries}
+import com.digitalasset.canton.data.{
+  CantonTimestamp,
+  ExternalCallKey,
+  ExternalCallReplayData,
+  LedgerTimeBoundaries,
+}
 import com.digitalasset.canton.interactive.InteractiveSubmissionEnricher
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdownImpl.*
@@ -24,16 +28,12 @@ import com.digitalasset.canton.util.PackageConsumer.PackageResolver
 import com.digitalasset.canton.util.Thereafter.syntax.*
 import com.digitalasset.canton.{LfCommand, LfPackageId, LfPartyId}
 import com.digitalasset.daml.lf.data.Ref.{PackageId, PackageName}
-import com.digitalasset.daml.lf.data.{Bytes as LfBytes, ImmArray, Ref}
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.engine.ResultNeedContract.Response
 import com.digitalasset.daml.lf.engine.{Enricher as _, *}
 import com.digitalasset.daml.lf.interpretation.InterpretationConfig
 import com.digitalasset.daml.lf.language.{Ast, LanguageVersion}
-import com.digitalasset.daml.lf.transaction.{
-  ExternalCallResult,
-  FatContractInstance,
-  NeedKeyProgression,
-}
+import com.digitalasset.daml.lf.transaction.{FatContractInstance, NeedKeyProgression}
 import com.digitalasset.daml.lf.value.ContractIdVersion
 
 import java.nio.file.Path
@@ -125,62 +125,12 @@ object DAMLe {
     override protected def pretty: Pretty[EnrichmentError] = adHocPrettyInstance
   }
 
-  final case class ExternalCallRecordedResultDisagreement(
-      key: ExternalCallKey,
-      outputs: Set[LfBytes],
-  ) extends ReinterpretationError {
-    override protected def pretty: Pretty[ExternalCallRecordedResultDisagreement] = prettyOfClass(
-      param("key", _.key),
-      param("recorded output count", _.outputs.size),
-      param(
-        "recorded output bytes",
-        disagreement =>
-          disagreement.outputs.toSeq
-            .sortBy(byteCount)
-            .map(byteSize)
-            .mkString("[", ", ", "]")
-            .doubleQuoted,
-      ),
-    )
-  }
-
   final case class ExternalCallReplayMissing(
       key: ExternalCallKey
   ) extends ReinterpretationError {
     override protected def pretty: Pretty[ExternalCallReplayMissing] = prettyOfClass(
       param("key", _.key)
     )
-  }
-
-  /** External-call replay data: recorded outputs indexed by semantic key. Multiple outputs for one
-    * semantic key are preserved so replay can report a recorded-result disagreement.
-    */
-  final case class ExternalCallReplayData private (
-      outputsByKey: Map[ExternalCallKey, Set[LfBytes]]
-  ) {
-    def size: Int = outputsByKey.size
-
-    def outputFor(
-        key: ExternalCallKey
-    ): Either[ExternalCallRecordedResultDisagreement, Option[LfBytes]] =
-      outputsByKey.get(key) match {
-        case None => Right(None)
-        case Some(outputs) if outputs.sizeCompare(1) == 0 => Right(outputs.headOption)
-        case Some(outputs) => Left(ExternalCallRecordedResultDisagreement(key, outputs))
-      }
-  }
-
-  object ExternalCallReplayData {
-    val empty: ExternalCallReplayData = ExternalCallReplayData(Map.empty)
-
-    def fromResults(results: Iterable[ExternalCallResult]): ExternalCallReplayData =
-      ExternalCallReplayData(
-        results
-          .groupMap(ExternalCallKey.fromResult)(_.output)
-          .view
-          .mapValues(_.toSet)
-          .toMap
-      )
   }
 
   trait HasReinterpret {
@@ -397,13 +347,10 @@ class DAMLe(
         resume: Either[ResultNeedExternalCall.Error, String] => Result[A],
     ): FutureUnlessShutdown[Either[ReinterpretationError, A]] =
       externalCallReplayData().outputFor(externalCallKey) match {
-        case Left(disagreement) =>
-          FutureUnlessShutdown.pure(Left(disagreement))
-
-        case Right(None) =>
+        case None =>
           FutureUnlessShutdown.pure(Left(ExternalCallReplayMissing(externalCallKey)))
 
-        case Right(Some(storedOutput)) =>
+        case Some(storedOutput) =>
           logger.debug(
             s"Replaying recorded external call result for extension=${externalCallKey.extensionId}, function=${externalCallKey.functionId}"
           )

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactoryTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactoryTest.scala
@@ -343,6 +343,35 @@ final class NextGenTransactionTreeFactoryTest
             }
           }
 
+          "reject a transaction recording conflicting outputs for the same external call" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+            val treeFactory = createTransactionTreeFactory()
+            val example = factory.TransientContracts
+            val childExternalCallNodeId = LfNodeId(3)
+            val parentExternalCallNodeId = LfNodeId(5)
+
+            createTransactionTree(
+              treeFactory,
+              withExternalCallResults(
+                example,
+                Map(
+                  childExternalCallNodeId -> ImmArray(
+                    externalCallResult.copy(output = Bytes.fromStringUtf8("output-1"))
+                  ),
+                  parentExternalCallNodeId -> ImmArray(
+                    externalCallResult.copy(output = Bytes.fromStringUtf8("output-2"))
+                  ),
+                ),
+              ),
+              successfulLookup(example),
+            ).value.map { result =>
+              result.left.value shouldBe ConflictingExternalCallResultsError(
+                "externalCallResults records conflicting outputs for the same external call: " +
+                  "ExternalCallKey(extension id = \"extension\", function id = \"function\", " +
+                  "config bytes = \"6 bytes\", input bytes = \"5 bytes\") with outputs [8 bytes, 8 bytes]"
+              )
+            }
+          }
+
           "record external call checking parties from signatories and actors" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
             val treeFactory = createTransactionTreeFactory()
             val example = factory.SingleExerciseWithNonstakeholderActor(factory.deriveNodeSeed(0))

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactoryTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/submission/NextGenTransactionTreeFactoryTest.scala
@@ -364,7 +364,7 @@ final class NextGenTransactionTreeFactoryTest
               ),
               successfulLookup(example),
             ).value.map { result =>
-              result.left.value shouldBe ConflictingExternalCallResultsError(
+              result.left.value shouldBe InvalidTransactionViewError(
                 "externalCallResults records conflicting outputs for the same external call: " +
                   "ExternalCallKey(extension id = \"extension\", function id = \"function\", " +
                   "config bytes = \"6 bytes\", input bytes = \"5 bytes\") with outputs [8 bytes, 8 bytes]"

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExampleTransactionConformanceTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExampleTransactionConformanceTest.scala
@@ -113,7 +113,7 @@ class ExampleTransactionConformanceTest
           packageResolution: Map[PackageName, PackageId],
           expectFailure: Boolean,
           getEngineAbortStatus: GetEngineAbortStatus,
-          externalCallReplayData: () => DAMLe.ExternalCallReplayData,
+          externalCallReplayData: () => ExternalCallReplayData,
       )(implicit traceContext: TraceContext): EitherT[
         FutureUnlessShutdown,
         DAMLe.ReinterpretationError,
@@ -161,7 +161,7 @@ class ExampleTransactionConformanceTest
           packageResolution: Map[PackageName, PackageId],
           expectFailure: Boolean,
           getEngineAbortStatus: GetEngineAbortStatus,
-          externalCallReplayData: () => DAMLe.ExternalCallReplayData,
+          externalCallReplayData: () => ExternalCallReplayData,
       )(implicit traceContext: TraceContext): EitherT[
         FutureUnlessShutdown,
         DAMLe.ReinterpretationError,
@@ -463,7 +463,7 @@ class ExampleTransactionConformanceTest
           output = Bytes.fromStringUtf8("output"),
         )
         val expectedReplayData =
-          DAMLe.ExternalCallReplayData.fromResults(Seq(externalCallResult))
+          ExternalCallReplayData.fromResults(Seq(externalCallResult)).value
         val example = factory.SingleExercise(factory.deriveNodeSeed(0))
         val transaction =
           withExternalCallResults(example, LfNodeId(0), ImmArray(externalCallResult))
@@ -512,9 +512,9 @@ class ExampleTransactionConformanceTest
         def observedExternalCallArguments(
             fullTree: FullTransactionViewTree,
             checkingParties: Set[LfPartyId],
-        ): Future[DAMLe.ExternalCallReplayData] = {
+        ): Future[ExternalCallReplayData] = {
           val observed = new AtomicReference[
-            Option[DAMLe.ExternalCallReplayData]
+            Option[ExternalCallReplayData]
           ](None)
           val recordingReinterpreter = new HasReinterpret {
             override def reinterpret(
@@ -529,7 +529,7 @@ class ExampleTransactionConformanceTest
                 packageResolution: Map[PackageName, PackageId],
                 expectFailure: Boolean,
                 getEngineAbortStatus: GetEngineAbortStatus,
-                externalCallReplayData: () => DAMLe.ExternalCallReplayData,
+                externalCallReplayData: () => ExternalCallReplayData,
             )(implicit traceContext: TraceContext): EitherT[
               FutureUnlessShutdown,
               DAMLe.ReinterpretationError,
@@ -590,7 +590,7 @@ class ExampleTransactionConformanceTest
 
       "observe empty external-call replay data" onlyRunWhen (testedProtocolVersion < ProtocolVersion.dev) in {
         val example = factory.SingleExercise(factory.deriveNodeSeed(0))
-        val observed = new AtomicReference[Option[DAMLe.ExternalCallReplayData]](None)
+        val observed = new AtomicReference[Option[ExternalCallReplayData]](None)
         val recordingReinterpreter = new HasReinterpret {
           override def reinterpret(
               contracts: ReplayContractLookup,
@@ -604,7 +604,7 @@ class ExampleTransactionConformanceTest
               packageResolution: Map[PackageName, PackageId],
               expectFailure: Boolean,
               getEngineAbortStatus: GetEngineAbortStatus,
-              externalCallReplayData: () => DAMLe.ExternalCallReplayData,
+              externalCallReplayData: () => ExternalCallReplayData,
           )(implicit traceContext: TraceContext): EitherT[
             FutureUnlessShutdown,
             DAMLe.ReinterpretationError,
@@ -641,7 +641,7 @@ class ExampleTransactionConformanceTest
           .failOnShutdown
           .map { result =>
             inside(result) { case Right(_) => succeed }
-            observed.get() shouldBe Some(DAMLe.ExternalCallReplayData.empty)
+            observed.get() shouldBe Some(ExternalCallReplayData.empty)
           }
       }
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/util/DAMLeExternalCallTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/util/DAMLeExternalCallTest.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.canton.participant.util
 
-import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallKey}
+import com.digitalasset.canton.data.{CantonTimestamp, ExternalCallKey, ExternalCallReplayData}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.participant.protocol.EngineController.EngineAbortStatus
 import com.digitalasset.canton.participant.store.ReplayContractLookup
@@ -78,7 +78,7 @@ final class DAMLeExternalCallTest
     output = Bytes.assertFromString("beef"),
   )
   private val defaultReplayData =
-    DAMLe.ExternalCallReplayData.fromResults(Seq(externalCallResult))
+    ExternalCallReplayData.fromResults(Seq(externalCallResult)).value
   private val externalCallKey = ExternalCallKey.fromResult(externalCallResult)
 
   private val packageResolver = new PackageResolver {
@@ -114,7 +114,7 @@ final class DAMLeExternalCallTest
   private val contracts = new ReplayContractLookup(Map(contract.contractId -> contract), Map.empty)
 
   private def runReinterpret(
-      replayData: DAMLe.ExternalCallReplayData = defaultReplayData
+      replayData: ExternalCallReplayData = defaultReplayData
   ): Either[DAMLe.ReinterpretationError, DAMLe.ReInterpretationResult] = {
     val damle = new DAMLe(
       participantId = DefaultTestIdentities.participant1,
@@ -148,7 +148,7 @@ final class DAMLeExternalCallTest
     "reject external calls without recorded output" in {
       inside(
         runReinterpret(
-          replayData = DAMLe.ExternalCallReplayData.empty
+          replayData = ExternalCallReplayData.empty
         )
       ) { case Left(error: DAMLe.ExternalCallReplayMissing) =>
         error.key shouldBe externalCallKey
@@ -165,27 +165,10 @@ final class DAMLeExternalCallTest
       }
     }
 
-    "reject conflicting semantic outputs without leaking their payloads" in {
-      val conflictingOutput = externalCallResult.copy(output = Bytes.assertFromString("cafe"))
-      val conflictingReplayData =
-        DAMLe.ExternalCallReplayData.fromResults(Seq(externalCallResult, conflictingOutput))
-
-      inside(
-        runReinterpret(
-          replayData = conflictingReplayData
-        )
-      ) { case Left(disagreement: DAMLe.ExternalCallRecordedResultDisagreement) =>
-        disagreement.toString should not include externalCallResult.output.toHexString
-        disagreement.toString should not include conflictingOutput.output.toHexString
-        disagreement.toString should not include externalCallResult.config.toHexString
-        disagreement.toString should not include externalCallResult.input.toHexString
-      }
-    }
-
     "not leak external-call payloads for replay errors" in {
       inside(
         runReinterpret(
-          replayData = DAMLe.ExternalCallReplayData.empty
+          replayData = ExternalCallReplayData.empty
         )
       ) { case Left(error: DAMLe.ExternalCallReplayMissing) =>
         error.key shouldBe externalCallKey


### PR DESCRIPTION
Centralizes the recorded external-call disagreement check in `TransactionView.validated`, per the #552 review ([r3506482637](https://github.com/digital-asset/canton/pull/552#discussion_r3506482637)) — moving from the fail-last model (a disagreement surfaced only during reinterpretation, as a model-conformance error) to fail-fast.

> Rebased onto `main` after #571 merged; the diff is now exactly this PR's change.

## What changes

- `TransactionView` computes `ExternalCallReplayData` over its subtree and **fails the view as malformed** if the same semantic key is recorded with conflicting outputs — so a view carrying an ambiguous recorded result is never reinterpreted. The aggregation recurses via the subviews' memoized values (`ExternalCallReplayData.merge`), so each view pays only for its direct children plus its own results, and views without results — every view below protocol version dev — cost effectively nothing. Exposed as a private `…E` used by `validated` plus a total accessor for consumers (the accessor skips blinded participant data, like the old `ModelConformanceChecker` aggregation did).
- `ExternalCallReplayData` moves to `community/base` as **single output per key** (`Map[ExternalCallKey, Bytes]`), built with `MapsUtil.toNonConflictingMap`.
- Removed: `ExternalCallRecordedResultDisagreement`, the multi-valued replay data and the late `outputFor` disagreement branch in `DAMLe`, and `ModelConformanceChecker.externalCallReplayDataFor` (now consumes the view's total `externalCallReplayData`).
- The conflict message is **size-only, never the payload bytes** (it is logged downstream).
- **Submission side**: `NextGenTransactionTreeFactory` builds views via `TransactionView.create` and surfaces a validation failure as a typed `InvalidTransactionViewError` (soft error), so a transaction whose recorded results conflict — reachable from a non-deterministic extension service or a crafted interactive-submission execute request — rejects gracefully instead of escaping as an uncaught `InvalidView`. (The legacy factory records no external-call results and is unchanged.)

## Behavioural note (verdict path for cross-view disagreements)

The check is grouped with the participant-data validation in `TransactionView.validated`. A conflict *within a single view* is caught cleanly at deserialization (→ `MalformedPayload`). A **cross-view** conflict (same key in a parent and a child view) is not visible until light-view-tree reassembly, where `validated` runs over the unblinded subtree and throws `InvalidView` at `LightTransactionViewTree.toFullViewTrees`.

This is the **same path the existing cross-view checks already take** — `validateViewParticipantData`'s package-preference check and `validateViewCommonData`'s equal-`viewCommonData` check are both cross-view, both only fire once subviews are unblinded, and both throw `InvalidView` at reassembly (no `catchOnly` there today), aborting the request. The transaction is not committed either way. So this PR inherits the established behaviour rather than introducing a new one; it does not add a `catchOnly`/`MalformedPayload` conversion at reassembly. Happy to follow up with one (it would give all three cross-view checks a clean malformed reject) if you'd prefer.

## Testing

`community-common` / `community-participant` / `community-app` Test compile green; `sbt format` clean. At `CANTON_PROTOCOL_VERSION=dev`: new `ExternalCallReplayDataTest` (`fromResults` + `merge`, conflict message pinned in full, payload no-leak asserted against the hex renderings), `TransactionViewTest` incl. within-view and across-parent/subview conflict cases (the cross-view fixture keeps the child's `viewCommonData` distinct, so it isolates the external-call rejection), `NextGenTransactionTreeFactoryTest` incl. the typed conflicting-results rejection, `ModelConformanceCheckerTest`, `ExampleTransactionConformanceTest`, `ExternalCallProtocolIntegrationTest`, `DAMLeExternalCallTest`, `SerializationDeserializationTest` — all green. `GeneratorsData` never generates a same-key/different-output view but keeps the legal same-key/same-output multiplicity in round-trip coverage.

Part of the #565 post-merge cleanup. Refs #565.
