### PR TITLE
test(external-call): fold prepare's await and annotate its return type

### DIFF
--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -8,6 +8,7 @@ import com.digitalasset.canton.data.DeduplicationPeriod.DeduplicationOffset
 import com.digitalasset.canton.data.LedgerTimeBoundaries
 import com.digitalasset.canton.interactive.InteractiveSubmissionEnricher
 import com.digitalasset.canton.ledger.api.{CommandId, Commands}
+import com.digitalasset.canton.ledger.error.groups.CommandExecutionErrors.InteractiveSubmissionPreparationError
 import com.digitalasset.canton.ledger.participant.state.index.ContractStore
 import com.digitalasset.canton.ledger.participant.state.{
   RoutingSynchronizerState,
@@ -164,18 +165,25 @@ class ExternalTransactionProcessorSpec
       submissionSeed: String,
       hashingSchemeVersion: HashingSchemeVersion,
       nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
-  ) = {
+  ): Either[
+    InteractiveSubmissionPreparationError.Reject,
+    ExternalTransactionProcessor.PrepareResult,
+  ] = {
     val (commandExecutionResult, commands) =
       commandExecutionResultFor(transaction, protocolVersion, submissionSeed, nodeSeeds)
     val processor = processorFor(transaction)
-    processor.processPrepare(
-      commandExecutionResult,
-      commands,
-      PositiveInt.one,
-      HashTracer.NoOp,
-      maxRecordTime = None,
-      hashingSchemeVersion = hashingSchemeVersion,
-    )
+    processor
+      .processPrepare(
+        commandExecutionResult,
+        commands,
+        PositiveInt.one,
+        HashTracer.NoOp,
+        maxRecordTime = None,
+        hashingSchemeVersion = hashingSchemeVersion,
+      )
+      .value
+      .failOnShutdown("prepare transaction")
+      .futureValue
   }
 
   "ExternalTransactionProcessor" should {
@@ -190,9 +198,9 @@ class ExternalTransactionProcessorSpec
         ProtocolVersion.v35,
         "prepared-requested-hash-version-test",
         HashingSchemeVersion.V3,
-      ).valueOrFailShutdown("prepare transaction").futureValue
+      )
 
-      result.hashVersion shouldBe HashingSchemeVersion.V3
+      result.value.hashVersion shouldBe HashingSchemeVersion.V3
     }
 
     "reject VDev prepared transactions when the requested hashing scheme is V2" in {
@@ -204,7 +212,7 @@ class ExternalTransactionProcessorSpec
         "prepared-vdev-requested-v2-test",
         HashingSchemeVersion.V2,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
-      ).value.failOnShutdown("prepare transaction").futureValue
+      )
 
       result.left.value.reason shouldBe
         "Cannot hash node with LF serialization version VDev using hashing scheme V2." +
@@ -220,9 +228,9 @@ class ExternalTransactionProcessorSpec
         "prepared-vdev-requested-v4-test",
         HashingSchemeVersion.V4,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v4-node")),
-      ).valueOrFailShutdown("prepare transaction").futureValue
+      )
 
-      result.hashVersion shouldBe HashingSchemeVersion.V4
+      result.value.hashVersion shouldBe HashingSchemeVersion.V4
     }
 
     "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is stable" in {
@@ -236,7 +244,7 @@ class ExternalTransactionProcessorSpec
         ProtocolVersion.v35,
         "prepared-pv35-requested-v4-test",
         HashingSchemeVersion.V4,
-      ).value.failOnShutdown("prepare transaction").futureValue
+      )
 
       result.left.value.reason shouldBe
         "Hashing scheme version V4 is not supported on protocol version 35." +


### PR DESCRIPTION
Two deferred `ExternalTransactionProcessorSpec` cleanups from #553.

- **Fold `prepare`'s await** ([r3528203484](https://github.com/digital-asset/canton/pull/553#discussion_r3528203484)): `.value.failOnShutdown("prepare transaction").futureValue` moves into `prepare`, which now returns the awaited `Either[InteractiveSubmissionPreparationError.Reject, PrepareResult]`. Call sites reduce to `prepare(...)` plus `.value.hashVersion` / `.left.value.reason`.
- **Type annotation** ([r3528195602](https://github.com/digital-asset/canton/pull/553#discussion_r3528195602)): `prepare` was the only top-level helper `def` without a return-type annotation; it now has one.

Behavior-preserving; the four existing tests are unchanged in outcome.

The remaining `ExternalTransactionProcessorSpec` cleanup ([r3528190170](https://github.com/digital-asset/canton/pull/553#discussion_r3528190170) — simplify the parameter list via `testedProtocolVersion` + protocol-version gating) is a larger, semantics-affecting restructure and will follow as a separate PR on top of this one.

## Testing

`ledger-api-core/Test/compile` green; `sbt format` clean; `ExternalTransactionProcessorSpec` green (4/4).

Part of the #565 post-merge cleanup. Refs #565.
