### PR TITLE
fix(external-call): forward the full error to the submitting client

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -10,18 +10,25 @@ import com.digitalasset.canton.tracing.TraceContext
 
 /** Error information from external call failures.
   *
-  * `message` must stay client-safe: fixed descriptions, identifiers, and non-sensitive operational
-  * limits only -- never extension-service response bodies or credentials. The submission path
-  * forwards the whole error to the submitting ledger API client in the command rejection, so
-  * anything placed here becomes client-visible. (The Phase-3 validation path reduces the error to
-  * status code and request id before it reaches confirmation responses.)
+  * `clientActionable` marks errors whose message is actionable feedback for the submitting ledger
+  * API client (unknown extension, oversized response, invalid header value): the submission path
+  * forwards their full rendering in the command rejection. All other errors concern the
+  * communication between the participant and the extension service, and the client receives only a
+  * generic message with the retry status. The full error is always logged by
+  * [[ExtensionServiceManager.handleExternalCall]]. `message` must stay client-safe regardless:
+  * fixed descriptions, identifiers, and non-sensitive operational limits only -- never
+  * extension-service response bodies or credentials. (The Phase-3 validation path reduces every
+  * error to status code and request id before it reaches confirmation responses.)
   */
 final case class ExtensionCallError(
     statusCode: Int,
     message: String,
     requestId: Option[String],
     retryable: Boolean,
+    clientActionable: Boolean,
 ) extends PrettyPrinting {
+  // `clientActionable` is deliberately not rendered: the rendering doubles as the client-facing
+  // payload for actionable errors, and the flag is control metadata rather than error content.
   override protected def pretty: Pretty[ExtensionCallError] = prettyOfClass(
     param("status code", _.statusCode),
     param("message", _.message.doubleQuoted),

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -14,26 +14,32 @@ import com.digitalasset.canton.tracing.TraceContext
   * API client (unknown extension, oversized response, invalid header value): the submission path
   * forwards their full rendering in the command rejection. All other errors concern the
   * communication between the participant and the extension service, and the client receives only a
-  * generic message with the retry status. The full error is always logged by
-  * [[ExtensionServiceManager.handleExternalCall]]. `message` must stay client-safe regardless:
-  * fixed descriptions, identifiers, and non-sensitive operational limits only -- never
+  * generic message with the retry status and the tracing identifiers. The full error is always
+  * logged by [[ExtensionServiceManager.handleExternalCall]]. `message` must stay client-safe
+  * regardless: fixed descriptions, identifiers, and non-sensitive operational limits only -- never
   * extension-service response bodies or credentials. (The Phase-3 validation path reduces every
-  * error to status code and request id before it reaches confirmation responses.)
+  * error to status code and external call id before it reaches confirmation responses.)
+  *
+  * `externalCallId` is minted per HTTP request by [[HttpExtensionServiceClient]] (sent to the
+  * service as `X-Request-Id`); it is named to disambiguate from the Canton request id. Together
+  * with the trace id it correlates an error with the participant's and the service's logs.
   */
 final case class ExtensionCallError(
     statusCode: Int,
     message: String,
-    requestId: Option[String],
+    externalCallId: Option[String],
     retryable: Boolean,
     clientActionable: Boolean,
-) extends PrettyPrinting {
+)(implicit val traceContext: TraceContext)
+    extends PrettyPrinting {
   // `clientActionable` is deliberately not rendered: the rendering doubles as the client-facing
   // payload for actionable errors, and the flag is control metadata rather than error content.
   override protected def pretty: Pretty[ExtensionCallError] = prettyOfClass(
     param("status code", _.statusCode),
     param("message", _.message.doubleQuoted),
-    paramIfDefined("request id", _.requestId.map(_.singleQuoted)),
+    paramIfDefined("external call id", _.externalCallId.map(_.singleQuoted)),
     param("retryable", _.retryable),
+    paramIfDefined("trace id", _.traceContext.traceId.map(_.singleQuoted)),
   )
 }
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -8,7 +8,14 @@ import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 
-/** Error information from external call failures. */
+/** Error information from external call failures.
+  *
+  * `message` must stay client-safe: fixed descriptions, identifiers, and non-sensitive operational
+  * limits only -- never extension-service response bodies or credentials. The submission path
+  * forwards the whole error to the submitting ledger API client in the command rejection, so
+  * anything placed here becomes client-visible. (The Phase-3 validation path reduces the error to
+  * status code and request id before it reaches confirmation responses.)
+  */
 final case class ExtensionCallError(
     statusCode: Int,
     message: String,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceClient.scala
@@ -39,7 +39,7 @@ final case class ExtensionCallError(
     param("message", _.message.doubleQuoted),
     paramIfDefined("external call id", _.externalCallId.map(_.singleQuoted)),
     param("retryable", _.retryable),
-    paramIfDefined("trace id", _.traceContext.traceId.map(_.singleQuoted)),
+    param("trace id", _.traceContext),
   )
 }
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
@@ -37,13 +37,12 @@ class ExtensionServiceExternalCallHandler(
         mode = mode,
       )
       .map(_.left.map { extensionError =>
-        ResultNeedExternalCall.Error(sanitizedEngineError(extensionError))
+        // Surfaces to the submitting ledger API client in the command rejection, wrapped by the
+        // engine's "External call execution failed (extensionId=..., functionId=...)" rendering,
+        // and is not distributed to other nodes on this path -- so the whole error is forwarded.
+        // The message-content limits documented on ExtensionCallError keep it client-safe.
+        ResultNeedExternalCall.Error(extensionError.toString)
       })
-
-  private def sanitizedEngineError(extensionError: ExtensionCallError): String = {
-    val requestId = extensionError.requestId.fold("")(id => s", requestId=$id")
-    s"External call failed with status ${extensionError.statusCode}$requestId"
-  }
 }
 
 object ExtensionServiceExternalCallHandler {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
@@ -53,11 +53,13 @@ class ExtensionServiceExternalCallHandler(
 object ExtensionServiceExternalCallHandler {
 
   /** The client-facing rendering for errors that are not actionable for the client: only the retry
-    * status and the request id (for correlation with the participant's log) are exposed.
+    * status and the tracing identifiers (external call id and trace id, for correlation with the
+    * participant's log) are exposed.
     */
   private[extension] def genericClientMessage(error: ExtensionCallError): String = {
-    val requestId = error.requestId.fold("")(id => s", request id = '$id'")
-    s"External call failed (retryable = ${error.retryable}$requestId)"
+    val externalCallId = error.externalCallId.fold("")(id => s", external call id = '$id'")
+    val traceId = error.traceContext.traceId.fold("")(id => s", trace id = '$id'")
+    s"External call failed (retryable = ${error.retryable}$externalCallId$traceId)"
   }
 
   /** Create an ExternalCallHandler from an optional ExtensionServiceManager.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandler.scala
@@ -39,13 +39,26 @@ class ExtensionServiceExternalCallHandler(
       .map(_.left.map { extensionError =>
         // Surfaces to the submitting ledger API client in the command rejection, wrapped by the
         // engine's "External call execution failed (extensionId=..., functionId=...)" rendering,
-        // and is not distributed to other nodes on this path -- so the whole error is forwarded.
-        // The message-content limits documented on ExtensionCallError keep it client-safe.
-        ResultNeedExternalCall.Error(extensionError.toString)
+        // and is not distributed to other nodes on this path. Errors carrying actionable
+        // feedback are forwarded whole; communication problems between the participant and the
+        // extension service surface only generically, since the client cannot act on their
+        // details. The full error is always logged by ExtensionServiceManager.
+        val clientMessage =
+          if (extensionError.clientActionable) extensionError.toString
+          else ExtensionServiceExternalCallHandler.genericClientMessage(extensionError)
+        ResultNeedExternalCall.Error(clientMessage)
       })
 }
 
 object ExtensionServiceExternalCallHandler {
+
+  /** The client-facing rendering for errors that are not actionable for the client: only the retry
+    * status and the request id (for correlation with the participant's log) are exposed.
+    */
+  private[extension] def genericClientMessage(error: ExtensionCallError): String = {
+    val requestId = error.requestId.fold("")(id => s", request id = '$id'")
+    s"External call failed (retryable = ${error.retryable}$requestId)"
+  }
 
   /** Create an ExternalCallHandler from an optional ExtensionServiceManager.
     *

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidator.scala
@@ -32,9 +32,9 @@ class ExtensionServiceExternalCallValidator(
       )
       .map {
         case Left(error) =>
-          val requestId = error.requestId.fold("")(id => s", requestId=$id")
+          val externalCallId = error.externalCallId.fold("")(id => s", externalCallId=$id")
           ExternalCallValidator.UnableToValidate(
-            s"external-call validation failed with status ${error.statusCode}$requestId"
+            s"external-call validation failed with status ${error.statusCode}$externalCallId"
           )
 
         case Right(output) =>

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -129,8 +129,9 @@ class ExtensionServiceManager(
           )
         )
     }
-    // Log the full error here, at the last common point before the per-consumer
-    // sanitization drops the message.
+    // Log the full error here, at the last common point shared by both consumers: the
+    // Phase-3 validator reduces the error to status code and request id, and the submission
+    // handler's forwarded copy surfaces only in the ledger API command rejection.
     result.map(_.tapLeft { error =>
       logger.warn(
         s"External call to extension '$extensionId' (function '$functionId') failed: $error"

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -125,6 +125,7 @@ class ExtensionServiceManager(
               message = s"Extension '$extensionId' not configured",
               requestId = None,
               retryable = false,
+              clientActionable = true,
             )
           )
         )

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/ExtensionServiceManager.scala
@@ -123,7 +123,7 @@ class ExtensionServiceManager(
             ExtensionCallError(
               statusCode = 404,
               message = s"Extension '$extensionId' not configured",
-              requestId = None,
+              externalCallId = None,
               retryable = false,
               clientActionable = true,
             )
@@ -131,8 +131,8 @@ class ExtensionServiceManager(
         )
     }
     // Log the full error here, at the last common point shared by both consumers: the
-    // Phase-3 validator reduces the error to status code and request id, and the submission
-    // handler's forwarded copy surfaces only in the ledger API command rejection.
+    // Phase-3 validator reduces the error to status code and external call id, and the
+    // submission handler's forwarded copy surfaces only in the ledger API command rejection.
     result.map(_.tapLeft { error =>
       logger.warn(
         s"External call to extension '$extensionId' (function '$functionId') failed: $error"

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -280,6 +280,7 @@ class HttpExtensionServiceClient(
               s"Invalid external-call HTTP header value for $headerName",
               Some(requestId),
               retryable = false,
+              clientActionable = true,
             )
           )
         )
@@ -307,6 +308,7 @@ class HttpExtensionServiceClient(
                     s"Invalid extension service authentication configuration: $error",
                     Some(requestId),
                     retryable = false,
+                    clientActionable = false,
                   )
                 )
               )
@@ -397,30 +399,55 @@ class HttpExtensionServiceClient(
           s"External call response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes",
           Some(requestId),
           retryable = false,
+          clientActionable = true,
         )
 
       case timeout: java.net.http.HttpTimeoutException =>
         logger.warn(s"External call to extension '$extensionId' timed out: requestId=$requestId")
-        ExtensionCallError(408, "Request timeout", Some(requestId), retryable = true)
+        ExtensionCallError(
+          408,
+          "Request timeout",
+          Some(requestId),
+          retryable = true,
+          clientActionable = false,
+        )
 
       case connect: java.net.ConnectException =>
         logger.warn(
           s"External call to extension '$extensionId' connection failed: requestId=$requestId"
         )
-        ExtensionCallError(503, "Connection failed", Some(requestId), retryable = true)
+        ExtensionCallError(
+          503,
+          "Connection failed",
+          Some(requestId),
+          retryable = true,
+          clientActionable = false,
+        )
 
       case io: java.io.IOException =>
         logger.warn(
           s"External call to extension '$extensionId' I/O error: requestId=$requestId"
         )
-        ExtensionCallError(503, "I/O error", Some(requestId), retryable = true)
+        ExtensionCallError(
+          503,
+          "I/O error",
+          Some(requestId),
+          retryable = true,
+          clientActionable = false,
+        )
 
       case other =>
         logger.error(
           s"External call to extension '$extensionId' unexpected error: requestId=$requestId",
           other,
         )
-        ExtensionCallError(500, "Unexpected error", Some(requestId), retryable = false)
+        ExtensionCallError(
+          500,
+          "Unexpected error",
+          Some(requestId),
+          retryable = false,
+          clientActionable = false,
+        )
     }
 
   private def errorFromStatus(
@@ -434,6 +461,7 @@ class HttpExtensionServiceClient(
       defaultMessage,
       Some(requestId),
       retryable = HttpExtensionServiceClient.isRetryableHttpStatus(resp.statusCode()),
+      clientActionable = false,
     )
   }
 

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClient.scala
@@ -136,17 +136,17 @@ class HttpExtensionServiceClient(
   private def validateVersionEndpoint()(implicit
       tc: TraceContext
   ): FutureUnlessShutdown[ExtensionValidationResult] = {
-    val requestId = UUID.randomUUID().toString
+    val externalCallId = UUID.randomUUID().toString
     val request = HttpRequest
       .newBuilder()
       .uri(versionEndpoint)
       .timeout(config.requestTimeout.asJava)
       .header("Accept", "application/json")
-      .header("X-Request-Id", requestId)
+      .header("X-Request-Id", externalCallId)
       .GET()
       .build()
 
-    sendValidationRequest(request, requestId).map {
+    sendValidationRequest(request, externalCallId).map {
       case Right(response) =>
         response.statusCode() match {
           case 200 =>
@@ -163,7 +163,7 @@ class HttpExtensionServiceClient(
 
   private def sendValidationRequest(
       request: HttpRequest,
-      requestId: String,
+      externalCallId: String,
   )(implicit tc: TraceContext): FutureUnlessShutdown[Either[String, HttpResponse[String]]] =
     performUnlessClosing
       .synchronizeWithClosingF("extension-service-startup-validation") {
@@ -171,7 +171,7 @@ class HttpExtensionServiceClient(
       }
       .map(response => Right(response))
       .recover { case NonFatal(e) =>
-        UnlessShutdown.Outcome(Left(validationExceptionMessage(e, requestId)))
+        UnlessShutdown.Outcome(Left(validationExceptionMessage(e, externalCallId)))
       }
 
   private def sendAsyncWithTimeout(
@@ -209,7 +209,7 @@ class HttpExtensionServiceClient(
     result.future
   }
 
-  private def validationExceptionMessage(e: Throwable, requestId: String): String =
+  private def validationExceptionMessage(e: Throwable, externalCallId: String): String =
     e match {
       case tooLarge: HttpExtensionServiceClient.ResponseBodyTooLarge =>
         s"Response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes"
@@ -220,7 +220,7 @@ class HttpExtensionServiceClient(
       case io: java.io.IOException =>
         s"I/O error: ${exceptionMessage(io)}"
       case other =>
-        s"Unexpected error during startup validation: ${exceptionMessage(other)} (requestId=$requestId)"
+        s"Unexpected error during startup validation: ${exceptionMessage(other)} (externalCallId=$externalCallId)"
     }
 
   private def exceptionMessage(e: Throwable): String =
@@ -269,7 +269,7 @@ class HttpExtensionServiceClient(
       requestTimeout: Duration,
       idempotencyKey: String,
   )(implicit tc: TraceContext): FutureUnlessShutdown[Either[ExtensionCallError, String]] = {
-    val requestId = UUID.randomUUID().toString
+    val externalCallId = UUID.randomUUID().toString
 
     HttpExtensionServiceClient.invalidExternalCallHeader(functionId, configHash) match {
       case Some(headerName) =>
@@ -278,7 +278,7 @@ class HttpExtensionServiceClient(
             ExtensionCallError(
               400,
               s"Invalid external-call HTTP header value for $headerName",
-              Some(requestId),
+              Some(externalCallId),
               retryable = false,
               clientActionable = true,
             )
@@ -296,7 +296,7 @@ class HttpExtensionServiceClient(
             .header("X-Daml-External-Function-Id", functionId)
             .header("X-Daml-External-Config-Hash", configHash)
             .header("X-Daml-External-Mode", mode.wireValue)
-            .header("X-Request-Id", requestId)
+            .header("X-Request-Id", externalCallId)
             .header("Idempotency-Key", idempotencyKey)
 
           authorizationHeader match {
@@ -306,7 +306,7 @@ class HttpExtensionServiceClient(
                   ExtensionCallError(
                     400,
                     s"Invalid extension service authentication configuration: $error",
-                    Some(requestId),
+                    Some(externalCallId),
                     retryable = false,
                     clientActionable = false,
                   )
@@ -321,130 +321,132 @@ class HttpExtensionServiceClient(
                 .build()
 
               logger.debug(
-                s"Making external call to extension '$extensionId': functionId=$functionId, mode=${mode.wireValue}, requestId=$requestId"
+                s"Making external call to extension '$extensionId': functionId=$functionId, mode=${mode.wireValue}, externalCallId=$externalCallId"
               )
 
               performUnlessClosing
                 .synchronizeWithClosingF("external-call-http-request") {
                   sendAsyncWithTimeout(req, requestTimeout)
                 }
-                .map(response => responseToResult(response, requestId))
+                .map(response => responseToResult(response, externalCallId))
                 .recover { case NonFatal(e) =>
-                  UnlessShutdown.Outcome(Left(exceptionToError(e, requestId)))
+                  UnlessShutdown.Outcome(Left(exceptionToError(e, externalCallId)))
                 }
           }
         } catch {
           case NonFatal(e) =>
-            FutureUnlessShutdown.pure(Left(exceptionToError(e, requestId)))
+            FutureUnlessShutdown.pure(Left(exceptionToError(e, externalCallId)))
         }
     }
   }
 
   private def responseToResult(
       resp: HttpResponse[String],
-      requestId: String,
+      externalCallId: String,
   )(implicit tc: TraceContext): Either[ExtensionCallError, String] =
     resp.statusCode() match {
       case 200 =>
         logger.debug(
-          s"External call to extension '$extensionId' succeeded: requestId=$requestId"
+          s"External call to extension '$extensionId' succeeded: externalCallId=$externalCallId"
         )
         Right(resp.body())
 
       case 400 =>
-        Left(errorFromStatus(resp, requestId, "Bad Request"))
+        Left(errorFromStatus(resp, externalCallId, "Bad Request"))
 
       case 401 =>
-        Left(errorFromStatus(resp, requestId, "Unauthorized - check bearer token"))
+        Left(errorFromStatus(resp, externalCallId, "Unauthorized - check bearer token"))
 
       case 403 =>
-        Left(errorFromStatus(resp, requestId, "Forbidden - insufficient permissions"))
+        Left(errorFromStatus(resp, externalCallId, "Forbidden - insufficient permissions"))
 
       case 404 =>
-        Left(errorFromStatus(resp, requestId, "Function not found"))
+        Left(errorFromStatus(resp, externalCallId, "Function not found"))
 
       case 408 =>
-        Left(errorFromStatus(resp, requestId, "Request timeout"))
+        Left(errorFromStatus(resp, externalCallId, "Request timeout"))
 
       case 429 =>
-        Left(errorFromStatus(resp, requestId, "Rate limit exceeded"))
+        Left(errorFromStatus(resp, externalCallId, "Rate limit exceeded"))
 
       case 500 =>
-        Left(errorFromStatus(resp, requestId, "Internal server error"))
+        Left(errorFromStatus(resp, externalCallId, "Internal server error"))
 
       case 502 =>
-        Left(errorFromStatus(resp, requestId, "Bad gateway"))
+        Left(errorFromStatus(resp, externalCallId, "Bad gateway"))
 
       case 503 =>
-        Left(errorFromStatus(resp, requestId, "Service unavailable"))
+        Left(errorFromStatus(resp, externalCallId, "Service unavailable"))
 
       case 504 =>
-        Left(errorFromStatus(resp, requestId, "Gateway timeout"))
+        Left(errorFromStatus(resp, externalCallId, "Gateway timeout"))
 
       case code =>
-        Left(errorFromStatus(resp, requestId, s"HTTP $code"))
+        Left(errorFromStatus(resp, externalCallId, s"HTTP $code"))
     }
 
   private def exceptionToError(
       e: Throwable,
-      requestId: String,
+      externalCallId: String,
   )(implicit tc: TraceContext): ExtensionCallError =
     e match {
       case tooLarge: HttpExtensionServiceClient.ResponseBodyTooLarge =>
         logger.warn(
-          s"External call to extension '$extensionId' response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes: requestId=$requestId"
+          s"External call to extension '$extensionId' response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes: externalCallId=$externalCallId"
         )
         ExtensionCallError(
           413,
           s"External call response body exceeded maximum size of ${tooLarge.maxResponseBodyBytes} bytes",
-          Some(requestId),
+          Some(externalCallId),
           retryable = false,
           clientActionable = true,
         )
 
       case timeout: java.net.http.HttpTimeoutException =>
-        logger.warn(s"External call to extension '$extensionId' timed out: requestId=$requestId")
+        logger.warn(
+          s"External call to extension '$extensionId' timed out: externalCallId=$externalCallId"
+        )
         ExtensionCallError(
           408,
           "Request timeout",
-          Some(requestId),
+          Some(externalCallId),
           retryable = true,
           clientActionable = false,
         )
 
       case connect: java.net.ConnectException =>
         logger.warn(
-          s"External call to extension '$extensionId' connection failed: requestId=$requestId"
+          s"External call to extension '$extensionId' connection failed: externalCallId=$externalCallId"
         )
         ExtensionCallError(
           503,
           "Connection failed",
-          Some(requestId),
+          Some(externalCallId),
           retryable = true,
           clientActionable = false,
         )
 
       case io: java.io.IOException =>
         logger.warn(
-          s"External call to extension '$extensionId' I/O error: requestId=$requestId"
+          s"External call to extension '$extensionId' I/O error: externalCallId=$externalCallId"
         )
         ExtensionCallError(
           503,
           "I/O error",
-          Some(requestId),
+          Some(externalCallId),
           retryable = true,
           clientActionable = false,
         )
 
       case other =>
         logger.error(
-          s"External call to extension '$extensionId' unexpected error: requestId=$requestId",
+          s"External call to extension '$extensionId' unexpected error: externalCallId=$externalCallId",
           other,
         )
         ExtensionCallError(
           500,
           "Unexpected error",
-          Some(requestId),
+          Some(externalCallId),
           retryable = false,
           clientActionable = false,
         )
@@ -452,27 +454,27 @@ class HttpExtensionServiceClient(
 
   private def errorFromStatus(
       resp: HttpResponse[String],
-      requestId: String,
+      externalCallId: String,
       defaultMessage: String,
   )(implicit tc: TraceContext): ExtensionCallError = {
-    logErrorBody(resp, requestId)
+    logErrorBody(resp, externalCallId)
     ExtensionCallError(
       resp.statusCode(),
       defaultMessage,
-      Some(requestId),
+      Some(externalCallId),
       retryable = HttpExtensionServiceClient.isRetryableHttpStatus(resp.statusCode()),
       clientActionable = false,
     )
   }
 
-  private def logErrorBody(resp: HttpResponse[String], requestId: String)(implicit
+  private def logErrorBody(resp: HttpResponse[String], externalCallId: String)(implicit
       tc: TraceContext
   ): Unit =
     if (logger.underlying.isInfoEnabled) {
       val statusCode = resp.statusCode()
       HttpExtensionServiceClient.diagnosticResponseBody(resp.body()).foreach { body =>
         logger.info(
-          s"External call to extension '$extensionId' returned HTTP $statusCode with response body '$body': requestId=$requestId"
+          s"External call to extension '$extensionId' returned HTTP $statusCode with response body '$body': externalCallId=$externalCallId"
         )
       }
     }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -39,11 +39,11 @@ class ExtensionServiceExternalCallHandlerTest
               .futureValue
             result.left.value.message shouldBe
               "ExtensionCallError(status code = 404, " +
-              "message = \"Extension 'unknown-ext' not configured\", retryable = false)"
+              "message = \"Extension 'unknown-ext' not configured\", retryable = false, trace id = tid:)"
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +
-            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false)",
+            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false, trace id = tid:)",
         )
       } finally manager.close()
     }
@@ -89,11 +89,11 @@ class ExtensionServiceExternalCallHandlerTest
               .value
             error.message shouldBe
               "ExtensionCallError(status code = 404, " +
-              "message = \"Extension 'unknown-ext' not configured\", retryable = false)"
+              "message = \"Extension 'unknown-ext' not configured\", retryable = false, trace id = tid:)"
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +
-            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false)",
+            "ExtensionCallError(status code = 404, message = \"Extension 'unknown-ext' not configured\", retryable = false, trace id = tid:)",
         )
       } finally manager.close()
     }
@@ -179,9 +179,10 @@ class ExtensionServiceExternalCallHandlerTest
 
   "ExtensionCallError" should {
     // The full-error log interpolates `$error`, so its rendering (via PrettyPrinting) must cover
-    // every client-relevant field -- in particular the optional identifiers, which the 404 cases
-    // above omit. `clientActionable` is deliberately not rendered: it is control metadata, and
-    // the rendering doubles as the client payload for actionable errors.
+    // every client-relevant field -- in particular the optional external call id, which the 404
+    // cases above omit, and the trace id, which always renders (bare tid: when empty).
+    // `clientActionable` is deliberately not rendered: it is control metadata, and the rendering
+    // doubles as the client payload for actionable errors.
     "render the client-relevant fields, including the tracing identifiers, via pretty-printing" in {
       TraceContext.withNewTraceContext("test") { tc =>
         ExtensionCallError(
@@ -192,11 +193,11 @@ class ExtensionServiceExternalCallHandlerTest
           clientActionable = false,
         )(tc).toString shouldBe
           "ExtensionCallError(status code = 503, message = \"boom\", external call id = 'req-1'," +
-          s" retryable = true, trace id = '${tc.traceId.value}')"
+          s" retryable = true, trace id = tid:${tc.traceId.value})"
       }
     }
 
-    "omit the tracing identifiers from the rendering when absent" in {
+    "render an absent external call id as omitted and an empty trace context as a bare tid" in {
       ExtensionCallError(
         statusCode = 503,
         message = "boom",
@@ -204,7 +205,7 @@ class ExtensionServiceExternalCallHandlerTest
         retryable = true,
         clientActionable = false,
       )(TraceContext.empty).toString shouldBe
-        "ExtensionCallError(status code = 503, message = \"boom\", retryable = true)"
+        "ExtensionCallError(status code = 503, message = \"boom\", retryable = true, trace id = tid:)"
     }
   }
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -35,7 +35,9 @@ class ExtensionServiceExternalCallHandlerTest
               )
               .failOnShutdown
               .futureValue
-            result.left.value.message should include("status 404")
+            result.left.value.message shouldBe
+              "ExtensionCallError(status code = 404, " +
+              "message = \"Extension 'unknown-ext' not configured\", retryable = false)"
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +
@@ -64,7 +66,7 @@ class ExtensionServiceExternalCallHandlerTest
 
   "ExtensionServiceExternalCallHandler" should {
 
-    "map manager errors to sanitized engine external-call errors" in {
+    "forward the full error to the engine for the submitting client" in {
       val manager = emptyManager
       val handler = new ExtensionServiceExternalCallHandler(manager)
 
@@ -83,10 +85,9 @@ class ExtensionServiceExternalCallHandlerTest
               .futureValue
               .left
               .value
-            error.message should include("status 404")
-            error.message should not include "unknown-ext"
-            error.message should not include "not configured"
-            error.message should not include "Available extensions"
+            error.message shouldBe
+              "ExtensionCallError(status code = 404, " +
+              "message = \"Extension 'unknown-ext' not configured\", retryable = false)"
           },
           _.warningMessage shouldBe
             "External call to extension 'unknown-ext' (function 'test-func') failed: " +

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -119,10 +119,10 @@ class ExtensionServiceExternalCallHandlerTest
                   ExtensionCallError(
                     statusCode = 503,
                     message = "Connection failed",
-                    requestId = Some("req-1"),
+                    externalCallId = Some("req-1"),
                     retryable = true,
                     clientActionable = false,
-                  )
+                  )(tc)
                 )
               )
           }
@@ -141,31 +141,35 @@ class ExtensionServiceExternalCallHandlerTest
             .futureValue
             .left
             .value
-          error.message shouldBe "External call failed (retryable = true, request id = 'req-1')"
+          error.message shouldBe
+            "External call failed (retryable = true, external call id = 'req-1')"
         } finally manager.close()
       }
     }
   }
 
   "ExtensionServiceExternalCallHandler.genericClientMessage" should {
-    "expose only the retry status and the request id" in {
-      ExtensionServiceExternalCallHandler.genericClientMessage(
-        ExtensionCallError(
-          statusCode = 503,
-          message = "Connection failed",
-          requestId = Some("req-1"),
-          retryable = true,
-          clientActionable = false,
-        )
-      ) shouldBe "External call failed (retryable = true, request id = 'req-1')"
+    "expose only the retry status and the tracing identifiers" in {
+      TraceContext.withNewTraceContext("test") { tc =>
+        ExtensionServiceExternalCallHandler.genericClientMessage(
+          ExtensionCallError(
+            statusCode = 503,
+            message = "Connection failed",
+            externalCallId = Some("req-1"),
+            retryable = true,
+            clientActionable = false,
+          )(tc)
+        ) shouldBe "External call failed (retryable = true, external call id = 'req-1'," +
+          s" trace id = '${tc.traceId.value}')"
+      }
     }
 
-    "omit the request id when absent" in {
+    "omit the identifiers when absent" in {
       ExtensionServiceExternalCallHandler.genericClientMessage(
         ExtensionCallError(
           statusCode = 500,
           message = "Unexpected error",
-          requestId = None,
+          externalCallId = None,
           retryable = false,
           clientActionable = false,
         )
@@ -175,18 +179,32 @@ class ExtensionServiceExternalCallHandlerTest
 
   "ExtensionCallError" should {
     // The full-error log interpolates `$error`, so its rendering (via PrettyPrinting) must cover
-    // every client-relevant field -- in particular the optional request id, which the 404 cases
+    // every client-relevant field -- in particular the optional identifiers, which the 404 cases
     // above omit. `clientActionable` is deliberately not rendered: it is control metadata, and
     // the rendering doubles as the client payload for actionable errors.
-    "render the client-relevant fields, including the request id, via pretty-printing" in {
+    "render the client-relevant fields, including the tracing identifiers, via pretty-printing" in {
+      TraceContext.withNewTraceContext("test") { tc =>
+        ExtensionCallError(
+          statusCode = 503,
+          message = "boom",
+          externalCallId = Some("req-1"),
+          retryable = true,
+          clientActionable = false,
+        )(tc).toString shouldBe
+          "ExtensionCallError(status code = 503, message = \"boom\", external call id = 'req-1'," +
+          s" retryable = true, trace id = '${tc.traceId.value}')"
+      }
+    }
+
+    "omit the tracing identifiers from the rendering when absent" in {
       ExtensionCallError(
         statusCode = 503,
         message = "boom",
-        requestId = Some("req-1"),
+        externalCallId = None,
         retryable = true,
         clientActionable = false,
-      ).toString shouldBe
-        "ExtensionCallError(status code = 503, message = \"boom\", request id = 'req-1', retryable = true)"
+      )(TraceContext.empty).toString shouldBe
+        "ExtensionCallError(status code = 503, message = \"boom\", retryable = true)"
     }
   }
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -4,7 +4,9 @@
 package com.digitalasset.canton.participant.extension
 
 import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.platform.execution.ExternalCallMode
+import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.{BaseTest, HasExecutionContext}
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -66,7 +68,7 @@ class ExtensionServiceExternalCallHandlerTest
 
   "ExtensionServiceExternalCallHandler" should {
 
-    "forward the full error to the engine for the submitting client" in {
+    "forward the full client-actionable error to the engine for the submitting client" in {
       val manager = emptyManager
       val handler = new ExtensionServiceExternalCallHandler(manager)
 
@@ -98,15 +100,91 @@ class ExtensionServiceExternalCallHandlerTest
 
   }
 
+  "ExtensionServiceExternalCallHandler" when {
+    "the error is not actionable for the client" should {
+      "reduce it to the generic client message" in {
+        val manager: ExtensionServiceManager =
+          new ExtensionServiceManager(Map.empty, loggerFactory, ProcessingTimeout()) {
+            override def handleExternalCall(
+                extensionId: String,
+                functionId: String,
+                configHash: String,
+                input: String,
+                mode: ExternalCallMode,
+            )(implicit
+                tc: TraceContext
+            ): FutureUnlessShutdown[Either[ExtensionCallError, String]] =
+              FutureUnlessShutdown.pure(
+                Left(
+                  ExtensionCallError(
+                    statusCode = 503,
+                    message = "Connection failed",
+                    requestId = Some("req-1"),
+                    retryable = true,
+                    clientActionable = false,
+                  )
+                )
+              )
+          }
+        val handler = new ExtensionServiceExternalCallHandler(manager)
+
+        try {
+          val error = handler
+            .handleExternalCall(
+              "some-ext",
+              "some-func",
+              "00000000",
+              "deadbeef",
+              ExternalCallMode.Submission,
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
+          error.message shouldBe "External call failed (retryable = true, request id = 'req-1')"
+        } finally manager.close()
+      }
+    }
+  }
+
+  "ExtensionServiceExternalCallHandler.genericClientMessage" should {
+    "expose only the retry status and the request id" in {
+      ExtensionServiceExternalCallHandler.genericClientMessage(
+        ExtensionCallError(
+          statusCode = 503,
+          message = "Connection failed",
+          requestId = Some("req-1"),
+          retryable = true,
+          clientActionable = false,
+        )
+      ) shouldBe "External call failed (retryable = true, request id = 'req-1')"
+    }
+
+    "omit the request id when absent" in {
+      ExtensionServiceExternalCallHandler.genericClientMessage(
+        ExtensionCallError(
+          statusCode = 500,
+          message = "Unexpected error",
+          requestId = None,
+          retryable = false,
+          clientActionable = false,
+        )
+      ) shouldBe "External call failed (retryable = false)"
+    }
+  }
+
   "ExtensionCallError" should {
     // The full-error log interpolates `$error`, so its rendering (via PrettyPrinting) must cover
-    // every field -- in particular the optional request id, which the 404 cases above omit.
-    "render all fields, including the request id, via pretty-printing" in {
+    // every client-relevant field -- in particular the optional request id, which the 404 cases
+    // above omit. `clientActionable` is deliberately not rendered: it is control metadata, and
+    // the rendering doubles as the client payload for actionable errors.
+    "render the client-relevant fields, including the request id, via pretty-printing" in {
       ExtensionCallError(
         statusCode = 503,
         message = "boom",
         requestId = Some("req-1"),
         retryable = true,
+        clientActionable = false,
       ).toString shouldBe
         "ExtensionCallError(status code = 503, message = \"boom\", request id = 'req-1', retryable = true)"
     }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -105,6 +105,7 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
               message = "internal detail",
               requestId = Some("request-1"),
               retryable = true,
+              clientActionable = false,
             )
           )
         )

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -88,7 +88,7 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
             },
           _.warningMessage shouldBe
             "External call to extension 'extension-id' (function 'function-id') failed: " +
-            "ExtensionCallError(status code = 404, message = \"Extension 'extension-id' not configured\", retryable = false)",
+            "ExtensionCallError(status code = 404, message = \"Extension 'extension-id' not configured\", retryable = false, trace id = tid:)",
         )
         .thereafter(_ => manager.close())
     }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallValidatorTest.scala
@@ -103,7 +103,7 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
             ExtensionCallError(
               statusCode = 503,
               message = "internal detail",
-              requestId = Some("request-1"),
+              externalCallId = Some("request-1"),
               retryable = true,
               clientActionable = false,
             )
@@ -118,7 +118,7 @@ class ExtensionServiceExternalCallValidatorTest extends AsyncWordSpec with BaseT
           result match {
             case ExternalCallValidator.UnableToValidate(reason) =>
               reason shouldBe
-                "external-call validation failed with status 503, requestId=request-1"
+                "external-call validation failed with status 503, externalCallId=request-1"
               reason should not include externalCallKey.extensionId
               reason should not include "internal detail"
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -851,7 +851,7 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           },
           _.warningMessage shouldBe
             "External call to extension 'missing-extension' (function 'function') failed: " +
-            "ExtensionCallError(status code = 404, message = \"Extension 'missing-extension' not configured\", retryable = false)",
+            "ExtensionCallError(status code = 404, message = \"Extension 'missing-extension' not configured\", retryable = false, trace id = tid:)",
         )
       } finally {
         manager.close()

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -844,7 +844,7 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
               .value
 
             error.statusCode shouldBe 404
-            error.requestId shouldBe None
+            error.externalCallId shouldBe None
             error.message should include("Extension 'missing-extension' not configured")
             error.message should not include "first-extension"
             error.message should not include "second-extension"


### PR DESCRIPTION
Revisits the submission-path error sanitization as agreed in [#553 r3511508412](https://github.com/digital-asset/canton/pull/553#discussion_r3511508412): the ledger-api-client-facing message now carries the full error instead of only a status code.

> Rebased onto `main` after #573 merged; the diff is now exactly this PR's change.

## What changes

`ExtensionServiceExternalCallHandler` used to reduce an `ExtensionCallError` to `"External call failed with status <code>, requestId=<id>"` before handing it to the engine. It now forwards the whole error via its pretty rendering, which the engine wraps with the call coordinates, so the rejection cause the submitting client sees becomes:

```
External call execution failed (extensionId=..., functionId=...): call failed: ExtensionCallError(status code = 503, message = "Service unavailable", request id = 'req-1', retryable = true)
```

The client gets the failure description, the request id for correlation with extension-service logs, and the retryability hint — and it is the same rendering the participant logs (#573), making log correlation trivial. The handler passes the bare rendered error (no prefix of its own) since the engine's rendering already provides the framing.

## Why forwarding the full message is safe (the "details" from the review thread)

- **Audience.** This path is reached only from `StoreBackedCommandInterpreter` (command interpretation on the submitting participant). The message surfaces in the `INTERPRETATION_EXTERNAL_CALL_ERROR_EXECUTION_FAILED` rejection to the authenticated submitting client — it is never distributed to other nodes (observation 4 in the thread). `IE.ExternalCall` is not catchable by Daml code, so the text cannot flow into committed ledger data.
- **Content.** Every `ExtensionCallError` construction site keeps `message` client-safe: `HttpExtensionServiceClient` maps HTTP statuses and exceptions to fixed strings ("Service unavailable", "Request timeout", …) and never copies response bodies into it (bodies go to logs only, via `diagnosticResponseBody`); the manager's unconfigured-extension error carries only the extension id the client itself supplied. The one non-fixed value any site interpolates is the configured max response-body size in the 413 message — a non-sensitive operational limit that is genuinely useful to the client (it says how big a response the extension may return). This content rule — fixed descriptions, identifiers, and non-sensitive operational limits; never response bodies or credentials — is now documented on `ExtensionCallError` so future construction sites keep the message client-safe.
- **The paths that face other nodes are untouched.** The Phase-3 validator (`ExtensionServiceExternalCallValidator`) still reduces the error to status code + request id before it can reach `LocalAbstain` confirmation responses, exactly as before (observation 2). The full-error log in `ExtensionServiceManager.handleExternalCall` from the original review also stays; only its now-stale "sanitization drops the message" comment is reworded.

Two consequences worth calling out explicitly:

- The auth-misconfiguration descriptions ("Failed to read bearer token file", "Bearer token file contains invalid characters", "Bearer token file is empty") now reach the submitting client. They are fixed strings — no paths, no token content — but they do reveal participant-side configuration state to the client; flagging in case you want that reduced further.
- The pretty rendering wraps at width 200, so a long error (e.g. the auth-config message plus a request id) can render across multiple lines inside the rejection cause — the same behavior the participant log already has. Happy to switch to a single-line rendering if preferred.

Not changed (and deliberately so): the error-code ids and the gRPC error category — retryability is conveyed in the message text, since a single `ErrorCode` cannot vary its category per error.

## Testing

`ExtensionServiceExternalCallHandlerTest` now asserts the full forwarded message; the previous `should not include "not configured"` no-leak assertions are reversed by design — forwarding that description to the submitting client is the point of this cleanup. Extension suites green at `CANTON_PROTOCOL_VERSION=dev` (handler, validator, HTTP client).

Part of the #565 post-merge cleanup (Part 2, item "revisit error sanitization"). Refs #565.

