### PR TITLE
fix(external-call): improve engine-extension config validation messages

### DIFF
--- a/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
+++ b/community/app-base/src/main/scala/com/digitalasset/canton/config/ConfigValidations.scala
@@ -463,8 +463,8 @@ object ConfigValidations extends NamedLogging {
   ): Validated[NonEmpty[Seq[String]], Unit] = {
     val errors = engineExtensionErrors(config) { case (name, extensionId, extensionConfig) =>
       Option.when(extensionConfig.port == Port.Dynamic)(
-        s"For participant ${name.unwrap}, engine.extensions.$extensionId.port must be " +
-          s"between 1 and ${Port.maxValidPort}, but found '${extensionConfig.port}'"
+        s"For participant ${name.unwrap}, engine.extensions.$extensionId.port must not be the " +
+          s"dynamic port ${Port.Dynamic}"
       )
     }
     toValidated(errors)
@@ -478,7 +478,7 @@ object ConfigValidations extends NamedLogging {
         extensionConfig.retryInitialDelay.underlying > extensionConfig.retryMaxDelay.underlying
       )(
         s"For participant ${name.unwrap}, engine.extensions.$extensionId retry delays must satisfy retry-initial-delay <= retry-max-delay; " +
-          s"respective values are (${extensionConfig.retryInitialDelay.underlying}, ${extensionConfig.retryMaxDelay.underlying})"
+          s"respective values are ${extensionConfig.retryInitialDelay.underlying} and ${extensionConfig.retryMaxDelay.underlying}"
       )
     }
     toValidated(errors)

--- a/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
@@ -611,62 +611,6 @@ class CantonConfigTest extends AnyWordSpec with BaseTest {
       }
     }
 
-    "reject extension service port 0" in {
-      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
-        overrideFile.writeText(
-          """
-             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
-             |  address = "127.0.0.1"
-             |  port = 0
-             |  version = "v1"
-             |  tls.enabled = false
-             |}
-             |""".stripMargin
-        )
-
-        val result = loggerFactory.assertLogs(
-          CantonConfig.parseAndLoad(
-            Seq(simpleConf.toJava, overrideFile.toJava),
-            defaultPorts = None,
-          ),
-          _.errorMessage should include(
-            "For participant participant1, engine.extensions.external-call-test.port" +
-              " must not be the dynamic port 0"
-          ),
-        )
-
-        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
-      }
-    }
-
-    "reject retry delays where the initial delay exceeds the maximum delay" in {
-      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
-        overrideFile.writeText(
-          """
-             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
-             |  address = "127.0.0.1"
-             |  port = 12345
-             |  version = "v1"
-             |  tls.enabled = false
-             |  retry-initial-delay = 2s
-             |  retry-max-delay = 1s
-             |}
-             |""".stripMargin
-        )
-
-        val result = loggerFactory.assertLogs(
-          CantonConfig.parseAndLoad(
-            Seq(simpleConf.toJava, overrideFile.toJava),
-            defaultPorts = None,
-          ),
-          _.errorMessage should (include("external-call-test") and include(
-            "retry-initial-delay <= retry-max-delay"
-          )),
-        )
-
-        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
-      }
-    }
   }
 
   "config validation on duplicate storage" should {

--- a/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
@@ -583,36 +583,6 @@ class CantonConfigTest extends AnyWordSpec with BaseTest {
     }
   }
 
-  "config validation on engine extensions" should {
-    "reject API versions that are not single path segments" in {
-      File.usingTemporaryFile("extension-service", ".conf") { overrideFile =>
-        overrideFile.writeText(
-          """
-             |canton.participants.participant1.parameters.engine.extensions.external-call-test {
-             |  address = "127.0.0.1"
-             |  port = 12345
-             |  version = "v1/internal"
-             |  tls.enabled = false
-             |}
-             |""".stripMargin
-        )
-
-        val result = loggerFactory.assertLogs(
-          CantonConfig.parseAndLoad(
-            Seq(simpleConf.toJava, overrideFile.toJava),
-            defaultPorts = None,
-          ),
-          _.errorMessage should (include("external-call-test") and include(
-            "version"
-          ) and include("URI path segment")),
-        )
-
-        result.left.value shouldBe a[ConfigErrors.ValidationError.Error]
-      }
-    }
-
-  }
-
   "config validation on duplicate storage" should {
     "return a ValidationError during loading" in {
       val result = loggerFactory.assertLogs(

--- a/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/CantonConfigTest.scala
@@ -629,9 +629,10 @@ class CantonConfigTest extends AnyWordSpec with BaseTest {
             Seq(simpleConf.toJava, overrideFile.toJava),
             defaultPorts = None,
           ),
-          _.errorMessage should (include("external-call-test") and include("port") and include(
-            "between 1"
-          )),
+          _.errorMessage should include(
+            "For participant participant1, engine.extensions.external-call-test.port" +
+              " must not be the dynamic port 0"
+          ),
         )
 
         result.left.value shouldBe a[ConfigErrors.ValidationError.Error]

--- a/community/app/src/test/scala/com/digitalasset/canton/config/ConfigValidationsTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/ConfigValidationsTest.scala
@@ -643,6 +643,36 @@ class ConfigValidationsTest extends BaseTestWordSpec {
     }
   }
 
+  "engine extension api version checks" when {
+    "the version is not a valid URI path segment" should {
+      "fail" in {
+        assertErrors(
+          participantWithExtension(
+            ExtensionServiceConfig(
+              address = "localhost",
+              port = Port.tryCreate(8080),
+              version = "v1/extra",
+            )
+          )
+        )(
+          "For participant p1, engine.extensions.ext1.version must be a non-empty URI path" +
+            " segment containing only unreserved characters [A-Za-z0-9._~-], excluding '.' and" +
+            " '..', but found 'v1/extra'"
+        )
+      }
+    }
+
+    "a valid version is configured" should {
+      "succeed" in {
+        assertValid(
+          participantWithExtension(
+            ExtensionServiceConfig(address = "localhost", port = Port.tryCreate(8080))
+          )
+        )
+      }
+    }
+  }
+
   "nodes with crypto scheme configurations" should {
     def configWithSchemes(
         signingSchemeConfig: Option[SigningSchemeConfig] = None,

--- a/community/app/src/test/scala/com/digitalasset/canton/config/ConfigValidationsTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/config/ConfigValidationsTest.scala
@@ -21,6 +21,7 @@ import com.digitalasset.canton.http.JsonApiConfig
 import com.digitalasset.canton.integration.ConfigTransforms
 import com.digitalasset.canton.participant.config.{
   CantonEngineConfig,
+  ExtensionServiceConfig,
   LedgerApiServerConfig,
   ParticipantNodeConfig,
   ParticipantNodeParameterConfig,
@@ -584,6 +585,60 @@ class ConfigValidationsTest extends BaseTestWordSpec {
       )
       "succeed" in {
         assertValid(config)
+      }
+    }
+  }
+
+  private def participantWithExtension(extension: ExtensionServiceConfig): CantonConfig =
+    CantonConfig(
+      participants = Map(
+        InstanceName.tryCreate("p1") -> ParticipantNodeConfig(
+          parameters = ParticipantNodeParameterConfig(engine =
+            CantonEngineConfig(extensions = Map("ext1" -> extension))
+          )
+        )
+      )
+    )
+
+  "engine extension target port checks" when {
+    "the extension port is the dynamic port" should {
+      "fail" in {
+        assertErrors(
+          participantWithExtension(
+            ExtensionServiceConfig(address = "localhost", port = Port.Dynamic)
+          )
+        )(
+          "For participant p1, engine.extensions.ext1.port must not be the dynamic port 0"
+        )
+      }
+    }
+
+    "a fixed port is configured" should {
+      "succeed" in {
+        assertValid(
+          participantWithExtension(
+            ExtensionServiceConfig(address = "localhost", port = Port.tryCreate(8080))
+          )
+        )
+      }
+    }
+  }
+
+  "engine extension retry delay checks" when {
+    "retry-initial-delay exceeds retry-max-delay" should {
+      "fail" in {
+        assertErrors(
+          participantWithExtension(
+            ExtensionServiceConfig(
+              address = "localhost",
+              port = Port.tryCreate(8080),
+              retryInitialDelay = NonNegativeFiniteDuration.ofSeconds(10),
+              retryMaxDelay = NonNegativeFiniteDuration.ofSeconds(5),
+            )
+          )
+        )(
+          "For participant p1, engine.extensions.ext1 retry delays must satisfy retry-initial-delay <= retry-max-delay; respective values are 10 seconds and 5 seconds"
+        )
       }
     }
   }


### PR DESCRIPTION
Addresses two deferred cleanups from #553 on the participant `engine.extensions` config validation messages ([r3527966232](https://github.com/digital-asset/canton/pull/553#discussion_r3527966232), [r3527974592](https://github.com/digital-asset/canton/pull/553#discussion_r3527974592)).

## Changes

- **Target-port message** now derives from `Port.Dynamic` instead of hardcoding `"between 1 and <maxValidPort>"`. The old wording was fragile (breaks if `Port.Dynamic` changes) and misleading — `Port.minValidPort == 0`, so `0` is a valid `Port` value and the range wrongly implied it was out of range. The check is `port == Port.Dynamic`, so the message now says the port must not be the dynamic port.
- **Retry-delay message** grammar: `respective values are (x, y)` → `respective values are x and y`.
- Adds the first tests for these two validations (there were none): dynamic port → error, fixed port → valid, and `retry-initial-delay > retry-max-delay` → error.

Scope note: the sibling `"respective values are (x, y, z)"` message in `ConfigValidations` belongs to the sequencer-client retry-delay validation (pre-existing, not external-call); it is intentionally left untouched here.

## Testing

`community-app/Test/compile` green; `sbt format` clean; `ConfigValidationsTest` green (the three new tests assert the exact corrected messages).

Part of the #565 post-merge cleanup. Refs #565.
