### PR TITLE
refactor(external-call): render ExtensionCallError via PrettyPrinting

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.canton.participant.extension
 
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 
@@ -13,7 +14,14 @@ final case class ExtensionCallError(
     message: String,
     requestId: Option[String],
     retryable: Boolean,
-)
+) extends PrettyPrinting {
+  override protected def pretty: Pretty[ExtensionCallError] = prettyOfClass(
+    param("status code", _.statusCode),
+    param("message", _.message.doubleQuoted),
+    paramIfDefined("request id", _.requestId.map(_.singleQuoted)),
+    param("retryable", _.retryable),
+  )
+}
 
 /** Result of validating an extension service at startup. */
 sealed trait ExtensionValidationResult extends Product with Serializable

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -131,9 +131,8 @@ class ExtensionServiceManager(
     // Log the full error here, at the last common point before the per-consumer
     // sanitization drops the message.
     result.map(_.tapLeft { error =>
-      val requestId = error.requestId.fold("")(id => s", requestId=$id")
       logger.warn(
-        s"External call to extension '$extensionId' (function '$functionId') failed: status=${error.statusCode}, retryable=${error.retryable}$requestId, message=${error.message}"
+        s"External call to extension '$extensionId' (function '$functionId') failed: $error"
       )
     })
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -39,7 +39,7 @@ class ExtensionServiceExternalCallHandlerTest
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +
-            "status=404, retryable=false, message=Extension 'unknown-ext' not configured",
+            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false)",
         )
       } finally manager.close()
     }
@@ -90,10 +90,24 @@ class ExtensionServiceExternalCallHandlerTest
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +
-            "status=404, retryable=false, message=Extension 'unknown-ext' not configured",
+            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false)",
         )
       } finally manager.close()
     }
 
+  }
+
+  "ExtensionCallError" should {
+    // The full-error log interpolates `$error`, so its rendering (via PrettyPrinting) must cover
+    // every field -- in particular the optional request id, which the 404 cases above omit.
+    "render all fields, including the request id, via pretty-printing" in {
+      ExtensionCallError(
+        statusCode = 503,
+        message = "boom",
+        requestId = Some("req-1"),
+        retryable = true,
+      ).toString shouldBe
+        "ExtensionCallError(status code = 503, message = \"boom\", request id = 'req-1', retryable = true)"
+    }
   }
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -88,7 +88,7 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
             },
           _.warningMessage shouldBe
             "External call to extension 'extension-id' (function 'function-id') failed: " +
-            "status=404, retryable=false, message=Extension 'extension-id' not configured",
+            "ExtensionCallError(status code = 404, message = \"Extension 'extension-id' not configured\", retryable = false)",
         )
         .thereafter(_ => manager.close())
     }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -849,7 +849,7 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           },
           _.warningMessage shouldBe
             "External call to extension 'missing-extension' (function 'function') failed: " +
-            "status=404, retryable=false, message=Extension 'missing-extension' not configured",
+            "ExtensionCallError(status code = 404, message = \"Extension 'missing-extension' not configured\", retryable = false)",
         )
       } finally {
         manager.close()


### PR DESCRIPTION
Addresses the deferred cleanup from #553 ([r3527995304](https://github.com/digital-asset/canton/pull/553#discussion_r3527995304)): make `ExtensionCallError` implement `PrettyPrinting` instead of interpolating its fields one by one, so a newly added field renders in the full-error log automatically rather than being silently dropped.

## Change

- `ExtensionCallError` now `extends PrettyPrinting` (`prettyOfClass`, with `paramIfDefined` for the optional `requestId`).
- The full-error log in `ExtensionServiceManager` renders `$error` via the pretty instead of listing each field.

The two ledger-api-client-facing renderings (`ExtensionServiceExternalCallHandler.sanitizedEngineError` and the `ExtensionServiceExternalCallValidator` failure message) are intentionally left field-by-field: they deliberately expose only the status code and request id, never the message, so they must not use the full pretty.

## Testing

`community-participant/Test/compile` green; `sbt format` clean. `ExtensionServiceExternalCallHandlerTest`, `ExtensionServiceExternalCallValidatorTest`, `HttpExtensionServiceClientTest` green — the four full-error log assertions were updated to the pretty format, and a case covering the optional `requestId` rendering was added.

Part of the #565 post-merge cleanup. Refs #565.
