### PR TITLE
test(external-call): parametrize ExternalTransactionProcessorSpec on testedProtocolVersion

### DIFF
--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -27,7 +27,13 @@ import com.digitalasset.canton.platform.config.InteractiveSubmissionServiceConfi
 import com.digitalasset.canton.protocol.hash.HashTracer
 import com.digitalasset.canton.topology.DefaultTestIdentities
 import com.digitalasset.canton.version.{HashingSchemeVersion, ProtocolVersion}
-import com.digitalasset.canton.{BaseTest, HasExecutionContext, LedgerUserId, LfTimestamp}
+import com.digitalasset.canton.{
+  BaseTest,
+  HasExecutionContext,
+  LedgerUserId,
+  LfTimestamp,
+  ProtocolVersionChecksAnyWordSpec,
+}
 import com.digitalasset.daml.lf.command.ApiCommands
 import com.digitalasset.daml.lf.crypto.Hash as LfHash
 import com.digitalasset.daml.lf.data.{ImmArray, Ref}
@@ -51,18 +57,17 @@ class ExternalTransactionProcessorSpec
     with BaseTest
     with HasExecutionContext
     with MockitoSugar
-    with ArgumentMatchersSugar {
+    with ArgumentMatchersSugar
+    with ProtocolVersionChecksAnyWordSpec {
 
   private implicit val loggingContext: LoggingContextWithTrace = LoggingContextWithTrace.ForTesting
 
   private def commandExecutionResultFor(
       transaction: VersionedTransaction,
-      protocolVersion: ProtocolVersion,
-      submissionSeed: String,
-      nodeSeeds: ImmArray[(NodeId, LfHash)],
+      nodeIds: Seq[NodeId],
   ): (CommandExecutionResult, Commands) = {
     val physicalSynchronizerId =
-      DefaultTestIdentities.physicalSynchronizerId.copy(protocolVersion = protocolVersion)
+      DefaultTestIdentities.physicalSynchronizerId.copy(protocolVersion = testedProtocolVersion)
     val commandId = Ref.CommandId.assertFromString("command")
     val submitterInfo = SubmitterInfo(
       actAs = List.empty,
@@ -80,10 +85,12 @@ class ExternalTransactionProcessorSpec
       ledgerEffectiveTime = LfTimestamp.Epoch,
       workflowId = None,
       preparationTime = LfTimestamp.Epoch,
-      submissionSeed = LfHash.hashPrivateKey(submissionSeed),
+      submissionSeed = LfHash.hashPrivateKey("submission-seed"),
       timeBoundaries = LedgerTimeBoundaries.unconstrained,
       optUsedPackages = None,
-      optNodeSeeds = Some(nodeSeeds),
+      optNodeSeeds = Some(
+        ImmArray.from(nodeIds.map(id => id -> LfHash.hashPrivateKey(s"node-seed-${id.index}")))
+      ),
       optByKeyNodes = None,
     )
     val commandExecutionResult = CommandExecutionResult(
@@ -161,16 +168,14 @@ class ExternalTransactionProcessorSpec
 
   private def prepare(
       transaction: VersionedTransaction,
-      protocolVersion: ProtocolVersion,
-      submissionSeed: String,
       hashingSchemeVersion: HashingSchemeVersion,
-      nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
+      nodeIds: Seq[NodeId] = Seq.empty,
   ): Either[
     InteractiveSubmissionPreparationError.Reject,
     ExternalTransactionProcessor.PrepareResult,
   ] = {
     val (commandExecutionResult, commands) =
-      commandExecutionResultFor(transaction, protocolVersion, submissionSeed, nodeSeeds)
+      commandExecutionResultFor(transaction, nodeIds)
     val processor = processorFor(transaction)
     processor
       .processPrepare(
@@ -186,70 +191,54 @@ class ExternalTransactionProcessorSpec
       .futureValue
   }
 
+  // Hashing scheme V3 is supported only from v35 and V4 only from dev, so the tests asserting
+  // stable-protocol behaviour run on any released protocol version in [v35, dev) -- notably not v34,
+  // where V3 is unsupported.
+  private val onStableProtocolVersion: ProtocolVersion => Boolean =
+    pv => pv >= ProtocolVersion.v35 && pv < ProtocolVersion.dev
+
   "ExternalTransactionProcessor" should {
-    "honor the requested hashing scheme for non-dev prepared transactions" in {
+    "honor the requested hashing scheme for non-dev prepared transactions" onlyRunWhen onStableProtocolVersion in {
       val transaction = VersionedTransaction(
         LfSerializationVersion.V2,
         Map.empty,
         ImmArray.Empty,
       )
-      val result = prepare(
-        transaction,
-        ProtocolVersion.v35,
-        "prepared-requested-hash-version-test",
-        HashingSchemeVersion.V3,
-      )
+      val result = prepare(transaction, HashingSchemeVersion.V3)
 
       result.value.hashVersion shouldBe HashingSchemeVersion.V3
     }
 
-    "reject VDev prepared transactions when the requested hashing scheme is V2" in {
+    "reject VDev prepared transactions when the requested hashing scheme is V2" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val (nodeId, transaction) = vDevCreateTransaction("prepared-vdev-requested-v2-contract")
 
-      val result = prepare(
-        transaction,
-        ProtocolVersion.dev,
-        "prepared-vdev-requested-v2-test",
-        HashingSchemeVersion.V2,
-        ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
-      )
+      val result = prepare(transaction, HashingSchemeVersion.V2, Seq(nodeId))
 
       result.left.value.reason shouldBe
         "Cannot hash node with LF serialization version VDev using hashing scheme V2." +
         " Please use hashing scheme V4 or higher."
     }
 
-    "honor the requested hashing scheme for dev prepared transactions" in {
+    "honor the requested hashing scheme for dev prepared transactions" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val (nodeId, transaction) = vDevCreateTransaction("prepared-vdev-requested-v4-contract")
 
-      val result = prepare(
-        transaction,
-        ProtocolVersion.dev,
-        "prepared-vdev-requested-v4-test",
-        HashingSchemeVersion.V4,
-        ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v4-node")),
-      )
+      val result = prepare(transaction, HashingSchemeVersion.V4, Seq(nodeId))
 
       result.value.hashVersion shouldBe HashingSchemeVersion.V4
     }
 
-    "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is stable" in {
+    "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is stable" onlyRunWhen onStableProtocolVersion in {
       val transaction = VersionedTransaction(
         LfSerializationVersion.V2,
         Map.empty,
         ImmArray.Empty,
       )
-      val result = prepare(
-        transaction,
-        ProtocolVersion.v35,
-        "prepared-pv35-requested-v4-test",
-        HashingSchemeVersion.V4,
-      )
+      val result = prepare(transaction, HashingSchemeVersion.V4)
 
       result.left.value.reason shouldBe
-        "Hashing scheme version V4 is not supported on protocol version 35." +
+        s"Hashing scheme version V4 is not supported on protocol version $testedProtocolVersion." +
         " Minimum protocol version for hashing version V4: dev." +
-        " Supported hashing version on protocol version 35: V2, V3"
+        s" Supported hashing version on protocol version $testedProtocolVersion: V2, V3"
     }
   }
 }

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -8,6 +8,7 @@ import com.digitalasset.canton.data.DeduplicationPeriod.DeduplicationOffset
 import com.digitalasset.canton.data.LedgerTimeBoundaries
 import com.digitalasset.canton.interactive.InteractiveSubmissionEnricher
 import com.digitalasset.canton.ledger.api.{CommandId, Commands}
+import com.digitalasset.canton.ledger.error.groups.CommandExecutionErrors.InteractiveSubmissionPreparationError
 import com.digitalasset.canton.ledger.participant.state.index.ContractStore
 import com.digitalasset.canton.ledger.participant.state.{
   RoutingSynchronizerState,
@@ -164,18 +165,25 @@ class ExternalTransactionProcessorSpec
       submissionSeed: String,
       hashingSchemeVersion: HashingSchemeVersion,
       nodeSeeds: ImmArray[(NodeId, LfHash)] = ImmArray.Empty,
-  ) = {
+  ): Either[
+    InteractiveSubmissionPreparationError.Reject,
+    ExternalTransactionProcessor.PrepareResult,
+  ] = {
     val (commandExecutionResult, commands) =
       commandExecutionResultFor(transaction, protocolVersion, submissionSeed, nodeSeeds)
     val processor = processorFor(transaction)
-    processor.processPrepare(
-      commandExecutionResult,
-      commands,
-      PositiveInt.one,
-      HashTracer.NoOp,
-      maxRecordTime = None,
-      hashingSchemeVersion = hashingSchemeVersion,
-    )
+    processor
+      .processPrepare(
+        commandExecutionResult,
+        commands,
+        PositiveInt.one,
+        HashTracer.NoOp,
+        maxRecordTime = None,
+        hashingSchemeVersion = hashingSchemeVersion,
+      )
+      .value
+      .failOnShutdown("prepare transaction")
+      .futureValue
   }
 
   "ExternalTransactionProcessor" should {
@@ -190,9 +198,9 @@ class ExternalTransactionProcessorSpec
         ProtocolVersion.v35,
         "prepared-requested-hash-version-test",
         HashingSchemeVersion.V3,
-      ).valueOrFailShutdown("prepare transaction").futureValue
+      )
 
-      result.hashVersion shouldBe HashingSchemeVersion.V3
+      result.value.hashVersion shouldBe HashingSchemeVersion.V3
     }
 
     "reject VDev prepared transactions when the requested hashing scheme is V2" in {
@@ -204,7 +212,7 @@ class ExternalTransactionProcessorSpec
         "prepared-vdev-requested-v2-test",
         HashingSchemeVersion.V2,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v2-node")),
-      ).value.failOnShutdown("prepare transaction").futureValue
+      )
 
       result.left.value.reason shouldBe
         "Cannot hash node with LF serialization version VDev using hashing scheme V2." +
@@ -220,9 +228,9 @@ class ExternalTransactionProcessorSpec
         "prepared-vdev-requested-v4-test",
         HashingSchemeVersion.V4,
         ImmArray(nodeId -> LfHash.hashPrivateKey("prepared-vdev-requested-v4-node")),
-      ).valueOrFailShutdown("prepare transaction").futureValue
+      )
 
-      result.hashVersion shouldBe HashingSchemeVersion.V4
+      result.value.hashVersion shouldBe HashingSchemeVersion.V4
     }
 
     "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is stable" in {
@@ -236,7 +244,7 @@ class ExternalTransactionProcessorSpec
         ProtocolVersion.v35,
         "prepared-pv35-requested-v4-test",
         HashingSchemeVersion.V4,
-      ).value.failOnShutdown("prepare transaction").futureValue
+      )
 
       result.left.value.reason shouldBe
         "Hashing scheme version V4 is not supported on protocol version 35." +


### PR DESCRIPTION
The remaining `ExternalTransactionProcessorSpec` cleanup from #553 ([r3528190170](https://github.com/digital-asset/canton/pull/553#discussion_r3528190170)): stop hardcoding protocol versions so each test runs once at the version it exercises, rather than redundantly at every supported version ([the pattern from #552 r3506896881](https://github.com/digital-asset/canton/pull/552#discussion_r3506896881)).

> **Builds on #575** (fold `prepare`'s await + annotate its return type). This PR's diff is cumulative until #575 merges; the incremental slice is [here](https://github.com/zenith-network/canton/compare/angelol/external-call-565-processor-spec-cleanup...angelol/external-call-565-processor-spec-pv-gating).

## Changes

- The test synchronizer now uses `testedProtocolVersion`; the two stable-behaviour tests are gated to `[v35, dev)` and the two VDev tests to `dev` (`onlyRunWithOrGreaterThan(ProtocolVersion.dev)`). The stable V4-rejection message is derived from `testedProtocolVersion`.
- Parameter list simplified per the review: `protocolVersion` gone (→ `testedProtocolVersion`), `submissionSeed` a fixed dummy, and `nodeSeeds` replaced by `nodeIds: Seq[NodeId]` with seeds generated internally.

The stable gate is `pv >= v35 && pv < dev` rather than a bare `< dev` because hashing scheme V3 is unsupported at v34 (a `< dev`-only gate would run the V3-success test at v34 and fail); a code comment records this.

## Testing

`ledger-api-core/Test/compile` green; `sbt format` clean. Ran the spec at both the default protocol version (v35 → the two stable tests run, the VDev tests are ignored) and `CANTON_PROTOCOL_VERSION=dev` (→ the VDev tests run, the stable tests are ignored) — all four pass at their gated version.

Part of the #565 post-merge cleanup. Refs #565.
