### PR TITLE
test(external-call): pin the negative-path failure logs and client messages

### DIFF
--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/ExtensionServiceExternalCallHandlerTest.scala
@@ -4,11 +4,16 @@
 package com.digitalasset.canton.participant.extension
 
 import com.digitalasset.canton.config.ProcessingTimeout
-import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, Port}
+import com.digitalasset.canton.participant.config.ExtensionServiceConfig
 import com.digitalasset.canton.platform.execution.ExternalCallMode
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.{BaseTest, HasExecutionContext}
+import com.sun.net.httpserver.{HttpHandler, HttpServer}
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
 
 class ExtensionServiceExternalCallHandlerTest
     extends AnyWordSpec
@@ -17,6 +22,9 @@ class ExtensionServiceExternalCallHandlerTest
 
   private def emptyManager: ExtensionServiceManager =
     ExtensionServiceManager.empty(loggerFactory, ProcessingTimeout())
+
+  private val uuidRegex: String =
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
   "ExtensionServiceExternalCallHandler.create" should {
 
@@ -62,7 +70,7 @@ class ExtensionServiceExternalCallHandlerTest
         .failOnShutdown
         .futureValue
 
-      result.left.value.message should include("External calls not supported")
+      result.left.value.message shouldBe "External calls not supported"
     }
   }
 
@@ -102,48 +110,62 @@ class ExtensionServiceExternalCallHandlerTest
 
   "ExtensionServiceExternalCallHandler" when {
     "the error is not actionable for the client" should {
-      "reduce it to the generic client message" in {
-        val manager: ExtensionServiceManager =
-          new ExtensionServiceManager(Map.empty, loggerFactory, ProcessingTimeout()) {
-            override def handleExternalCall(
-                extensionId: String,
-                functionId: String,
-                configHash: String,
-                input: String,
-                mode: ExternalCallMode,
-            )(implicit
-                tc: TraceContext
-            ): FutureUnlessShutdown[Either[ExtensionCallError, String]] =
-              FutureUnlessShutdown.pure(
-                Left(
-                  ExtensionCallError(
-                    statusCode = 503,
-                    message = "Connection failed",
-                    externalCallId = Some("req-1"),
-                    retryable = true,
-                    clientActionable = false,
-                  )(tc)
-                )
-              )
-          }
+      "reduce it to the generic client message and log the full error" in {
+        val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext(
+          "/",
+          (exchange => {
+            val body = "back later".getBytes(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(503, body.length.toLong)
+            exchange.getResponseBody.write(body)
+            exchange.close()
+          }): HttpHandler,
+        )
+        server.start()
+
+        val manager = new ExtensionServiceManager(
+          Map(
+            "some-ext" -> ExtensionServiceConfig(
+              address = "127.0.0.1",
+              port = Port.tryCreate(server.getAddress.getPort),
+              maxRetries = NonNegativeInt.tryCreate(0),
+            )
+          ),
+          loggerFactory,
+          ProcessingTimeout(),
+        )
         val handler = new ExtensionServiceExternalCallHandler(manager)
 
         try {
-          val error = handler
-            .handleExternalCall(
-              "some-ext",
-              "some-func",
-              "00000000",
-              "deadbeef",
-              ExternalCallMode.Submission,
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-          error.message shouldBe
-            "External call failed (retryable = true, external call id = 'req-1')"
-        } finally manager.close()
+          val error = loggerFactory.assertLogs(
+            handler
+              .handleExternalCall(
+                "some-ext",
+                "some-func",
+                "00000000",
+                "deadbeef",
+                ExternalCallMode.Submission,
+              )
+              .failOnShutdown
+              .futureValue
+              .left
+              .value,
+            // The manager logs the full internal error; only the generic message may reach
+            // the engine and thereby the submitting client.
+            _.warningMessage should fullyMatch regex
+              ("External call to extension 'some-ext' \\(function 'some-func'\\) failed: " +
+                "ExtensionCallError\\(status code = 503, message = \"Service unavailable\", " +
+                s"external call id = '$uuidRegex', retryable = true, trace id = tid:\\)"),
+          )
+
+          error.message should fullyMatch regex
+            s"External call failed \\(retryable = true, external call id = '$uuidRegex'\\)"
+          error.message should not include "Service unavailable"
+          error.message should not include "back later"
+        } finally {
+          manager.close()
+          server.stop(0)
+        }
       }
     }
   }

--- a/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
+++ b/community/participant/src/test/scala/com/digitalasset/canton/participant/extension/HttpExtensionServiceClientTest.scala
@@ -186,20 +186,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           ("X-Daml-External-Function-Id", oversizedValue, "config-hash", oversizedValue),
           ("X-Daml-External-Config-Hash", "function", oversizedValue, oversizedValue),
         ).foreach { case (headerName, functionId, configHash, redactedValue) =>
-          val error = loggerFactory.suppressWarnings {
-            client
-              .call(functionId, configHash, "input", ExternalCallMode.Submission)(
-                TraceContext.empty
-              )
-              .failOnShutdown
-              .futureValue
-              .left
-              .value
-          }
+          val error = client
+            .call(functionId, configHash, "input", ExternalCallMode.Submission)(
+              TraceContext.empty
+            )
+            .failOnShutdown
+            .futureValue
+            .left
+            .value
 
           error.statusCode shouldBe 400
-          error.message should include(headerName)
-          error.message should not include redactedValue
+          // Full equality proves the rejected value does not leak.
+          error.message shouldBe s"Invalid external-call HTTP header value for $headerName"
         }
 
         requests.get shouldBe 0
@@ -302,12 +300,11 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)
-            .failOnShutdown
-            .futureValue shouldBe Right("cafe")
-        }
+        // Retries with a finite maxRetries log at INFO only; there is no warning to suppress.
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)
+          .failOnShutdown
+          .futureValue shouldBe Right("cafe")
         attempts.get() shouldBe 2
       } finally {
         server.stop(0)
@@ -342,17 +339,15 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        loggerFactory.suppressWarnings {
-          client
-            .call(
-              "function",
-              "config-hash",
-              "input",
-              ExternalCallMode.Submission,
-            )
-            .failOnShutdown
-            .futureValue shouldBe Right("cafe")
-        }
+        client
+          .call(
+            "function",
+            "config-hash",
+            "input",
+            ExternalCallMode.Submission,
+          )
+          .failOnShutdown
+          .futureValue shouldBe Right("cafe")
 
         observedIdempotencyKeys.size shouldBe 2
         observedIdempotencyKeys.get(0) should not be empty
@@ -390,12 +385,10 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)
-            .failOnShutdown
-            .futureValue shouldBe Right("cafe")
-        }
+        client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)
+          .failOnShutdown
+          .futureValue shouldBe Right("cafe")
 
         attempts.get() shouldBe 2
       } finally {
@@ -424,17 +417,15 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 503
-        error.message should include("Service unavailable")
+        error.message shouldBe "Service unavailable"
         error.message should not include "still unavailable"
         attempts.get() shouldBe 2
       } finally {
@@ -463,17 +454,15 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 401
-        error.message should include("Unauthorized - check bearer token")
+        error.message shouldBe "Unauthorized - check bearer token"
         error.message should not include "missing token"
         attempts.get() shouldBe 1
       } finally {
@@ -505,17 +494,24 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
               )
             )
 
-            val error = loggerFactory.suppressWarnings {
+            val error = loggerFactory.assertLogs(
               client
                 .call("function", "config-hash", "input", ExternalCallMode.Submission)
                 .failOnShutdown
                 .futureValue
                 .left
-                .value
-            }
+                .value,
+              { entry =>
+                entry.warningMessage should fullyMatch regex
+                  ("External call to extension 'test-extension' response body exceeded " +
+                    s"maximum size of 4 bytes: externalCallId=$uuidRegex")
+                entry.warningMessage should not include "beef00"
+              },
+            )
 
             error.statusCode shouldBe 413
-            error.message should include("exceeded maximum size of 4 bytes")
+            error.message shouldBe
+              "External call response body exceeded maximum size of 4 bytes"
             error.message should not include "beef00"
             attempts.get() shouldBe 1
           } finally {
@@ -558,16 +554,19 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           )
         )
 
-        val error = loggerFactory.suppressWarnings {
+        val error = loggerFactory.assertLogs(
           client
             .call("function", "config-hash", "input", ExternalCallMode.Submission)
             .failOnShutdown
             .futureValue
             .left
-            .value
-        }
+            .value,
+          _.warningMessage should fullyMatch regex
+            s"External call to extension 'test-extension' timed out: externalCallId=$uuidRegex",
+        )
 
         error.statusCode shouldBe 408
+        error.message shouldBe "Request timeout"
       } finally {
         releaseResponse.countDown()
         server.stop(0)
@@ -579,16 +578,20 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         configForUnusedPort()
       )
 
-      val error = loggerFactory.suppressWarnings {
+      val error = loggerFactory.assertLogs(
         client
           .call("function", "config-hash", "input", ExternalCallMode.Submission)
           .failOnShutdown
           .futureValue
           .left
-          .value
-      }
+          .value,
+        _.warningMessage should fullyMatch regex
+          ("External call to extension 'test-extension' connection failed: " +
+            s"externalCallId=$uuidRegex"),
+      )
 
       error.statusCode shouldBe 503
+      error.message shouldBe "Connection failed"
     }
 
     "abort retry delay when the extension manager is closing" in {
@@ -658,20 +661,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         )
         val client = newClient(config)
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
-              TraceContext.empty
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 400
-        error.message should include("Bearer token file is empty")
-        error.message should not include tokenFile.toString
+        error.message shouldBe
+          "Invalid extension service authentication configuration: Bearer token file is empty"
       } finally {
         Files.deleteIfExists(tokenFile)
       }
@@ -692,20 +693,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       )
       val client = newClient(config)
 
-      val error = loggerFactory.suppressWarnings {
-        client
-          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
-            TraceContext.empty
-          )
-          .failOnShutdown
-          .futureValue
-          .left
-          .value
-      }
+      val error = client
+        .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+          TraceContext.empty
+        )
+        .failOnShutdown
+        .futureValue
+        .left
+        .value
 
       error.statusCode shouldBe 400
-      error.message should include("Failed to read bearer token file")
-      error.message should not include tokenFile.toString
+      error.message shouldBe
+        "Invalid extension service authentication configuration: Failed to read bearer token file"
     }
 
     "reject malformed bearer token contents without exposing the token" in {
@@ -725,21 +724,20 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         )
         val client = newClient(config)
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
-              TraceContext.empty
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 400
-        error.message should include("Bearer token file contains invalid characters")
-        error.message should not include "secret-token"
-        error.message should not include tokenFile.toString
+        // Full equality proves neither the token nor the file path leaks.
+        error.message shouldBe
+          "Invalid extension service authentication configuration: " +
+          "Bearer token file contains invalid characters"
       } finally {
         Files.deleteIfExists(tokenFile)
       }
@@ -758,21 +756,20 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         )
         val client = newClient(config)
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
-              TraceContext.empty
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 400
-        error.message should include("Bearer token file contains invalid characters")
-        error.message should not include "secret-token"
-        error.message should not include tokenFile.toString
+        // Full equality proves neither the token nor the file path leaks.
+        error.message shouldBe
+          "Invalid extension service authentication configuration: " +
+          "Bearer token file contains invalid characters"
       } finally {
         Files.deleteIfExists(tokenFile)
       }
@@ -795,21 +792,20 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         )
         val client = newClient(config)
 
-        val error = loggerFactory.suppressWarnings {
-          client
-            .call("function", "config-hash", "input", ExternalCallMode.Submission)(
-              TraceContext.empty
-            )
-            .failOnShutdown
-            .futureValue
-            .left
-            .value
-        }
+        val error = client
+          .call("function", "config-hash", "input", ExternalCallMode.Submission)(
+            TraceContext.empty
+          )
+          .failOnShutdown
+          .futureValue
+          .left
+          .value
 
         error.statusCode shouldBe 400
-        error.message should include("Bearer token file contains invalid characters")
-        error.message should not include "secret-token"
-        error.message should not include tokenFile.toString
+        // Full equality proves neither the token nor the file path leaks.
+        error.message shouldBe
+          "Invalid extension service authentication configuration: " +
+          "Bearer token file contains invalid characters"
       } finally {
         Files.deleteIfExists(tokenFile)
       }
@@ -845,9 +841,8 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
 
             error.statusCode shouldBe 404
             error.externalCallId shouldBe None
-            error.message should include("Extension 'missing-extension' not configured")
-            error.message should not include "first-extension"
-            error.message should not include "second-extension"
+            // Full equality proves the configured extension ids do not leak.
+            error.message shouldBe "Extension 'missing-extension' not configured"
           },
           _.warningMessage shouldBe
             "External call to extension 'missing-extension' (function 'function') failed: " +
@@ -888,17 +883,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
           timeouts,
         )
 
+        // The exact message proves the token file path does not leak.
+        val preflightFailure =
+          "Extension startup local preflight failed: Extension 'test-extension': " +
+            "Invalid extension service authentication configuration: Bearer token file is empty"
+
         try {
           loggerFactory.assertLogsSeq(SuppressionRule.LevelAndAbove(Level.ERROR))(
-            inside(manager.initializeOnStartup().failOnShutdown.futureValue) { case Left(error) =>
-              error should include("Bearer token file is empty")
-              error should not include tokenFile.toString
-            },
+            manager.initializeOnStartup().failOnShutdown.futureValue shouldBe
+              Left(preflightFailure),
             entries =>
               inside(entries) { case Seq(entry) =>
-                entry.errorMessage should include("Extension startup local preflight failed")
-                entry.errorMessage should include("Bearer token file is empty")
-                entry.errorMessage should not include tokenFile.toString
+                entry.errorMessage shouldBe preflightFailure
               },
           )
         } finally {
@@ -916,16 +912,18 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
         timeouts,
       )
 
+      // The tail is the JDK's connection-refused message, so pin the structure via regex.
+      val validationFailureRegex =
+        "Extension startup validation failed: Extension 'test-extension': Connection failed: .*"
+
       try {
         loggerFactory.assertLogsSeq(SuppressionRule.LevelAndAbove(Level.ERROR))(
           inside(manager.initializeOnStartup().failOnShutdown.futureValue) { case Left(error) =>
-            error should include("Extension startup validation failed")
-            error should include("test-extension")
+            error should fullyMatch regex validationFailureRegex
           },
           entries =>
             inside(entries) { case Seq(entry) =>
-              entry.errorMessage should include("Extension startup validation failed")
-              entry.errorMessage should include("test-extension")
+              entry.errorMessage should fullyMatch regex validationFailureRegex
             },
         )
       } finally {
@@ -933,6 +931,9 @@ class HttpExtensionServiceClientTest extends AnyWordSpec with BaseTest with HasE
       }
     }
   }
+
+  private val uuidRegex: String =
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
   private def newClient(config: ExtensionServiceConfig)(implicit
       ec: ExecutionContext


### PR DESCRIPTION
Second slice of #564: the unit-level half of the negative-path test work requested at the [#553 approval](https://github.com/digital-asset/canton/pull/553#issuecomment-4891915028) — "these tests should check failures reported to ledger api clients as well as log messages". (The other half — asserting the gRPC rejection a ledger-API client observes — needs the mock-extension-service integration fixture and comes with the e2e test PR.)

## What changes

**`HttpExtensionServiceClientTest`** — the failure-path tests suppressed warnings wholesale and asserted message fragments; they now pin the behavior:
- The exception paths (oversized body, stalled-body timeout, connection failure) assert the full warning message — up to the random external call id, hence a regex with the UUID pattern pinned — and that the response body does not leak into the log.
- Every other negative path (HTTP status mapping, header validation, bearer-token preflight, the manager's 404) emits no warning at all: status errors log the diagnostic body at INFO, and finite-`maxRetries` retries log each attempt and the give-up at INFO. Their blanket suppressions were vestigial and are dropped. The shutdown test's suppression stays — closing mid-retry warns nondeterministically.
- Client-visible messages upgrade from fragment to full-message asserts throughout; where full equality already proves an identifier cannot leak (token, token file path, sibling extension ids, rejected header values), the redundant negative checks are folded into it.
- The startup tests assert the exact preflight failure and pin the remote-validation failure's structure via regex (its tail is the JDK's connection-refused message).

**`ExtensionServiceExternalCallHandlerTest`** — the non-actionable-error test stubbed the manager method that contains the full-error warning, so the log was untestable. It now runs against a real `ExtensionServiceManager` over a local HTTP server returning 503 and asserts the pair of observables together: the warning carries the full internal error while the engine receives only the generic message. The `Unsupported` path's assertion becomes a full-message check; it emits no log by design (no logger there), so no log assertion is added — doing so would need a production change, deliberately out of scope for a test-only PR.

One commit per suite. Locally green: the three extension suites 39/0 at dev PV, `sbt format`, whole-repo `scalafixCheck`.
