### PR TITLE
refactor(external-call)!: remove the per-party disagreement machinery

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -83,16 +83,14 @@ class ExternalCallCheck(
     if (recordedResults.isEmpty)
       FutureUnlessShutdown.pure(Passed)
     else {
-      // Hosted parties are irrelevant for the request-level outcome: any visible disagreement
-      // rejects the request, so only the party-independent visible inconsistencies are consulted.
-      val consistency = ExternalCallConsistencyChecker.check(views, Set.empty)
+      val inconsistencies = ExternalCallConsistencyChecker.check(views)
 
       // Every visible inconsistency is alarmed: only the first one is propagated into the
       // rejection, so the confirmation-responses factory reports just that one.
-      consistency.visibleInconsistencies.foreach(alarmDisagreement(requestId, _))
+      inconsistencies.foreach(alarmDisagreement(requestId, _))
 
       // The checker sorts the inconsistencies, so the reported disagreement is deterministic.
-      consistency.visibleInconsistencies.headOption match {
+      inconsistencies.headOption match {
         case Some(inconsistency) =>
           FutureUnlessShutdown.pure(Rejected(inconsistency.description))
         case None if !runValidation =>

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -124,20 +124,15 @@ object ExternalCallConsistencyChecker {
         }
       }
 
-  private def visibleInconsistencies(
-      occurrences: Seq[VisibleExternalCallOccurrence]
-  ): Seq[Inconsistency] =
-    occurrences
+  /** Returns the disagreements across all occurrences visible to this participant, sorted
+    * deterministically (by key, then outputs, then occurrences).
+    */
+  def check(views: Map[ViewPosition, ParticipantTransactionView]): Seq[Inconsistency] =
+    visibleOccurrences(views)
       .groupMap(_.key)(occurrence => occurrence.output -> occurrence.occurrence)
       .toSeq
       .flatMap { case (key, outputsAndOccurrences) =>
         inconsistencyFor(key, outputsAndOccurrences)
       }
       .sorted(orderInconsistency)
-
-  /** Returns the disagreements across all occurrences visible to this participant, sorted
-    * deterministically (by key, then outputs, then occurrences).
-    */
-  def check(views: Map[ViewPosition, ParticipantTransactionView]): Seq[Inconsistency] =
-    visibleInconsistencies(visibleOccurrences(views))
 }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.canton.participant.protocol.validation
 
 import cats.Order
-import com.digitalasset.canton.LfPartyId
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.ExternalCallPayloadDescription.{byteCount, hexPayloadSize}
 import com.digitalasset.canton.data.{ExternalCallKey, ParticipantTransactionView, ViewPosition}
@@ -18,9 +17,8 @@ import com.google.protobuf.ByteString
   * An external-call result is ''visible'' to this participant if it is recorded in one of the
   * (unblinded) views that this participant has received for validation. External-call results are
   * replay data that participate in validation. If two visible occurrences of the same external call
-  * record different outputs, a hosted confirming party must reject the transaction locally instead
-  * of approving an ambiguous result. Visible disagreements are also retained independently of
-  * hosted-party routing so callers can report suspicious recorded data.
+  * record different outputs, the recorded data is ambiguous: the transaction must be rejected
+  * rather than approved, and the disagreement is reported as suspicious recorded data.
   */
 object ExternalCallConsistencyChecker {
 
@@ -67,47 +65,11 @@ object ExternalCallConsistencyChecker {
       )
   }
 
-  /** Outcome of [[check]].
-    *
-    * @param hostedInconsistencies
-    *   Inconsistencies grouped by hosted confirming party, restricted for each party to the
-    *   occurrences that the party is responsible for checking. Grouped by party because
-    *   confirmation responses are issued on behalf of individual confirming parties: each hosted
-    *   confirming party must reject exactly the disagreements among its own occurrences.
-    * @param visibleInconsistencies
-    *   Inconsistencies across all occurrences visible to this participant, irrespective of which
-    *   parties it hosts. Used to alarm on suspicious recorded data even if this participant hosts
-    *   no affected checking party.
-    */
-  final case class Result(
-      hostedInconsistencies: Map[LfPartyId, Seq[Inconsistency]],
-      visibleInconsistencies: Seq[Inconsistency],
-  ) extends PrettyPrinting {
-    def inconsistentParties: Set[LfPartyId] = hostedInconsistencies.keySet
-
-    override protected def pretty: Pretty[Result] = prettyOfClass(
-      param("hostedInconsistencies", _.hostedInconsistencies),
-      param("visibleInconsistencies", _.visibleInconsistencies),
-    )
-  }
-
-  object Result {
-    val empty: Result = Result(Map.empty, Seq.empty)
-  }
-
-  /** An external-call result recorded in a view that this participant has received.
-    *
-    * @param checkingParties
-    *   The node-level confirming parties responsible for checking this result: the signatories and
-    *   acting parties of the exercise node that recorded the call, as determined at
-    *   transaction-tree construction. See
-    *   [[com.digitalasset.canton.data.ViewParticipantData.ViewExternalCallResult]].
-    */
+  /** An external-call result recorded in a view that this participant has received. */
   private final case class VisibleExternalCallOccurrence(
       key: ExternalCallKey,
       output: Bytes,
       occurrence: ExternalCallOccurrence,
-      checkingParties: Set[LfPartyId],
   )
 
   private implicit val orderBytes: Order[Bytes] =
@@ -158,7 +120,6 @@ object ExternalCallConsistencyChecker {
             ExternalCallKey.fromResult(externalCallResult.result),
             externalCallResult.result.output,
             occurrence,
-            externalCallResult.checkingParties,
           )
         }
       }
@@ -174,38 +135,9 @@ object ExternalCallConsistencyChecker {
       }
       .sorted(orderInconsistency)
 
-  private def hostedInconsistencies(
-      occurrences: Seq[VisibleExternalCallOccurrence],
-      hostedConfirmingParties: Set[LfPartyId],
-  ): Map[LfPartyId, Seq[Inconsistency]] =
-    occurrences
-      .flatMap { occurrence =>
-        occurrence.checkingParties.intersect(hostedConfirmingParties).toSeq.map { party =>
-          (party, occurrence.key) -> (occurrence.output -> occurrence.occurrence)
-        }
-      }
-      .groupMap(_._1)(_._2)
-      .toSeq
-      .flatMap { case ((party, key), outputsAndOccurrences) =>
-        inconsistencyFor(key, outputsAndOccurrences).map(party -> _)
-      }
-      .groupMap(_._1)(_._2)
-      .view
-      .mapValues(_.sorted(orderInconsistency))
-      .toMap
-
-  /** Returns per-party inconsistencies for hosted confirming parties that check disagreeing outputs
-    * for the same external call, as well as the disagreements across all visible occurrences. See
-    * [[Result]] for how the two differ.
+  /** Returns the disagreements across all occurrences visible to this participant, sorted
+    * deterministically (by key, then outputs, then occurrences).
     */
-  def check(
-      views: Map[ViewPosition, ParticipantTransactionView],
-      hostedConfirmingParties: Set[LfPartyId],
-  ): Result = {
-    val occurrences = visibleOccurrences(views)
-    Result(
-      hostedInconsistencies = hostedInconsistencies(occurrences, hostedConfirmingParties),
-      visibleInconsistencies = visibleInconsistencies(occurrences),
-    )
-  }
+  def check(views: Map[ViewPosition, ParticipantTransactionView]): Seq[Inconsistency] =
+    visibleInconsistencies(visibleOccurrences(views))
 }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -25,6 +25,12 @@ class ExternalCallConsistencyCheckerTest
 
   private val checkingParties: Set[LfPartyId] = Set(ExampleTransactionFactory.signatory)
 
+  private val leftPosition: ViewPosition = ViewPosition.root
+  private val rightPosition: ViewPosition =
+    ViewPosition(
+      List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+    )
+
   private def check(
       rightResult: ExternalCallResult = otherExternalCallResult
   ): Seq[ExternalCallConsistencyChecker.Inconsistency] = {
@@ -52,11 +58,8 @@ class ExternalCallConsistencyCheckerTest
 
     ExternalCallConsistencyChecker.check(
       Map(
-        ViewPosition.root -> participantView(left),
-        ViewPosition(
-          List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
-        ) ->
-          participantView(right),
+        leftPosition -> participantView(left),
+        rightPosition -> participantView(right),
       )
     )
   }
@@ -69,12 +72,7 @@ class ExternalCallConsistencyCheckerTest
         externalCallResult.output,
         otherExternalCallResult.output,
       )
-      inconsistency.occurrences.map(_.viewPosition) shouldBe Set(
-        ViewPosition.root,
-        ViewPosition(
-          List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
-        ),
-      )
+      inconsistency.occurrences.map(_.viewPosition) shouldBe Set(leftPosition, rightPosition)
     }
 
     "not report identical outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
@@ -123,11 +121,8 @@ class ExternalCallConsistencyCheckerTest
 
       val inconsistencies = ExternalCallConsistencyChecker.check(
         Map(
-          ViewPosition.root -> participantView(left),
-          ViewPosition(
-            List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
-          ) ->
-            participantView(right),
+          leftPosition -> participantView(left),
+          rightPosition -> participantView(right),
         )
       )
 
@@ -138,7 +133,7 @@ class ExternalCallConsistencyCheckerTest
       val example = factory.MultipleRoots
 
       ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> participantView(example.rootViews(4)))
+        Map(leftPosition -> participantView(example.rootViews(4)))
       ) shouldBe Seq.empty
     }
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyCheckerTest.scala
@@ -3,7 +3,6 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
-import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.ViewPosition
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.version.ProtocolVersion
@@ -24,16 +23,11 @@ class ExternalCallConsistencyCheckerTest
 
   protected val factory: ExampleTransactionFactory = new ExampleTransactionFactory()()
 
-  private val partyA: LfPartyId = ExampleTransactionFactory.signatory
-  private val partyB: LfPartyId = ExampleTransactionFactory.submitter
-  private val partyC: LfPartyId = ExampleTransactionFactory.observer
+  private val checkingParties: Set[LfPartyId] = Set(ExampleTransactionFactory.signatory)
 
   private def check(
-      leftCheckingParties: Set[LfPartyId],
-      rightCheckingParties: Set[LfPartyId],
-      hostedParties: Set[LfPartyId],
-      rightResult: ExternalCallResult = otherExternalCallResult,
-  ): ExternalCallConsistencyChecker.Result = {
+      rightResult: ExternalCallResult = otherExternalCallResult
+  ): Seq[ExternalCallConsistencyChecker.Inconsistency] = {
     val example = factory.MultipleRoots
     val left = withExternalCallResults(
       example.rootViews(4),
@@ -41,7 +35,7 @@ class ExternalCallConsistencyCheckerTest
         externalCallViewResult(
           exerciseIndex = 0,
           result = externalCallResult,
-          checkingParties = leftCheckingParties,
+          checkingParties = checkingParties,
         )
       ),
     )
@@ -51,7 +45,7 @@ class ExternalCallConsistencyCheckerTest
         externalCallViewResult(
           exerciseIndex = 0,
           result = rightResult,
-          checkingParties = rightCheckingParties,
+          checkingParties = checkingParties,
         )
       ),
     )
@@ -63,108 +57,36 @@ class ExternalCallConsistencyCheckerTest
           List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
         ) ->
           participantView(right),
-      ),
-      hostedParties,
+      )
     )
   }
 
   "ExternalCallConsistencyChecker" should {
-    "report only hosted parties that check conflicting outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val result = check(
-        leftCheckingParties = Set(partyA),
-        rightCheckingParties = Set(partyA),
-        hostedParties = Set(partyA, partyB),
-      )
+    "report conflicting outputs for the same call across views" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      val inconsistency = check().loneElement
 
-      result.inconsistentParties shouldBe Set(partyA)
-    }
-
-    "not report conflicting outputs for disjoint checking parties" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val result = check(
-        leftCheckingParties = Set(partyA),
-        rightCheckingParties = Set(partyB),
-        hostedParties = Set(partyA, partyB),
-      )
-
-      result.inconsistentParties shouldBe Set.empty
-      result.visibleInconsistencies should have size 1
-    }
-
-    "record visible disagreements without reporting non-hosted checking parties" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val result = check(
-        leftCheckingParties = Set(partyC),
-        rightCheckingParties = Set(partyC),
-        hostedParties = Set(partyA, partyB),
-      )
-
-      result.inconsistentParties shouldBe Set.empty
-      result.visibleInconsistencies should have size 1
-      val visibleInconsistency = result.visibleInconsistencies.loneElement
-      visibleInconsistency.outputs shouldBe Set(
+      inconsistency.outputs shouldBe Set(
         externalCallResult.output,
         otherExternalCallResult.output,
+      )
+      inconsistency.occurrences.map(_.viewPosition) shouldBe Set(
+        ViewPosition.root,
+        ViewPosition(
+          List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
+        ),
       )
     }
 
     "not report identical outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val result = check(
-        leftCheckingParties = Set(partyA),
-        rightCheckingParties = Set(partyA),
-        hostedParties = Set(partyA),
-        rightResult = externalCallResult,
-      )
-
-      result.inconsistentParties shouldBe Set.empty
+      check(rightResult = externalCallResult) shouldBe Seq.empty
     }
 
     "not report different semantic calls with different outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val result = check(
-        leftCheckingParties = Set(partyA),
-        rightCheckingParties = Set(partyA),
-        hostedParties = Set(partyA),
-        rightResult = otherExternalCallResult.copy(functionId = "other-function"),
-      )
-
-      result.inconsistentParties shouldBe Set.empty
+      check(rightResult = otherExternalCallResult.copy(functionId = "other-function")) shouldBe
+        Seq.empty
     }
 
-    "report repeated semantic calls on the same node with different outputs" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
-      val example = factory.MultipleRoots
-      val view = withExternalCallResults(
-        example.rootViews(4),
-        Seq(
-          externalCallViewResult(
-            exerciseIndex = 0,
-            result = externalCallResult,
-            checkingParties = Set(partyA),
-            callIndex = 0,
-          ),
-          externalCallViewResult(
-            exerciseIndex = 0,
-            result = otherExternalCallResult,
-            checkingParties = Set(partyA),
-            callIndex = 1,
-          ),
-        ),
-      )
-
-      val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> participantView(view)),
-        Set(partyA),
-      )
-
-      result.inconsistentParties shouldBe Set(partyA)
-      val inconsistency = result.hostedInconsistencies(partyA).loneElement
-      inconsistency.outputs shouldBe Set(externalCallResult.output, otherExternalCallResult.output)
-      inconsistency.occurrences.map(occurrence =>
-        occurrence.exerciseIndex -> occurrence.callIndex
-      ) shouldBe Set(
-        NonNegativeInt.zero -> NonNegativeInt.zero,
-        NonNegativeInt.zero -> NonNegativeInt.one,
-      )
-    }
-
-    "report all independent disagreements for the same hosted checking party" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+    "report all independent disagreements" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       val example = factory.MultipleRoots
       val firstCall = externalCallResult.copy(functionId = "function-a")
       val secondCall = externalCallResult.copy(functionId = "function-b")
@@ -174,12 +96,12 @@ class ExternalCallConsistencyCheckerTest
           externalCallViewResult(
             exerciseIndex = 0,
             result = firstCall,
-            checkingParties = Set(partyA),
+            checkingParties = checkingParties,
           ),
           externalCallViewResult(
             exerciseIndex = 1,
             result = secondCall,
-            checkingParties = Set(partyA),
+            checkingParties = checkingParties,
           ),
         ),
       )
@@ -189,43 +111,35 @@ class ExternalCallConsistencyCheckerTest
           externalCallViewResult(
             exerciseIndex = 0,
             result = firstCall.copy(output = Bytes.fromStringUtf8("other-output-a")),
-            checkingParties = Set(partyA),
+            checkingParties = checkingParties,
           ),
           externalCallViewResult(
             exerciseIndex = 1,
             result = secondCall.copy(output = Bytes.fromStringUtf8("other-output-b")),
-            checkingParties = Set(partyA),
+            checkingParties = checkingParties,
           ),
         ),
       )
 
-      val result = ExternalCallConsistencyChecker.check(
+      val inconsistencies = ExternalCallConsistencyChecker.check(
         Map(
           ViewPosition.root -> participantView(left),
           ViewPosition(
             List(ViewPosition.MerkleSeqIndex(List(ViewPosition.MerkleSeqIndex.Direction.Right)))
           ) ->
             participantView(right),
-        ),
-        Set(partyA),
+        )
       )
 
-      result.inconsistentParties shouldBe Set(partyA)
-      result.hostedInconsistencies(partyA).map(_.key.functionId).toSet shouldBe Set(
-        "function-a",
-        "function-b",
-      )
+      inconsistencies.map(_.key.functionId) shouldBe Seq("function-a", "function-b")
     }
 
-    "return the empty result for views without external-call results" in {
+    "return no inconsistencies for views without external-call results" in {
       val example = factory.MultipleRoots
 
-      val result = ExternalCallConsistencyChecker.check(
-        Map(ViewPosition.root -> participantView(example.rootViews(4))),
-        Set(partyA),
-      )
-
-      result shouldBe ExternalCallConsistencyChecker.Result.empty
+      ExternalCallConsistencyChecker.check(
+        Map(ViewPosition.root -> participantView(example.rootViews(4)))
+      ) shouldBe Seq.empty
     }
   }
 }


### PR DESCRIPTION
Implements the first action of the [#565 decision](https://github.com/digital-asset/canton/issues/565#issuecomment-4938124738 ): per-party rejection routing is not needed, so the machinery supporting it goes away.

## What changes

Removes `ExternalCallConsistencyChecker.Result#hostedInconsistencies` and everything that existed only to feed it: the derived `inconsistentParties`, the private per-party grouping, the `hostedConfirmingParties` parameter of `check`, and the `checkingParties` copy in the checker-private `VisibleExternalCallOccurrence`. This is a pure deletion — the path was already dead in production, since the only caller passed `hostedConfirmingParties = Set.empty`.

One knock-on: with a single field left, the checker's `Result` wrapper serves no purpose, so `check` now returns the visible inconsistencies directly.

Deliberately kept: `ViewParticipantData.ViewExternalCallResult.checkingParties`. It is a serialized wire field, protected by model-conformance reconstruction, and the input to the upcoming re-validation restriction (point 3 of the decision, follow-up PR).

## Testing

`ExternalCallConsistencyCheckerTest` rewritten to the slimmed API: the per-party routing tests collapse into visible-inconsistency tests, and the fixture test for a conflicting-outputs-within-one-view scenario is deleted — since the fail-fast in `TransactionView.validated` (#572), such a view cannot be deserialized, so the scenario is unreachable in production. Suites green at `CANTON_PROTOCOL_VERSION=dev`; whole-repo `scalafixCheck` clean.

First of three PRs for the #565 per-view rework (removal → per-view results → re-validation restriction). Refs #565.
