### PR TITLE
feat(external-call)!: produce and consume external-call check results per view

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -1684,7 +1684,7 @@ object TransactionProcessingSteps {
         ErrorWithInternalConsistencyCheck,
         Unit,
       ],
-      externalCallCheckResultF: FutureUnlessShutdown[ExternalCallCheck.Result],
+      externalCallCheckResultF: FutureUnlessShutdown[Map[ViewPosition, ExternalCallCheck.Result]],
       timeValidationResultE: Either[TimeCheckFailure, Unit],
       replayCheckResult: Option[String],
   ) {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.canton.participant.protocol.validation
 
+import cats.syntax.functor.*
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.data.{
   ExternalCallKey,
@@ -32,10 +33,12 @@ import scala.concurrent.ExecutionContext
   *   - re-validation: whether the (undisputed) recorded outputs agree with the extension service,
   *     re-executing each distinct call once ([[ExternalCallValidator]]).
   *
-  * Every disagreement found by either part is alarmed. The outcome is a single per-request
-  * `ExternalCallCheck.Result`: a disagreement from either part rejects the request on behalf of all
-  * hosted confirming parties, and a recorded result that cannot be re-validated leads to an
-  * abstention instead of an approval (see [[TransactionConfirmationResponsesFactory]]).
+  * Every disagreement found by either part is alarmed, once per request. The outcome is one
+  * `ExternalCallCheck.Result` per view that records external-call results: a disagreement or
+  * re-validation failure rejects exactly the views whose participant data records the affected
+  * call, and a recorded result that cannot be re-validated abstains those views instead of
+  * approving them (see [[TransactionConfirmationResponsesFactory]], which consults only the result
+  * of the view it responds for). Views without external-call results receive no result.
   * Disagreements among the recorded results within a single view's subtree are rejected earlier, as
   * a malformed view when the view is validated, independently of this check.
   *
@@ -53,10 +56,15 @@ class ExternalCallCheck(
   import ExternalCallCheck.*
 
   /** Checks consistency of the recorded external-call results and re-validates them against the
-    * extension service.
+    * extension service, producing one result per view that records external-call results. A view
+    * without a result in the returned map records no external calls and needs no verdict.
     *
     * If no view records an external-call result -- in particular, always, on protocol versions
-    * without external-call support -- the check short-circuits to `ExternalCallCheck.Passed`.
+    * without external-call support -- the check short-circuits to an empty map.
+    *
+    * Keys whose visible occurrences disagree have no unambiguous output and are not re-validated;
+    * all other keys still are, so a disagreement on one call does not mask a re-validation failure
+    * of another.
     *
     * @param requestId
     *   The request under validation, used to correlate logs and alarms.
@@ -73,7 +81,7 @@ class ExternalCallCheck(
   )(implicit
       traceContext: TraceContext,
       ec: ExecutionContext,
-  ): FutureUnlessShutdown[Result] = {
+  ): FutureUnlessShutdown[Map[ViewPosition, Result]] = {
     val recordedResults = views.toSeq
       .sortBy { case (viewPosition, _) => viewPosition }(ViewPosition.orderViewPosition.toOrdering)
       .flatMap { case (viewPosition, view) =>
@@ -81,30 +89,73 @@ class ExternalCallCheck(
       }
 
     if (recordedResults.isEmpty)
-      FutureUnlessShutdown.pure(Passed)
+      FutureUnlessShutdown.pure(Map.empty)
     else {
       val inconsistencies = ExternalCallConsistencyChecker.check(views)
 
-      // Every visible inconsistency is alarmed: only the first one is propagated into the
-      // rejection, so the confirmation-responses factory reports just that one.
+      // Every visible inconsistency is alarmed here, once per request; the per-view results
+      // reject each affected view with the first (in the checker's deterministic order)
+      // inconsistency among the calls recorded in that view.
       inconsistencies.foreach(alarmDisagreement(requestId, _))
 
-      // The checker sorts the inconsistencies, so the reported disagreement is deterministic.
-      inconsistencies.headOption match {
-        case Some(inconsistency) =>
-          FutureUnlessShutdown.pure(Rejected(inconsistency.description))
-        case None if !runValidation =>
-          FutureUnlessShutdown.pure(Passed)
-        case None =>
-          validateRecordedResults(requestId, recordedResults)
+      val disagreeingKeys = inconsistencies.map(_.key).toSet
+      val validatableResults = recordedResults.filter { case (_, result) =>
+        !disagreeingKeys.contains(ExternalCallKey.fromResult(result.result))
       }
+
+      val revalidationF =
+        if (!runValidation || validatableResults.isEmpty)
+          FutureUnlessShutdown.pure(Seq.empty[(ExternalCallKey, KeyOutcome)])
+        else validateRecordedResults(requestId, validatableResults)
+
+      revalidationF.map(keyOutcomes =>
+        assemblePerViewResults(recordedResults, inconsistencies, keyOutcomes)
+      )
+    }
+  }
+
+  /** Combines the per-key outcomes into one result per view that records external-call results.
+    * Within a view, a disagreement takes precedence over a re-validation mismatch, which takes
+    * precedence over an unvalidatable result; each verdict describes a call recorded in that view.
+    * Outcomes are examined in key order, so every result is deterministic.
+    */
+  private def assemblePerViewResults(
+      recordedResults: Seq[(ViewPosition, ViewParticipantData.ViewExternalCallResult)],
+      inconsistencies: Seq[Inconsistency],
+      keyOutcomes: Seq[(ExternalCallKey, KeyOutcome)],
+  ): Map[ViewPosition, Result] = {
+    val keysByView: Map[ViewPosition, Set[ExternalCallKey]] =
+      recordedResults
+        .groupMap { case (viewPosition, _) => viewPosition } { case (_, result) =>
+          ExternalCallKey.fromResult(result.result)
+        }
+        .view
+        .mapValues(_.toSet)
+        .toMap
+
+    val mismatches = keyOutcomes.collect { case (_, KeyOutcome.Mismatch(inconsistency)) =>
+      inconsistency
+    }
+    val unvalidatable = keyOutcomes.collect { case (key, KeyOutcome.Unvalidatable(reason)) =>
+      key -> reason
+    }
+
+    keysByView.fmap { viewKeys =>
+      inconsistencies
+        .find(inconsistency => viewKeys.contains(inconsistency.key))
+        .orElse(mismatches.find(mismatch => viewKeys.contains(mismatch.key)))
+        .map(inconsistency => Rejected(inconsistency.description))
+        .orElse(unvalidatable.collectFirst {
+          case (key, reason) if viewKeys.contains(key) => CannotValidate(reason)
+        })
+        .getOrElse(Passed)
     }
   }
 
   /** Re-validates the recorded results, one validator call per distinct semantic call
-    * ([[com.digitalasset.canton.data.ExternalCallKey]]). At this point every key has a single
-    * recorded output: a key with disagreeing outputs is a visible inconsistency and was rejected
-    * before re-validation. Outcomes are examined in key order, so the result is deterministic.
+    * ([[com.digitalasset.canton.data.ExternalCallKey]]), returning the outcome per key in key
+    * order. At this point every key has a single recorded output: keys with disagreeing outputs are
+    * excluded from re-validation by the caller.
     */
   private def validateRecordedResults(
       requestId: RequestId,
@@ -112,7 +163,7 @@ class ExternalCallCheck(
   )(implicit
       traceContext: TraceContext,
       ec: ExecutionContext,
-  ): FutureUnlessShutdown[Result] = {
+  ): FutureUnlessShutdown[Seq[(ExternalCallKey, KeyOutcome)]] = {
     val occurrencesByKey = recordedResults
       .groupMap { case (_, result) => ExternalCallKey.fromResult(result.result) } {
         case (viewPosition, result) =>
@@ -134,30 +185,25 @@ class ExternalCallCheck(
             .map(outcome => (key, occurrencesAndOutputs, recordedOutput, outcome))
       }
       .map { outcomes =>
-        val mismatches = outcomes.collect {
-          case (
+        outcomes.map { case (key, occurrencesAndOutputs, recordedOutput, validated) =>
+          val outcome = validated match {
+            case mismatched: ExternalCallValidator.Mismatched =>
+              val inconsistency = Inconsistency(
                 key,
-                occurrencesAndOutputs,
-                recordedOutput,
-                validated: ExternalCallValidator.Mismatched,
-              ) =>
-            Inconsistency(
-              key,
-              Set(validated.computedOutput, recordedOutput),
-              occurrencesAndOutputs.map { case (occurrence, _) => occurrence }.toSet,
-            )
+                Set(mismatched.computedOutput, recordedOutput),
+                occurrencesAndOutputs.map { case (occurrence, _) => occurrence }.toSet,
+              )
+              // Mirrors the visible-inconsistency alarms in check: every disagreement with the
+              // extension service is suspicious and alarmed once per request.
+              alarmDisagreement(requestId, inconsistency)
+              KeyOutcome.Mismatch(inconsistency)
+            case ExternalCallValidator.UnableToValidate(reason) =>
+              KeyOutcome.Unvalidatable(reason)
+            case ExternalCallValidator.Matched =>
+              KeyOutcome.Ok
+          }
+          key -> outcome
         }
-        // Mirrors the visible-inconsistency alarms in check: every disagreement with the
-        // extension service is suspicious, not only the first one.
-        mismatches.foreach(alarmDisagreement(requestId, _))
-
-        val rejectionO =
-          mismatches.headOption.map(inconsistency => Rejected(inconsistency.description))
-        val abstentionO = outcomes.collectFirst {
-          case (_, _, _, ExternalCallValidator.UnableToValidate(reason)) =>
-            CannotValidate(reason)
-        }
-        rejectionO.orElse(abstentionO).getOrElse(Passed)
       }
   }
 
@@ -171,22 +217,32 @@ class ExternalCallCheck(
 
 object ExternalCallCheck {
 
-  /** Per-request outcome of the external-call check, consumed by
-    * `TransactionConfirmationResponsesFactory` as pure data.
+  /** Per-view outcome of the external-call check, consumed by
+    * `TransactionConfirmationResponsesFactory` as pure data when responding for that view.
     */
   sealed trait Result extends Product with Serializable
 
-  /** All recorded results agree with each other and with the extension service (or there are none).
+  /** The results recorded in the view agree with all visible occurrences of the same calls and with
+    * the extension service.
     */
   case object Passed extends Result
 
-  /** Recorded results disagree with each other, or with the extension service. The request is
-    * rejected on behalf of all hosted confirming parties.
+  /** A result recorded in the view disagrees with another visible occurrence of the same call, or
+    * with the extension service. The view is rejected; the description names a call recorded in
+    * this view.
     */
   final case class Rejected(description: String) extends Result
 
-  /** A recorded result could not be re-validated (for example, no extension service is configured).
-    * Views that would otherwise be approved are abstained from instead.
+  /** A result recorded in the view could not be re-validated (for example, no extension service is
+    * configured). The view is abstained from instead of approved.
     */
   final case class CannotValidate(reason: String) extends Result
+
+  /** Re-validation outcome of a single distinct call. */
+  private sealed trait KeyOutcome extends Product with Serializable
+  private object KeyOutcome {
+    case object Ok extends KeyOutcome
+    final case class Mismatch(inconsistency: Inconsistency) extends KeyOutcome
+    final case class Unvalidatable(reason: String) extends KeyOutcome
+  }
 }

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionConfirmationResponsesFactory.scala
@@ -248,15 +248,16 @@ class TransactionConfirmationResponsesFactory(
                   ).toLocalReject(protocolVersion)
                 )
 
-              // Verdicts due to the external-call check: recorded results that disagree (with
-              // each other across the request, or with the extension service on re-validation)
-              // reject the request on behalf of all hosted confirming parties; a recorded result
-              // that could not be re-validated abstains instead of approving, as the participant
-              // cannot vouch for the recorded result while the request is not provably wrong
-              // either.
+              // Verdicts due to the external-call check for THIS view: a result recorded in the
+              // view that disagrees with another visible occurrence of the same call, or with
+              // the extension service on re-validation, rejects the view; a recorded result that
+              // could not be re-validated abstains instead of approving, as the participant
+              // cannot vouch for the recorded result while the view is not provably wrong
+              // either. Views without external-call results have no entry and get no verdict
+              // from this check.
               val externalCallVerdicts =
-                externalCallCheckResult match {
-                  case ExternalCallCheck.Rejected(description) =>
+                externalCallCheckResult.get(viewPosition) match {
+                  case Some(ExternalCallCheck.Rejected(description)) =>
                     Some(
                       logged(
                         requestId,
@@ -264,14 +265,14 @@ class TransactionConfirmationResponsesFactory(
                           .Reject(description),
                       ).toLocalReject(protocolVersion)
                     )
-                  case ExternalCallCheck.CannotValidate(reason) =>
+                  case Some(ExternalCallCheck.CannotValidate(reason)) =>
                     Some(
                       logged(
                         requestId,
                         LocalAbstainError.CannotPerformAllValidations.Abstain(reason),
                       ).toLocalAbstain(protocolVersion)
                     )
-                  case ExternalCallCheck.Passed => None
+                  case Some(ExternalCallCheck.Passed) | None => None
                 }
 
               // Approve if the consistency check succeeded, reject otherwise.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/TransactionValidationResult.scala
@@ -33,7 +33,7 @@ final case class TransactionValidationResult(
       ErrorWithInternalConsistencyCheck,
       Unit,
     ],
-    externalCallCheckResultF: FutureUnlessShutdown[ExternalCallCheck.Result],
+    externalCallCheckResultF: FutureUnlessShutdown[Map[ViewPosition, ExternalCallCheck.Result]],
     consumedInputsOfHostedParties: Map[LfContractId, Set[LfPartyId]],
     witnessed: Map[LfContractId, GenContractInstance],
     createdContracts: Map[LfContractId, NewContractInstance],

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -134,7 +134,7 @@ final class ExternalCallProtocolIntegrationTest
       validator: ExternalCallValidator,
       views: Map[ViewPosition, ParticipantTransactionView],
       runValidation: Boolean = true,
-  ): ExternalCallCheck.Result =
+  ): Map[ViewPosition, ExternalCallCheck.Result] =
     externalCallCheck(validator).check(requestId, views, runValidation).futureValueUS
 
   private def assertDisagreementAlarm[A](within: => A): A =
@@ -149,10 +149,10 @@ final class ExternalCallProtocolIntegrationTest
     )
 
   "ExternalCallCheck" should {
-    "pass when no view records external-call results" in {
+    "return no results when no view records external-call results" in {
       val validator = new RecordingExternalCallValidator(Map.empty)
 
-      runCheck(validator, views(Seq.empty)) shouldBe ExternalCallCheck.Passed
+      runCheck(validator, views(Seq.empty)) shouldBe Map.empty
       validator.observed shouldBe empty
     }
 
@@ -166,7 +166,10 @@ final class ExternalCallProtocolIntegrationTest
         ),
       )
 
-      result shouldBe ExternalCallCheck.Passed
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Passed,
+        rightViewPosition -> ExternalCallCheck.Passed,
+      )
       // Re-validated once for the shared semantic key.
       validator.observed shouldBe Seq(externalCallKey)
     }
@@ -191,7 +194,11 @@ final class ExternalCallProtocolIntegrationTest
           ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
         ),
       )
-      result shouldBe ExternalCallCheck.Rejected(expectedInconsistency.description)
+      // Both views record the disagreeing call, so both are rejected.
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+      )
       // Disagreeing results are not re-validated.
       validator.observed shouldBe empty
     }
@@ -218,7 +225,9 @@ final class ExternalCallProtocolIntegrationTest
         occurrences =
           Set(ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero)),
       )
-      result shouldBe ExternalCallCheck.Rejected(expectedInconsistency.description)
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description)
+      )
       validator.observed shouldBe Seq(externalCallKey)
     }
 
@@ -235,8 +244,10 @@ final class ExternalCallProtocolIntegrationTest
         views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
       )
 
-      result shouldBe ExternalCallCheck.CannotValidate(
-        "extension service is not configured"
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.CannotValidate(
+          "extension service is not configured"
+        )
       )
     }
 
@@ -251,8 +262,125 @@ final class ExternalCallProtocolIntegrationTest
         runValidation = false,
       )
 
-      result shouldBe ExternalCallCheck.Passed
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Passed,
+        rightViewPosition -> ExternalCallCheck.Passed,
+      )
       validator.observed shouldBe empty
+    }
+
+    "reject every view recording a mismatched call" in {
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(externalCallViewResult(1, externalCallResult, Set(submitter))),
+          ),
+        )
+      }
+
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(otherExternalCallResult.output, externalCallResult.output),
+        occurrences = Set(
+          ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero),
+          ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
+        ),
+      )
+      // The mismatched call is recorded in both views, so both are rejected, after a single
+      // validator invocation for the shared semantic key.
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+      )
+      validator.observed shouldBe Seq(externalCallKey)
+    }
+
+    "isolate re-validation failures to the views recording the call" in {
+      val independentCall = externalCallResult.copy(functionId = "other-function")
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(externalCallViewResult(1, independentCall, Set(submitter))),
+          ),
+        )
+      }
+
+      // Only the view recording the mismatched call is rejected; the view recording the
+      // independently validated call passes.
+      result(leftViewPosition) shouldBe a[ExternalCallCheck.Rejected]
+      result(rightViewPosition) shouldBe ExternalCallCheck.Passed
+      validator.observed should contain theSameElementsAs
+        Seq(externalCallKey, ExternalCallKey.fromResult(independentCall))
+    }
+
+    "re-validate calls unaffected by a disagreement" in {
+      val independentCall = externalCallResult.copy(functionId = "other-function")
+      val independentKey = ExternalCallKey.fromResult(independentCall)
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          independentKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = independentCall.output,
+          )
+        )
+      )
+      val result = loggerFactory.assertLogs(
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(
+              externalCallViewResult(1, otherExternalCallResult, Set(submitter)),
+              externalCallViewResult(2, independentCall, Set(submitter)),
+            ),
+          ),
+        ),
+        // One alarm for the cross-view disagreement, one for the re-validation mismatch.
+        _.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        ),
+        _.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        ),
+      )
+
+      // The disagreeing key is not re-validated, but the independent call still is: its
+      // mismatch rejects the recording view. Both views record the disagreeing call, so both
+      // are rejected; the right view's rejection reports the disagreement, which takes
+      // precedence over its re-validation mismatch.
+      validator.observed shouldBe Seq(independentKey)
+      val expectedDisagreement = Inconsistency(
+        externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
+        occurrences = Set(
+          ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero),
+          ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
+        ),
+      )
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedDisagreement.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(expectedDisagreement.description),
+      )
     }
   }
 
@@ -273,7 +401,7 @@ final class ExternalCallProtocolIntegrationTest
   }
 
   private def createResponses(
-      checkResult: ExternalCallCheck.Result,
+      checkResult: Map[ViewPosition, ExternalCallCheck.Result],
       timeValidationResultE: Either[TimeValidator.TimeCheckFailure, Unit] = Right(()),
       authorizationResult: Map[ViewPosition, String] = Map.empty,
   ): Seq[ConfirmationResponse] = {
@@ -335,35 +463,47 @@ final class ExternalCallProtocolIntegrationTest
   }
 
   "TransactionConfirmationResponsesFactory" should {
-    "reject every view on behalf of all hosted confirming parties on a rejected check" in {
-      val responses = createResponses(ExternalCallCheck.Rejected("disagreeing external call"))
-
-      responses should have size 2
-      forEvery(responses) { response =>
-        inside(response) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
-          reject.isMalformed shouldBe false
-          reject.reason.message shouldBe
-            "LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT(8,0): " +
-            "Rejected transaction due to inconsistent external call results: " +
-            "disagreeing external call"
-          parties shouldBe confirmers
-        }
-      }
-    }
-
-    "abstain instead of approving when the check cannot validate" in {
+    "reject exactly the views with a rejected result and approve the others" in {
       val responses = createResponses(
-        ExternalCallCheck.CannotValidate("extension service is not configured")
+        Map(leftViewPosition -> ExternalCallCheck.Rejected("disagreeing external call"))
       )
 
       responses should have size 2
-      forEvery(responses) { response =>
-        inside(response) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
-          abstain.reason.message shouldBe
-            "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
-            "Cannot perform all validations: extension service is not configured"
-          parties shouldBe confirmers
-        }
+      val leftResponse = responses.find(_.viewPositionO.contains(leftViewPosition)).value
+      inside(leftResponse) { case ConfirmationResponse(_, reject: LocalReject, parties) =>
+        reject.isMalformed shouldBe false
+        reject.reason.message shouldBe
+          "LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT(8,0): " +
+          "Rejected transaction due to inconsistent external call results: " +
+          "disagreeing external call"
+        parties shouldBe confirmers
+      }
+      // The view without external-call results receives no verdict from the check.
+      val rightResponse = responses.find(_.viewPositionO.contains(rightViewPosition)).value
+      inside(rightResponse) { case ConfirmationResponse(_, LocalApprove(), parties) =>
+        parties shouldBe confirmers
+      }
+    }
+
+    "abstain instead of approving exactly the views that cannot be validated" in {
+      val responses = createResponses(
+        Map(
+          leftViewPosition ->
+            ExternalCallCheck.CannotValidate("extension service is not configured")
+        )
+      )
+
+      responses should have size 2
+      val leftResponse = responses.find(_.viewPositionO.contains(leftViewPosition)).value
+      inside(leftResponse) { case ConfirmationResponse(_, abstain: LocalAbstain, parties) =>
+        abstain.reason.message shouldBe
+          "CANNOT_PERFORM_ALL_VALIDATIONS(9,0): " +
+          "Cannot perform all validations: extension service is not configured"
+        parties shouldBe confirmers
+      }
+      val rightResponse = responses.find(_.viewPositionO.contains(rightViewPosition)).value
+      inside(rightResponse) { case ConfirmationResponse(_, LocalApprove(), parties) =>
+        parties shouldBe confirmers
       }
     }
 
@@ -372,7 +512,12 @@ final class ExternalCallProtocolIntegrationTest
       val recordTime = CantonTimestamp.Epoch.plusSeconds(10)
       val maxDelta = NonNegativeFiniteDuration.tryOfSeconds(1)
       val responses = createResponses(
-        ExternalCallCheck.CannotValidate("extension service is not configured"),
+        Map(
+          leftViewPosition ->
+            ExternalCallCheck.CannotValidate("extension service is not configured"),
+          rightViewPosition ->
+            ExternalCallCheck.CannotValidate("extension service is not configured"),
+        ),
         timeValidationResultE = Left(
           TimeValidator.LedgerTimeRecordTimeDeltaTooLargeError(ledgerTime, recordTime, maxDelta)
         ),
@@ -394,7 +539,12 @@ final class ExternalCallProtocolIntegrationTest
     "prefer a rejection from a later validation suite over the abstention" in {
       val responses = loggerFactory.assertLogs(
         createResponses(
-          ExternalCallCheck.CannotValidate("extension service is not configured"),
+          Map(
+            leftViewPosition ->
+              ExternalCallCheck.CannotValidate("extension service is not configured"),
+            rightViewPosition ->
+              ExternalCallCheck.CannotValidate("extension service is not configured"),
+          ),
           authorizationResult = Map(leftViewPosition -> "no authorization"),
         ),
         _.shouldBeCantonErrorCode(LocalRejectError.MalformedRejects.MalformedRequest),
@@ -420,7 +570,12 @@ final class ExternalCallProtocolIntegrationTest
     }
 
     "approve when the check passed" in {
-      val responses = createResponses(ExternalCallCheck.Passed)
+      val responses = createResponses(
+        Map(
+          leftViewPosition -> ExternalCallCheck.Passed,
+          rightViewPosition -> ExternalCallCheck.Passed,
+        )
+      )
 
       responses should have size 2
       forEvery(responses) { response =>


### PR DESCRIPTION
Implements point 4 of the [#565 decision](https://github.com/digital-asset/canton/issues/565#issuecomment-4938124738 ): external-call validation is computed and consumed per view.

> **Update (2026-07-22):** #581 has merged and this PR has been rebased onto latest main — the diff is now exactly this PR's single commit.

## What changes

- `ExternalCallCheck.check` returns one result per view that records external-call results (`Map[ViewPosition, Result]`); views without external calls have no entry.
- `TransactionConfirmationResponsesFactory` consults only the result of the view it responds for, following the existing per-position pattern of the authentication and authorization results. This fixes the two defects named in the decision — rejections duplicated across responses, and rejections attached to views without external calls — plus a third of the same family: the aggregate `Rejected` carried the globally-first inconsistency's description, so a view could be rejected with a message about calls recorded in other views. Each view's rejection now describes a call recorded in that view.
- Attachment rules per the decision: a re-validation failure rejects exactly the views whose participant data records the failed call; a disagreement rejects exactly the views that record the disagreeing key. Within a view, a disagreement takes precedence over a mismatch, which takes precedence over an unvalidatable result — mirroring the previous request-level precedence.
- Re-validation suppression is now per key: keys whose visible occurrences disagree are still not re-validated (there is no unambiguous output to validate), but other keys now are — previously any disagreement suppressed all re-validation, which under per-view results would have masked an independent re-validation failure in an unaffected view.
- Alarms are unchanged: every disagreement and every mismatch is alarmed once, at request level, so the per-view fan-out does not multiply alarms.

## Testing

`ExternalCallProtocolIntegrationTest` rewritten for per-view semantics; the response-factory cases now attach results to specific views (the previous fixtures injected verdicts into views without any external calls — an executable specification of the defect this PR removes) and assert reject/abstain on exactly the affected view with approval of the other. New coverage: a mismatch on a key recorded in several views rejects all of them after a single validator invocation; a re-validation failure is isolated to the recording view; a disagreement no longer suppresses re-validation of unaffected calls. Suites green at `CANTON_PROTOCOL_VERSION=dev`; whole-repo `scalafixCheck` clean.

Second of three PRs for the #565 per-view rework. Refs #565.

