### PR TITLE
feat(external-call): restrict re-validation to hosted checking parties

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessingSteps.scala
@@ -926,6 +926,7 @@ class TransactionProcessingSteps(
           val checkResultF = externalCallCheck.check(
             requestId,
             participantViews,
+            ipsSnapshot,
             runValidation = malformedPayloads.isEmpty,
           )
           if (malformedPayloads.nonEmpty) {

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/TransactionProcessor.scala
@@ -132,6 +132,7 @@ class TransactionProcessor(
           loggerFactory,
         ),
         new ExternalCallCheck(
+          participantId,
           externalCallValidator,
           participantNodeParameters.general.batchingConfig.parallelism,
           loggerFactory,

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -74,9 +74,10 @@ class ExternalCallCheck(
     * If no view records an external-call result -- in particular, always, on protocol versions
     * without external-call support -- the check short-circuits to an empty map.
     *
-    * Keys whose visible occurrences disagree have no unambiguous output and are not re-validated;
-    * all other keys still are, so a disagreement on one call does not mask a re-validation failure
-    * of another.
+    * Keys whose visible occurrences disagree have no unambiguous output and are not re-validated.
+    * Other keys are re-validated if this participant is responsible for them (see the class
+    * documentation), so a disagreement on one call does not mask a re-validation failure of
+    * another.
     *
     * @param requestId
     *   The request under validation, used to correlate logs and alarms.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -27,29 +27,8 @@ import com.digitalasset.canton.util.{ErrorUtil, MonadUtil}
 import scala.concurrent.ExecutionContext
 
 /** Checks the external-call results recorded in the views of a transaction request, as one of the
-  * parallel validation suites invoked from `TransactionProcessingSteps.doParallelChecks`.
-  *
-  * The check has two parts:
-  *   - consistency: whether occurrences of the same external call recorded across the request agree
-  *     on their output ([[ExternalCallConsistencyChecker]]),
-  *   - re-validation: whether the (undisputed) recorded outputs agree with the extension service,
-  *     re-executing each distinct call once ([[ExternalCallValidator]]).
-  *
-  * Every disagreement found by either part is alarmed, once per request. The outcome is one
-  * `ExternalCallCheck.Result` per view that records external-call results: a disagreement or
-  * re-validation failure rejects exactly the views whose participant data records the affected
-  * call, and a recorded result that cannot be re-validated abstains those views instead of
-  * approving them (see [[TransactionConfirmationResponsesFactory]], which consults only the result
-  * of the view it responds for). Views without external-call results receive no result.
-  * Disagreements among the recorded results within a single view's subtree are rejected earlier, as
-  * a malformed view when the view is validated, independently of this check.
-  *
-  * Re-validation is restricted to the calls this participant is responsible for: a call is
-  * re-validated only if the participant hosts one of its checking parties as a confirming party of
-  * a view recording the call. The checking parties of a call are confirming parties of the
-  * recording view whose confirmation is required, so every call is re-validated by the participants
-  * hosting its checking parties; re-validating it elsewhere would only invoke the extension service
-  * needlessly.
+  * parallel validation suites invoked from `TransactionProcessingSteps.doParallelChecks`. See
+  * [[check]] for the semantics.
   *
   * @param participantId
   *   This participant, for deciding which checking parties it hosts.
@@ -67,17 +46,32 @@ class ExternalCallCheck(
 
   import ExternalCallCheck.*
 
-  /** Checks consistency of the recorded external-call results and re-validates them against the
-    * extension service, producing one result per view that records external-call results. A view
-    * without a result in the returned map records no external calls and needs no verdict.
+  /** Checks the recorded external-call results, in two parts:
+    *   - consistency: whether occurrences of the same external call recorded across the request
+    *     agree on their output ([[ExternalCallConsistencyChecker]]),
+    *   - re-validation: whether the (undisputed) recorded outputs agree with the extension service,
+    *     re-executing each distinct call once ([[ExternalCallValidator]]).
     *
-    * If no view records an external-call result -- in particular, always, on protocol versions
-    * without external-call support -- the check short-circuits to an empty map.
+    * The outcome is one result per view that records external-call results: a disagreement or
+    * re-validation failure rejects exactly the views whose participant data records the affected
+    * call, and a recorded result that cannot be re-validated abstains those views instead of
+    * approving them (see [[TransactionConfirmationResponsesFactory]], which consults only the
+    * result of the view it responds for). Views without external-call results have no entry in the
+    * returned map and need no verdict; if no view records any result -- in particular, always, on
+    * protocol versions without external-call support -- the map is empty. Disagreements among the
+    * recorded results within a single view's subtree are rejected earlier, as a malformed view when
+    * the view is validated, independently of this check.
     *
-    * Keys whose visible occurrences disagree have no unambiguous output and are not re-validated.
-    * Other keys are re-validated if this participant is responsible for them (see the class
-    * documentation), so a disagreement on one call does not mask a re-validation failure of
-    * another.
+    * Re-validation is restricted to the calls this participant is responsible for: a call is
+    * re-validated only if the participant hosts one of its checking parties as a confirming party
+    * of a view recording the call. The checking parties of a call are confirming parties of the
+    * recording view whose confirmation is required, so every call is re-validated by the
+    * participants hosting its checking parties; re-validating it elsewhere would only invoke the
+    * extension service needlessly. Keys whose visible occurrences disagree have no unambiguous
+    * output and are not re-validated either, so a disagreement on one call does not mask a
+    * re-validation failure of another.
+    *
+    * Every disagreement found by either part is alarmed, once per request.
     *
     * @param requestId
     *   The request under validation, used to correlate logs and alarms.
@@ -128,12 +122,12 @@ class ExternalCallCheck(
           keysToRevalidate(views, validatableResults, topologySnapshot).flatMap { gatedKeys =>
             // The gate selects the keys to re-validate; a resulting mismatch still rejects
             // every view recording the key, also where the gate did not pass.
-            val toValidate = validatableResults.filter { case (_, result) =>
-              gatedKeys.contains(ExternalCallKey.fromResult(result.result))
-            }
-            if (toValidate.isEmpty)
-              FutureUnlessShutdown.pure(Seq.empty[(ExternalCallKey, KeyOutcome)])
-            else validateRecordedResults(requestId, toValidate)
+            validateRecordedResults(
+              requestId,
+              validatableResults.filter { case (_, result) =>
+                gatedKeys.contains(ExternalCallKey.fromResult(result.result))
+              },
+            )
           }
 
       revalidationF.map(keyOutcomes =>
@@ -162,14 +156,12 @@ class ExternalCallCheck(
       candidates
     }.toSet
 
-    if (allCandidateParties.isEmpty) FutureUnlessShutdown.pure(Set.empty)
-    else
-      topologySnapshot.canConfirm(participantId, allCandidateParties).map { hostedParties =>
-        resultsWithCandidateParties.collect {
-          case (result, candidates) if candidates.exists(hostedParties) =>
-            ExternalCallKey.fromResult(result.result)
-        }.toSet
-      }
+    topologySnapshot.canConfirm(participantId, allCandidateParties).map { hostedParties =>
+      resultsWithCandidateParties.collect {
+        case (result, candidates) if candidates.exists(hostedParties) =>
+          ExternalCallKey.fromResult(result.result)
+      }.toSet
+    }
   }
 
   /** Combines the per-key outcomes into one result per view that records external-call results.

--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallCheck.scala
@@ -19,6 +19,8 @@ import com.digitalasset.canton.participant.protocol.validation.ExternalCallConsi
   Inconsistency,
 }
 import com.digitalasset.canton.protocol.RequestId
+import com.digitalasset.canton.topology.ParticipantId
+import com.digitalasset.canton.topology.client.TopologySnapshot
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.{ErrorUtil, MonadUtil}
 
@@ -42,12 +44,22 @@ import scala.concurrent.ExecutionContext
   * Disagreements among the recorded results within a single view's subtree are rejected earlier, as
   * a malformed view when the view is validated, independently of this check.
   *
+  * Re-validation is restricted to the calls this participant is responsible for: a call is
+  * re-validated only if the participant hosts one of its checking parties as a confirming party of
+  * a view recording the call. The checking parties of a call are confirming parties of the
+  * recording view whose confirmation is required, so every call is re-validated by the participants
+  * hosting its checking parties; re-validating it elsewhere would only invoke the extension service
+  * needlessly.
+  *
+  * @param participantId
+  *   This participant, for deciding which checking parties it hosts.
   * @param externalCallValidator
   *   The validator used to re-run external calls against the extension service.
   * @param externalCallValidationParallelism
   *   Bounds the number of concurrent validator calls.
   */
 class ExternalCallCheck(
+    participantId: ParticipantId,
     externalCallValidator: ExternalCallValidator,
     externalCallValidationParallelism: PositiveInt,
     protected val loggerFactory: NamedLoggerFactory,
@@ -70,6 +82,10 @@ class ExternalCallCheck(
     *   The request under validation, used to correlate logs and alarms.
     * @param views
     *   All views of the request received by this participant, by position.
+    * @param topologySnapshot
+    *   The topology snapshot used for the request, for deciding which confirming parties this
+    *   participant hosts. Must be the same snapshot the confirmation responses are computed with,
+    *   so that the re-validation restriction and the responses cannot diverge.
     * @param runValidation
     *   Whether to re-validate recorded results. False for requests with malformed payloads, which
     *   are rejected wholesale: only the alarms are of interest there.
@@ -77,6 +93,7 @@ class ExternalCallCheck(
   def check(
       requestId: RequestId,
       views: Map[ViewPosition, ParticipantTransactionView],
+      topologySnapshot: TopologySnapshot,
       runValidation: Boolean,
   )(implicit
       traceContext: TraceContext,
@@ -106,12 +123,52 @@ class ExternalCallCheck(
       val revalidationF =
         if (!runValidation || validatableResults.isEmpty)
           FutureUnlessShutdown.pure(Seq.empty[(ExternalCallKey, KeyOutcome)])
-        else validateRecordedResults(requestId, validatableResults)
+        else
+          keysToRevalidate(views, validatableResults, topologySnapshot).flatMap { gatedKeys =>
+            // The gate selects the keys to re-validate; a resulting mismatch still rejects
+            // every view recording the key, also where the gate did not pass.
+            val toValidate = validatableResults.filter { case (_, result) =>
+              gatedKeys.contains(ExternalCallKey.fromResult(result.result))
+            }
+            if (toValidate.isEmpty)
+              FutureUnlessShutdown.pure(Seq.empty[(ExternalCallKey, KeyOutcome)])
+            else validateRecordedResults(requestId, toValidate)
+          }
 
       revalidationF.map(keyOutcomes =>
         assemblePerViewResults(recordedResults, inconsistencies, keyOutcomes)
       )
     }
+  }
+
+  /** The keys this participant is responsible for re-validating: those with at least one occurrence
+    * whose checking parties include a party this participant hosts as a confirming party of the
+    * recording view. Hosting is decided with a single topology lookup over all candidate parties.
+    */
+  private def keysToRevalidate(
+      views: Map[ViewPosition, ParticipantTransactionView],
+      recordedResults: Seq[(ViewPosition, ViewParticipantData.ViewExternalCallResult)],
+      topologySnapshot: TopologySnapshot,
+  )(implicit
+      traceContext: TraceContext,
+      ec: ExecutionContext,
+  ): FutureUnlessShutdown[Set[ExternalCallKey]] = {
+    val resultsWithCandidateParties = recordedResults.map { case (viewPosition, result) =>
+      val confirmers = views(viewPosition).viewCommonData.viewConfirmationParameters.confirmers
+      (result, result.checkingParties.intersect(confirmers))
+    }
+    val allCandidateParties = resultsWithCandidateParties.flatMap { case (_, candidates) =>
+      candidates
+    }.toSet
+
+    if (allCandidateParties.isEmpty) FutureUnlessShutdown.pure(Set.empty)
+    else
+      topologySnapshot.canConfirm(participantId, allCandidateParties).map { hostedParties =>
+        resultsWithCandidateParties.collect {
+          case (result, candidates) if candidates.exists(hostedParties) =>
+            ExternalCallKey.fromResult(result.result)
+        }.toSet
+      }
   }
 
   /** Combines the per-key outcomes into one result per view that records external-call results.

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -353,7 +353,14 @@ final class ExternalCallProtocolIntegrationTest
 
       // Only the view recording the mismatched call is rejected; the view recording the
       // independently validated call passes.
-      result(leftViewPosition) shouldBe a[ExternalCallCheck.Rejected]
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(otherExternalCallResult.output, externalCallResult.output),
+        occurrences =
+          Set(ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero)),
+      )
+      result(leftViewPosition) shouldBe
+        ExternalCallCheck.Rejected(expectedInconsistency.description)
       result(rightViewPosition) shouldBe ExternalCallCheck.Passed
       validator.observed should contain theSameElementsAs
         Seq(externalCallKey, ExternalCallKey.fromResult(independentCall))
@@ -471,10 +478,147 @@ final class ExternalCallProtocolIntegrationTest
       }
 
       // The gate passes only for the left view's occurrence, so the call is re-validated
-      // (once); the mismatch nevertheless rejects every view recording the call.
+      // (once); the mismatch nevertheless rejects every view recording the call, and its
+      // reported occurrences include the view whose occurrence did not pass the gate.
       validator.observed shouldBe Seq(externalCallKey)
-      result(leftViewPosition) shouldBe a[ExternalCallCheck.Rejected]
-      result(rightViewPosition) shouldBe result(leftViewPosition)
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(otherExternalCallResult.output, externalCallResult.output),
+        occurrences = Set(
+          ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero),
+          ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
+        ),
+      )
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+      )
+    }
+
+    "reject disagreements regardless of hosting" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(externalCallViewResult(1, otherExternalCallResult, Set(submitter))),
+          ),
+          topologySnapshot = hostingOnly(Set.empty),
+        )
+      }
+
+      // The re-validation gate does not apply to the consistency check: a visible disagreement
+      // is local evidence of ambiguous recorded data, alarmed and rejected also by participants
+      // hosting none of the checking parties.
+      val expectedInconsistency = Inconsistency(
+        externalCallKey,
+        outputs = Set(externalCallResult.output, otherExternalCallResult.output),
+        occurrences = Set(
+          ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero),
+          ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero),
+        ),
+      )
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+      )
+      validator.observed shouldBe empty
+    }
+
+    "describe each view's rejection by a call recorded in that view" in {
+      val leftCall = externalCallResult.copy(functionId = "left-function")
+      val rightCall = externalCallResult.copy(functionId = "right-function")
+      val leftKey = ExternalCallKey.fromResult(leftCall)
+      val rightKey = ExternalCallKey.fromResult(rightCall)
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          leftKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = leftCall.output,
+          ),
+          rightKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = rightCall.output,
+          ),
+        )
+      )
+      val result = loggerFactory.assertLogs(
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, leftCall, Set(submitter))),
+            rightResults = Seq(externalCallViewResult(1, rightCall, Set(submitter))),
+          ),
+        ),
+        _.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        ),
+        _.shouldBeCantonErrorCode(
+          ExternalCallValidationError.ExternalCallResultDisagreementAlarm
+        ),
+      )
+
+      // Each view's rejection describes the mismatched call recorded in that view, not the
+      // globally first mismatch.
+      val leftInconsistency = Inconsistency(
+        leftKey,
+        outputs = Set(otherExternalCallResult.output, leftCall.output),
+        occurrences =
+          Set(ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero)),
+      )
+      val rightInconsistency = Inconsistency(
+        rightKey,
+        outputs = Set(otherExternalCallResult.output, rightCall.output),
+        occurrences =
+          Set(ExternalCallOccurrence(rightViewPosition, NonNegativeInt.one, NonNegativeInt.zero)),
+      )
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(leftInconsistency.description),
+        rightViewPosition -> ExternalCallCheck.Rejected(rightInconsistency.description),
+      )
+    }
+
+    "prefer a mismatch over an unvalidatable result within a view" in {
+      val mismatchedCall = externalCallResult.copy(functionId = "mismatched-function")
+      val unvalidatableCall = externalCallResult.copy(functionId = "unvalidatable-function")
+      val mismatchedKey = ExternalCallKey.fromResult(mismatchedCall)
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          mismatchedKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = mismatchedCall.output,
+          ),
+          ExternalCallKey.fromResult(unvalidatableCall) ->
+            ExternalCallValidator.UnableToValidate("extension service is not configured"),
+        )
+      )
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(
+              externalCallViewResult(0, mismatchedCall, Set(submitter)),
+              externalCallViewResult(1, unvalidatableCall, Set(submitter)),
+            ),
+            rightResults = Seq(externalCallViewResult(2, unvalidatableCall, Set(submitter))),
+          ),
+        )
+      }
+
+      // Within the left view, the mismatch takes precedence over the unvalidatable result;
+      // the right view, recording only the unvalidatable call, abstains independently.
+      val expectedInconsistency = Inconsistency(
+        mismatchedKey,
+        outputs = Set(otherExternalCallResult.output, mismatchedCall.output),
+        occurrences =
+          Set(ExternalCallOccurrence(leftViewPosition, NonNegativeInt.zero, NonNegativeInt.zero)),
+      )
+      result shouldBe Map(
+        leftViewPosition -> ExternalCallCheck.Rejected(expectedInconsistency.description),
+        rightViewPosition ->
+          ExternalCallCheck.CannotValidate("extension service is not configured"),
+      )
     }
   }
 

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallProtocolIntegrationTest.scala
@@ -98,8 +98,31 @@ final class ExternalCallProtocolIntegrationTest
     }
   }
 
+  private val identityTopologySnapshot: TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties)
+      }
+    snapshot
+  }
+
+  private def hostingOnly(hostedParties: Set[LfPartyId]): TopologySnapshot = {
+    val snapshot = mock[TopologySnapshot]
+    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
+      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
+        FutureUnlessShutdown.pure(parties.intersect(hostedParties))
+      }
+    snapshot
+  }
+
   private def externalCallCheck(validator: ExternalCallValidator): ExternalCallCheck =
-    new ExternalCallCheck(validator, PositiveInt.tryCreate(8), loggerFactory)
+    new ExternalCallCheck(
+      submittingParticipant,
+      validator,
+      PositiveInt.tryCreate(8),
+      loggerFactory,
+    )
 
   private def withConfirmers(
       view: TransactionView,
@@ -134,8 +157,11 @@ final class ExternalCallProtocolIntegrationTest
       validator: ExternalCallValidator,
       views: Map[ViewPosition, ParticipantTransactionView],
       runValidation: Boolean = true,
+      topologySnapshot: TopologySnapshot = identityTopologySnapshot,
   ): Map[ViewPosition, ExternalCallCheck.Result] =
-    externalCallCheck(validator).check(requestId, views, runValidation).futureValueUS
+    externalCallCheck(validator)
+      .check(requestId, views, topologySnapshot, runValidation)
+      .futureValueUS
 
   private def assertDisagreementAlarm[A](within: => A): A =
     loggerFactory.assertLogs(
@@ -382,6 +408,74 @@ final class ExternalCallProtocolIntegrationTest
         rightViewPosition -> ExternalCallCheck.Rejected(expectedDisagreement.description),
       )
     }
+
+    "skip re-validation when no checking party is hosted" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = runCheck(
+        validator,
+        views(leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter)))),
+        topologySnapshot = hostingOnly(Set.empty),
+      )
+
+      // The participant hosts no checking party of the call, so re-validation is not its
+      // responsibility; the view passes from this check's perspective.
+      result shouldBe Map(leftViewPosition -> ExternalCallCheck.Passed)
+      validator.observed shouldBe empty
+    }
+
+    "skip re-validation when the checking parties are not confirmers of the recording view" in {
+      val validator = new RecordingExternalCallValidator(Map.empty)
+      val result = runCheck(
+        validator,
+        views(
+          leftResults = Seq(
+            externalCallViewResult(
+              0,
+              externalCallResult,
+              Set(ExampleTransactionFactory.observer),
+            )
+          )
+        ),
+      )
+
+      // The observer checks the call but does not confirm the view, so hosting it does not
+      // make this participant responsible for re-validation.
+      result shouldBe Map(leftViewPosition -> ExternalCallCheck.Passed)
+      validator.observed shouldBe empty
+    }
+
+    "attach a mismatch to every view recording the key when the gate passes on one" in {
+      val validator = new RecordingExternalCallValidator(
+        Map(
+          externalCallKey -> ExternalCallValidator.Mismatched(
+            computedOutput = otherExternalCallResult.output,
+            recordedOutput = externalCallResult.output,
+          )
+        )
+      )
+      val result = assertDisagreementAlarm {
+        runCheck(
+          validator,
+          views(
+            leftResults = Seq(externalCallViewResult(0, externalCallResult, Set(submitter))),
+            rightResults = Seq(
+              externalCallViewResult(
+                1,
+                externalCallResult,
+                Set(ExampleTransactionFactory.observer),
+              )
+            ),
+          ),
+          topologySnapshot = hostingOnly(Set(submitter)),
+        )
+      }
+
+      // The gate passes only for the left view's occurrence, so the call is re-validated
+      // (once); the mismatch nevertheless rejects every view recording the call.
+      validator.observed shouldBe Seq(externalCallKey)
+      result(leftViewPosition) shouldBe a[ExternalCallCheck.Rejected]
+      result(rightViewPosition) shouldBe result(leftViewPosition)
+    }
   }
 
   private lazy val responsesFactory: TransactionConfirmationResponsesFactory =
@@ -390,15 +484,6 @@ final class ExternalCallProtocolIntegrationTest
       factory.psid,
       loggerFactory,
     )
-
-  private val identityTopologySnapshot: TopologySnapshot = {
-    val snapshot = mock[TopologySnapshot]
-    when(snapshot.canConfirm(any[ParticipantId], any[Set[LfPartyId]])(anyTraceContext))
-      .thenAnswer { (_: ParticipantId, parties: Set[LfPartyId]) =>
-        FutureUnlessShutdown.pure(parties)
-      }
-    snapshot
-  }
 
   private def createResponses(
       checkResult: Map[ViewPosition, ExternalCallCheck.Result],


### PR DESCRIPTION
Implements point 3 of the [#565 decision](https://github.com/digital-asset/canton/issues/565#issuecomment-4938124738 ): a call is re-validated only if the participant hosts one of its checking parties as a confirming party of a view recording the call.

> **Update (2026-07-23):** #582 has merged and this PR has been rebased onto latest main — the diff is now exactly this PR's three commits.

## What changes

- `ExternalCallCheck` learns which calls this participant is responsible for: it now takes the participant id (construction) and the request's topology snapshot (per check) — the same snapshot the confirmation responses are computed with, so the restriction and the responses cannot diverge. Hosting is decided with a single `canConfirm` lookup over the union of `checkingParties ∩ recording-view confirmers` across all recorded results.
- The gate restricts only which keys are re-validated (avoiding needless extension-service invocations, per the decision's rationale). A distinct key is still validated at most once per request — iff at least one of its recorded occurrences passes the gate — and a resulting mismatch rejects every view recording the key, including views whose own occurrence did not pass the gate: the mismatch is objective evidence regardless of which occurrence triggered the invocation.
- The consistency check is not gated: a visible disagreement is local evidence of ambiguous recorded data, alarmed and rejected also by participants hosting none of the checking parties. (The decision's invocation-cost rationale applies only to the validator.)

Soundness: checking parties are computed with the same formula as submission-time `checkConfirmingParties` and are quorum-mandatory confirmers of the recording view, so a view recording a call can only be confirmed once every checking party's participant — which under this gate does re-validate — has approved.

The second commit adds regression pins from the pre-push review of the three-PR stack: disagreements reject regardless of hosting, each view's rejection describes its own call, mismatch-over-unvalidatable precedence with mixed per-view outcomes, and occurrence completeness for gated mismatches; plus two scaladoc corrections.

## Testing

New gate coverage in `ExternalCallProtocolIntegrationTest`: no hosted checking party → no invocation (view passes from this check's perspective); checking parties that are not confirmers of the recording view → no invocation; gate passing on one of several recording views → single invocation, mismatch attached to all. Suites green at `CANTON_PROTOCOL_VERSION=dev`; whole-repo `scalafixCheck` clean.

Third of three PRs for the #565 per-view rework. Refs #565.


