### PR TITLE
Fail indexer batch on unresolved deactivation reference

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -206,6 +206,41 @@ The Ledger API command completion service now exposes a `GetCompletionByHash` en
 
 #### Recommendation
 
+### The indexer no longer persists deactivation events with an unresolvable activation reference
+
+#### Issue Description
+When the indexer could not resolve the activation reference of a deactivation event, it logged a
+warning and persisted the event with a NULL `deactivated_event_sequential_id`. Ledger API
+activeness queries anti-join on that reference, so the archived contract stayed visible as active
+in the ACS permanently, while ACS commitments (computed from the synchronizer-side stores)
+remained correct.
+
+#### Affected Deployments
+Participant nodes.
+
+#### Impact
+Participants hosting the same party could serve diverging ACS contents; aggregates computed from
+the ACS (e.g. a token registry's total supply) differed per node.
+
+#### Symptom
+A contract remains in `/v2/state/active-contracts` responses although the transaction stream shows
+its archival. The participant log contains "Activation is missing for a deactivation" warnings at
+the time the archival was indexed.
+
+#### Workaround
+Run the index database integrity check to detect affected rows; contact support for repairing the
+affected index database entries.
+
+#### Likeliness
+Very rare; requires a transient contract-resolution failure (e.g. a stale contract cache mapping
+or an indexer restart window) at the moment the archival is indexed.
+
+#### Recommendation
+Upgrade. The indexer now fails the ingestion batch and restarts instead of persisting the
+corruption, exposes the restarts via the new
+`daml.indexer.indexer_restart_due_to_unresolved_deactivation` metric, and the integrity check
+reports deactivation events without an activation reference.
+
 ## Deprecations
 - `StaticSynchronizerParameters.defaultsWithoutKMS` has been deprecated in favor of `StaticSynchronizerParameters.defaults`. Supported cryptographic schemes now have parity between KMS and non-KMS configurations.
 

--- a/community/common/src/main/scala/com/digitalasset/canton/participant/store/ContractStore.scala
+++ b/community/common/src/main/scala/com/digitalasset/canton/participant/store/ContractStore.scala
@@ -86,6 +86,13 @@ trait ContractStore extends ContractLookup with FlagCloseable {
     */
   def contractsPruned(internalContractIds: Iterable[Long]): Unit
 
+  /** Invalidate any cached lookups for the given internal contract IDs without modifying the
+    * underlying store. In contrast to [[contractsPruned]], this must never remove contract data: it
+    * is used when a cached mapping is suspected to be stale and a fresh read from persistence is
+    * needed. Stores without a cache do nothing.
+    */
+  def invalidateCachedContracts(internalContractIds: Iterable[Long]): Unit
+
   def contractCount()(implicit traceContext: TraceContext): FutureUnlessShutdown[Int]
 
   // TODO(i24535): implement this on db level

--- a/community/common/src/main/scala/com/digitalasset/canton/participant/store/db/DbContractStore.scala
+++ b/community/common/src/main/scala/com/digitalasset/canton/participant/store/db/DbContractStore.scala
@@ -470,6 +470,11 @@ class DbContractStore(
   override def contractsPruned(
       internalContractIds: Iterable[Long]
   ): Unit =
+    invalidateCachedContracts(internalContractIds)
+
+  override def invalidateCachedContracts(
+      internalContractIds: Iterable[Long]
+  ): Unit =
     internalContractIds.view
       .flatMap(cache.getIfPresentAuxKey)
       .foreach(cache.invalidate)

--- a/community/common/src/main/scala/com/digitalasset/canton/participant/store/memory/InMemoryContractStore.scala
+++ b/community/common/src/main/scala/com/digitalasset/canton/participant/store/memory/InMemoryContractStore.scala
@@ -141,6 +141,10 @@ class InMemoryContractStore(
       .flatMap(internalIds.remove)
       .foreach(contracts.remove(_).discard)
 
+  // The in-memory store has no cache in front of it: it is the authoritative store itself,
+  // so there is nothing stale to invalidate.
+  override def invalidateCachedContracts(internalContractIds: Iterable[Long]): Unit = ()
+
   override def lookupStakeholders(ids: Set[LfContractId])(implicit
       traceContext: TraceContext
   ): EitherT[FutureUnlessShutdown, UnknownContracts, Map[LfContractId, Set[LfPartyId]]] = {

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/metrics/IndexerMetrics.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/metrics/IndexerMetrics.scala
@@ -135,6 +135,23 @@ class IndexerMetrics(
     )
   )
 
+  // Number of times the Indexer needed to restart because the activation reference of a
+  // deactivation event could not be resolved
+  val indexerRestartDueToUnresolvedDeactivation: Counter = factory.counter(
+    MetricInfo(
+      prefix :+ "indexer_restart_due_to_unresolved_deactivation",
+      summary =
+        "Number of times the Indexer needed to restart due to an unresolvable deactivation reference.",
+      description =
+        """A deactivation event whose activation reference cannot be resolved would be persisted
+          |with a NULL activation reference, making it invisible to activeness queries and leaving
+          |the deactivated contract in the Ledger API ACS permanently. The indexer restarts and
+          |retries instead, and does not progress while the failure persists. A steadily
+          |increasing value therefore means the indexer is stalled and needs investigation.""",
+      qualification = MetricQualification.Errors,
+    )
+  )
+
   val ingestionBlockedByPruningDuration: Timer =
     factory.timer(histograms.ingestionBlockedByPruningDuration.info)
 

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerSubscription.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerSubscription.scala
@@ -223,6 +223,7 @@ private[platform] final case class ParallelIndexerSubscription[DbBatch](
             lastActivations = contractStorageBackend.lastActivations,
             dbDispatcher = dbDispatcher,
             resolveInternalContractIds = resolveInternalContractIdsF,
+            invalidateCachedContracts = contractStore.invalidateCachedContracts,
             logger = logger,
             metrics = metrics,
             executionContext = executionContext,
@@ -919,6 +920,7 @@ object ParallelIndexerSubscription {
       resolveInternalContractIds: TraceContext => Iterable[ContractId] => Future[
         Map[ContractId, Long]
       ],
+      invalidateCachedContracts: Iterable[Long] => Unit,
       executionContext: ExecutionContext,
       metrics: LedgerApiServerMetrics,
       logger: TracedLogger,
@@ -973,6 +975,35 @@ object ParallelIndexerSubscription {
                   )
             )
             .toMap
+        unresolvedDeactivations =
+          updatedMissingDeactivatedActivations.view.collect { case (synCon, None) =>
+            synCon
+          }.toVector
+        _ =
+          if (unresolvedDeactivations.nonEmpty) {
+            // A deactivation without an activation reference would be persisted with
+            // deactivated_event_sequential_id = NULL, making it invisible to all activeness
+            // queries: the deactivated contract would remain in the Ledger API ACS forever.
+            // Fail the batch instead, so the indexer restarts and retries. The retry converges
+            // when the failure was transient, e.g. a stale cached contract mapping (invalidated
+            // below) or a ledger-end-cache window. A persistent failure keeps the indexer
+            // restarting, which is deliberate: an unresolvable activation reference means the
+            // index database is inconsistent, and a loud stall is preferable to persisting the
+            // corruption.
+            invalidateCachedContracts(
+              unresolvedDeactivations.flatMap(synCon =>
+                resolvedInternalContractIds.get(synCon.contractId)
+              )
+            )
+            logger.error(
+              s"Could not resolve the activation for ${unresolvedDeactivations.size} deactivation(s) of contracts (first 10 shown) ${unresolvedDeactivations
+                  .take(10)
+                  .map(synCon => s"${synCon.contractId} on synchronizer ${synCon.synchronizerId}")
+                  .mkString("[", ", ", "]")}. Restarting indexer to retry. If this error repeats for the same contracts, the index database may be inconsistent: run the index database integrity check."
+            )
+            metrics.indexer.indexerRestartDueToUnresolvedDeactivation.inc()
+            throw new UnresolvedDeactivationReferenceException()
+          }
       } yield batch.copy(
         missingDeactivatedActivations = updatedMissingDeactivatedActivations
       )
@@ -995,10 +1026,9 @@ object ParallelIndexerSubscription {
           )(ErrorLoggingContext.fromTracedLogger(logger)(batch.batchTraceContext))
 
         case Some(None) =>
-          logger.warn(
-            s"Activation is missing for a deactivation for $marker."
-          )(batch.batchTraceContext)
-          dbDto.withActivationRef(None)
+          ErrorUtil.invalidState(
+            s"Programming error: activation was not resolved for $marker; dbPrepare must fail the batch when a deactivation reference cannot be computed."
+          )(ErrorLoggingContext.fromTracedLogger(logger)(batch.batchTraceContext))
 
         case Some(Some(deactivationReference)) =>
           dbDto.withActivationRef(Some(deactivationReference))
@@ -1056,6 +1086,8 @@ object ParallelIndexerSubscription {
           )
         )
       case deactivate: DbDto.EventDeactivate =>
+        // A missing activation reference cannot occur here: refillMissingDeactivatedActivations
+        // fails the batch first, so the Option.map is defensive only.
         deactivate.deactivated_event_sequential_id.map { deactivatedEventSequentialId =>
           ContractStateEvent.Deactivated(
             contractId = deactivate.contract_id,
@@ -1320,6 +1352,11 @@ object ParallelIndexerSubscription {
   class ReferencedContractNotFoundException
       extends RuntimeException(
         "Restarting indexer due to attempt to store events relying on missing internal contract IDs."
+      )
+
+  class UnresolvedDeactivationReferenceException
+      extends RuntimeException(
+        "Restarting indexer due to failure to resolve the activation reference of a deactivation event."
       )
 }
 

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/LedgerApiContractStore.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/LedgerApiContractStore.scala
@@ -39,6 +39,8 @@ trait LedgerApiContractStore {
   ): Future[Map[LfContractId, Long]]
 
   def contractsPruned(internalContractIds: Iterable[Long]): Unit
+
+  def invalidateCachedContracts(internalContractIds: Iterable[Long]): Unit
 }
 
 final case class LedgerApiContractStoreImpl(
@@ -109,6 +111,9 @@ final case class LedgerApiContractStoreImpl(
 
   override def contractsPruned(internalContractIds: Iterable[Long]): Unit =
     participantContractStore.contractsPruned(internalContractIds)
+
+  override def invalidateCachedContracts(internalContractIds: Iterable[Long]): Unit =
+    participantContractStore.invalidateCachedContracts(internalContractIds)
 
   private def failOnShutdown[T](f: FutureUnlessShutdown[T])(implicit
       errorLoggingContext: ErrorLoggingContext

--- a/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/backend/common/IntegrityStorageBackendImpl.scala
+++ b/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/store/backend/common/IntegrityStorageBackendImpl.scala
@@ -589,6 +589,34 @@ private[backend] object IntegrityStorageBackendImpl extends IntegrityStorageBack
             .take(10)
             .mkString("[", ", ", "]")}"
       )
+
+    // A deactivation event with a NULL deactivated_event_sequential_id is invisible to all
+    // activeness queries, so the contract it deactivated stays in the Ledger API ACS permanently.
+    // Rows strictly below the pruning point are legitimate pruning leftovers and are reported by
+    // the check above instead.
+    val deactivationsWithoutActivationReference =
+      SQL"""
+        SELECT event_sequential_id, event_offset
+        FROM lapi_events_deactivate_contract dea, lapi_parameters
+        WHERE dea.deactivated_event_sequential_id is null
+        AND dea.event_offset >= $lapi_pruning_started_up_to_inclusive
+        AND lapi_parameters.ledger_end is not null
+        AND dea.event_offset <= lapi_parameters.ledger_end
+        ${QueryStrategy.limitClause(Some(11))}
+      """
+        .asVectorOf(
+          long("event_sequential_id") ~ long("event_offset") map {
+            case event_sequential_id ~ event_offset => (event_sequential_id, event_offset)
+          }
+        )(connection)
+        .sorted
+
+    if (deactivationsWithoutActivationReference.nonEmpty)
+      throw new RuntimeException(
+        s"some deactivation events have no activation reference, so the contracts they deactivated stay visible as active, event_sequential_id-s with offsets (first 10 shown) ${deactivationsWithoutActivationReference
+            .take(10)
+            .mkString("[", ", ", "]")}"
+      )
   } catch {
     case t: Throwable if !failForEmptyDB =>
       val failure = t.getMessage

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerSubscriptionSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/indexer/parallel/ParallelIndexerSubscriptionSpec.scala
@@ -4,6 +4,8 @@
 package com.digitalasset.canton.platform.indexer.parallel
 
 import com.daml.metrics.DatabaseMetrics
+import com.daml.metrics.api.testing.{InMemoryMetricsFactory, MetricValues}
+import com.daml.metrics.api.{HistogramInventory, MetricName}
 import com.digitalasset.canton.data.{CantonTimestamp, LedgerTimeBoundaries, Offset}
 import com.digitalasset.canton.ledger.participant.state
 import com.digitalasset.canton.ledger.participant.state.Update.TransactionAccepted.RepresentativePackageId.SameAsContractPackageId
@@ -31,13 +33,14 @@ import com.digitalasset.canton.logging.{
   SuppressionRule,
   TracedLogger,
 }
-import com.digitalasset.canton.metrics.LedgerApiServerMetrics
+import com.digitalasset.canton.metrics.{LedgerApiServerHistograms, LedgerApiServerMetrics}
 import com.digitalasset.canton.participant.store.PersistedContractInstance
 import com.digitalasset.canton.platform.indexer.ha.TestConnection
 import com.digitalasset.canton.platform.indexer.parallel.ParallelIndexerSubscription.{
   ActivationRef,
   Batch,
   SynCon,
+  UnresolvedDeactivationReferenceException,
   ZeroLedgerEnd,
 }
 import com.digitalasset.canton.platform.store.LedgerApiContractStore
@@ -98,6 +101,7 @@ class ParallelIndexerSubscriptionSpec
     extends AnyFlatSpec
     with ScalaFutures
     with Matchers
+    with MetricValues
     with HasExecutionContext
     with NamedLogging {
 
@@ -1247,10 +1251,8 @@ class ParallelIndexerSubscriptionSpec
     )
   }
 
-  it should "report warning, but succeed, if activation is missing" in {
-    loggerFactory.assertLogs(
-      LoggerNameContains("ParallelIndexerSubscription") && SuppressionRule.Level(Level.WARN)
-    )(
+  it should "report error and fail, if activation is missing" in {
+    loggerFactory.assertInternalError[IllegalStateException](
       ParallelIndexerSubscription
         .refillMissingDeactivatedActivations(LedgerApiServerMetrics.ForTesting, logger)(
           Batch(
@@ -1276,18 +1278,9 @@ class ParallelIndexerSubscriptionSpec
             usedInternalContractIds = Set.empty,
             contractStateEvents = Vector.empty,
           )
-        )
-        .batch should contain theSameElementsInOrderAs Vector(
-        someEventDeactivate.copy(
-          synchronizer_id = someSynchronizerId2,
-          contract_id = hashCid("A"),
-          deactivated_event_sequential_id = None,
-          internal_contract_id = None,
-          event_type = 3,
-        )
-      ),
-      _.warningMessage should include(
-        s"Activation is missing for a deactivation for deactivated event with type:ConsumingExercise offset:1 nodeId:1 for synchronizerId:$someSynchronizerId2 contractId:${hashCid("A")}."
+        ),
+      _.getMessage should include(
+        s"Programming error: activation was not resolved for deactivated event with type:ConsumingExercise offset:1 nodeId:1 for synchronizerId:$someSynchronizerId2 contractId:${hashCid("A")}; dbPrepare must fail the batch when a deactivation reference cannot be computed."
       ),
     )
   }
@@ -1334,6 +1327,7 @@ class ParallelIndexerSubscriptionSpec
         @unused _connection: Connection
     ): Map[(SynchronizerId, Long), Long] = Map(
       (someSynchronizerId, 5L) -> 2L,
+      (someSynchronizerId, 7L) -> 3L,
       (someSynchronizerId2, 15L) -> 4L,
     )
 
@@ -1365,7 +1359,7 @@ class ParallelIndexerSubscriptionSpec
       offsetsUpdates = Vector.empty,
       missingDeactivatedActivations = Map(
         SynCon(someSynchronizerId, hashCid("#1")) -> None,
-        SynCon(someSynchronizerId, hashCid("#2")) -> None, // not in last activations
+        SynCon(someSynchronizerId, hashCid("#2")) -> None,
         SynCon(someSynchronizerId2, hashCid("#3")) -> None,
       ),
       eventCount = 0L,
@@ -1374,10 +1368,13 @@ class ParallelIndexerSubscriptionSpec
       contractStateEvents = Vector.empty,
     )
 
+    val invalidated = mutable.ArrayBuffer.empty[Long]
+
     val outBatchF = ParallelIndexerSubscription.dbPrepare(
       lastActivations,
       mockDbDispatcher(new TestConnection),
       resolveInternalContractIds,
+      ids => invalidated ++= ids,
       executionContext,
       metrics,
       logger,
@@ -1396,7 +1393,7 @@ class ParallelIndexerSubscriptionSpec
         offsetsUpdates = Vector.empty,
         missingDeactivatedActivations = Map(
           SynCon(someSynchronizerId, hashCid("#1")) -> Some(ActivationRef(2L, 5L)),
-          SynCon(someSynchronizerId, hashCid("#2")) -> None,
+          SynCon(someSynchronizerId, hashCid("#2")) -> Some(ActivationRef(3L, 7L)),
           SynCon(someSynchronizerId2, hashCid("#3")) -> Some(ActivationRef(4L, 15L)),
         ),
         eventCount = 0L,
@@ -1404,6 +1401,79 @@ class ParallelIndexerSubscriptionSpec
         usedInternalContractIds = Set.empty,
         contractStateEvents = Vector.empty,
       )
+
+    invalidated shouldBe empty
+  }
+
+  it should "invalidate cached contracts and fail the batch if an activation cannot be resolved" in {
+    def lastActivations(@unused _synchronizerContracts: Iterable[(SynchronizerId, Long)])(
+        @unused _connection: Connection
+    ): Map[(SynchronizerId, Long), Long] = Map(
+      (someSynchronizerId, 5L) -> 2L
+    )
+
+    def resolveInternalContractIds(@unused _tc: TraceContext)(
+        @unused _contractIds: Iterable[ContractId]
+    ): Future[Map[ContractId, Long]] = Future.successful {
+      Map(
+        hashCid("#1") -> 5L,
+        hashCid("#2") -> 7L, // resolvable internal contract ID, but no activation found
+      )
+    }
+
+    val invalidated = mutable.ArrayBuffer.empty[Long]
+    val testMetrics = new LedgerApiServerMetrics(
+      new LedgerApiServerHistograms(MetricName("test"))(new HistogramInventory),
+      new InMemoryMetricsFactory,
+    )
+
+    val inBatch = Batch(
+      ledgerEnd = ZeroLedgerEnd.copy(lastOffset = offset(2)),
+      batchTraceContext = TraceContext.empty,
+      batch = Vector(someEventActivate),
+      batchSize = 1,
+      offsetsUpdates = Vector.empty,
+      // the log assertions below rely on insertion-order iteration, which Scala Maps only
+      // guarantee for up to 4 entries
+      missingDeactivatedActivations = Map(
+        SynCon(someSynchronizerId, hashCid("#1")) -> None,
+        SynCon(someSynchronizerId, hashCid("#2")) -> None,
+        SynCon(someSynchronizerId, hashCid("#3")) -> None, // no internal contract ID either
+      ),
+      eventCount = 0L,
+      distinctRawStrings = Nil,
+      usedInternalContractIds = Set.empty,
+      contractStateEvents = Vector.empty,
+    )
+
+    loggerFactory.assertLogs(
+      LoggerNameContains("ParallelIndexerSubscription") && SuppressionRule.LevelAndAbove(
+        Level.WARN
+      )
+    )(
+      ParallelIndexerSubscription
+        .dbPrepare(
+          lastActivations,
+          mockDbDispatcher(new TestConnection),
+          resolveInternalContractIds,
+          ids => invalidated ++= ids,
+          executionContext,
+          testMetrics,
+          logger,
+        )(inBatch)
+        .failed
+        .futureValue shouldBe a[UnresolvedDeactivationReferenceException],
+      _.warningMessage should include(
+        s"internal_contract_id for contract ID:${hashCid("#3")} not found"
+      ),
+      _.errorMessage should (include(
+        "Could not resolve the activation for 2 deactivation(s)"
+      ) and include(s"${hashCid("#2")}") and include(s"${hashCid("#3")}")),
+    )
+
+    // only #2 resolved to an internal contract ID whose cached mapping can be invalidated
+    invalidated should contain theSameElementsAs Seq(7L)
+    testMetrics.indexer.indexerRestartDueToUnresolvedDeactivation.value shouldBe 1
   }
 
   behavior of "batcher"
@@ -1574,25 +1644,20 @@ class ParallelIndexerSubscriptionSpec
     result.contractStateEvents shouldBe Vector.empty
   }
 
-  it should "skip deactivations that, after refillMissingDeactivatedActivations, still have no deactivated_event_sequential_id" in {
-    // A deactivation that arrived without an activation ref AND whose lookup was registered as
-    // "no activation found" (Some(None)) is refilled to keep deactivated_event_sequential_id = None.
-    // buildContractStateEvents must skip such deactivations.
-    val skippedContractId = hashCid("skipped-no-ref")
+  it should "fail on deactivations that, after refillMissingDeactivatedActivations, still have no deactivated_event_sequential_id" in {
+    // A deactivation without an activation reference must never be persisted: it would be
+    // invisible to all activeness queries, so the deactivated contract would stay in the
+    // Ledger API ACS permanently. dbPrepare fails the batch before this point; reaching
+    // batcher with an unresolved deactivation is an invariant violation.
+    val unresolvedContractId = hashCid("unresolved-no-ref")
     val deactivateWithoutRef = someEventDeactivate.copy(
       event_type = PersistentEventType.ConsumingExercise.asInt,
       event_sequential_id = 20L,
       deactivated_event_sequential_id = None,
-      contract_id = skippedContractId,
-    )
-    val createActivate = someEventActivate.copy(
-      event_type = PersistentEventType.Create.asInt,
-      event_sequential_id = 21L,
-      notPersistedContractId = hashCid("create"),
-      notPersistedContractKey = None,
+      contract_id = unresolvedContractId,
     )
 
-    val result = loggerFactory.assertLogs(
+    loggerFactory.assertInternalError[IllegalStateException](
       ParallelIndexerSubscription.batcher(
         batchF = _ => "ignored",
         logger = logger,
@@ -1601,11 +1666,11 @@ class ParallelIndexerSubscriptionSpec
         Batch(
           ledgerEnd = ZeroLedgerEnd.copy(lastOffset = offset(2)),
           batchTraceContext = TraceContext.empty,
-          batch = Vector(deactivateWithoutRef, createActivate),
-          batchSize = 2,
+          batch = Vector(deactivateWithoutRef),
+          batchSize = 1,
           offsetsUpdates = offsetsAndUpdates,
           missingDeactivatedActivations = Map(
-            SynCon(deactivateWithoutRef.synchronizer_id, skippedContractId) -> None
+            SynCon(deactivateWithoutRef.synchronizer_id, unresolvedContractId) -> None
           ),
           eventCount = 0L,
           distinctRawStrings = Nil,
@@ -1613,17 +1678,9 @@ class ParallelIndexerSubscriptionSpec
           contractStateEvents = Vector.empty,
         )
       ),
-      _.warningMessage should include("Activation is missing for a deactivation"),
-    )
-
-    // Only the activation produces a ContractStateEvent; the deactivation is skipped.
-    result.contractStateEvents shouldBe Vector(
-      ContractStateEvent.Activated(
-        contractId = createActivate.notPersistedContractId,
-        globalKey = None,
-        eventSequentialId = createActivate.event_sequential_id,
-        isInitial = true,
-      )
+      _.getMessage should include(
+        "Programming error: activation was not resolved for"
+      ),
     )
   }
 
@@ -3140,6 +3197,9 @@ class ParallelIndexerSubscriptionSpec
       }
 
     override def contractsPruned(internalContractIds: Iterable[Long]): Unit =
+      fail("should not be used")
+
+    override def invalidateCachedContracts(internalContractIds: Iterable[Long]): Unit =
       fail("should not be used")
   }
 }

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/store/backend/StorageBackendTestsIntegrity.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/store/backend/StorageBackendTestsIntegrity.scala
@@ -757,7 +757,8 @@ private[backend] trait StorageBackendTestsIntegrity extends Matchers with Storag
         deactivated_event_sequential_id = Some(6L),
         internal_contract_id = Some(1L),
       ),
-      dtosConsumingExercise( // deactivated_event_sequential_id is NULL - not reported
+      dtosConsumingExercise( // NULL deactivated_event_sequential_id - reported by the
+        // missing-activation-reference check, but the stray-deactivation check fires first here
         event_offset = 6,
         event_sequential_id = 6L,
         deactivated_event_sequential_id = None,
@@ -915,6 +916,58 @@ private[backend] trait StorageBackendTestsIntegrity extends Matchers with Storag
 
     failure.getMessage should include(
       "some events in deactivate have not been pruned, offsets (first 10 shown) [2]"
+    )
+  }
+
+  it should "report deactivation events without an activation reference below the ledger end" in {
+    val updates = Vector(
+      dtosConsumingExercise( // NULL activation reference below the ledger end - reported
+        event_offset = 2,
+        event_sequential_id = 2L,
+        deactivated_event_sequential_id = None,
+      ),
+      dtosConsumingExercise( // NULL activation reference beyond the ledger end - not reported
+        event_offset = 100,
+        event_sequential_id = 100L,
+        deactivated_event_sequential_id = None,
+      ),
+    ).flatten
+
+    executeSql(backend.parameter.initializeParameters(someIdentityParams, loggerFactory))
+    executeSql(ingest(updates, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+
+    // using inMemoryCantonStore = true to skip the par_contracts check
+    val failure = intercept[RuntimeException](
+      executeSql(backend.integrity.verifyIntegrity(inMemoryCantonStore = true))
+    )
+
+    failure.getMessage should include(
+      "some deactivation events have no activation reference, so the contracts they deactivated stay visible as active, event_sequential_id-s with offsets (first 10 shown) [(2,2)]"
+    )
+  }
+
+  it should "report deactivation events without an activation reference at the pruning point" in {
+    val updates = Vector(
+      dtosConsumingExercise( // NULL activation reference at exactly the pruning point - reported
+        event_offset = 2,
+        event_sequential_id = 2L,
+        deactivated_event_sequential_id = None,
+      )
+    ).flatten
+
+    executeSql(backend.parameter.initializeParameters(someIdentityParams, loggerFactory))
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset(2)))
+    executeSql(ingest(updates, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+
+    // using inMemoryCantonStore = true to skip the par_contracts check
+    val failure = intercept[RuntimeException](
+      executeSql(backend.integrity.verifyIntegrity(inMemoryCantonStore = true))
+    )
+
+    failure.getMessage should include(
+      "some deactivation events have no activation reference, so the contracts they deactivated stay visible as active, event_sequential_id-s with offsets (first 10 shown) [(2,2)]"
     )
   }
 


### PR DESCRIPTION
Fixes #598.

## What

The indexer computes the `deactivated_event_sequential_id` back-pointer for each deactivation event at ingestion time. When resolution failed, it logged a warning and persisted the event with a NULL back-pointer. Every Ledger API activeness query anti-joins on that back-pointer, so the archived contract stayed visible as active in the ACS permanently. We observed this in production: a mainnet participant served 3 archived contracts as active for 7 weeks, diverging from every other participant hosting the same party (details in #598 and DA support ticket DA-4793).

This PR makes the failure loud instead of corrupting:

1. `dbPrepare` now fails the ingestion batch when any deactivation's activation reference stays unresolved, following the `ReferencedContractNotFoundException` recovery pattern: the indexer restarts and retries. Before throwing, it invalidates the cached contract lookups for the affected contracts, so a stale cached mapping cannot cause a restart loop.
2. The tolerant branch in `refillMissingDeactivatedActivations` becomes an invariant violation, closing the only code path that wrote NULL back-pointers.
3. A new integrity check reports deactivation events with a NULL activation reference at or above the pruning point and below the ledger end. The existing checks either skipped NULL back-pointers or treated them as pruning leftovers.
4. A new `Errors`-qualified counter, `indexer_restart_due_to_unresolved_deactivation`, makes the restarts alertable.

## Design decisions

**Cache invalidation uses a new `ContractStore.invalidateCachedContracts` method** instead of the existing `contractsPruned`. The existing method deletes contract data on the in-memory store (correct at its call site, where the contracts are proven absent), which would destroy live contracts here. The new method only invalidates caches: the JDBC store invalidates its lookup cache, the in-memory store is a no-op because it has no cache.

**A persistent resolution failure now stalls the indexer deliberately.** The retry converges when the failure was transient (a stale cached mapping, or a ledger-end-cache window). If the activation reference is genuinely unresolvable, the indexer keeps restarting: we consider a loud stall preferable to silently persisting corruption that pruning later makes undiagnosable. If you would rather have an operator escape hatch (bounded retries, or a flag restoring the old warn-and-persist behavior), we are happy to add one — we did not want to grow the config surface unilaterally.

**Can a legitimate flow produce an unresolvable deactivation?** We believe not. Pruning only removes an activation row together with the deactivation that consumed it, so a live contract's activation row is never pruned; witnessed-only consuming exercises take the `lapi_events_various_witnessed` path and need no back-pointer. An unresolved reference at ingestion time is therefore either transient or evidence of an inconsistent index database. The integration test environments run `verifyIntegrity` at teardown, so a green CI run across the ACS-import, party-replication, and pruning suites is empirical evidence for this claim — we would appreciate maintainers double-checking the reasoning.

## How tested

- `community-common` / `ledger-api-core` (main and test) pass `scalafmtCheck` and compile.
- `ParallelIndexerSubscriptionSpec` extended: the throw from `dbPrepare` (both failure stages: internal-contract-id resolution miss and `lastActivations` miss), the invalidation contents, the single summarizing error log, the metric increment (via `InMemoryMetricsFactory`), the no-invalidation happy path, and the invariant violation through `batcher`.
- `StorageBackendTestsIntegrity` extended: the new check reports a NULL back-pointer below the ledger end and at exactly the pruning point, and ignores rows beyond the ledger end. One pre-existing test comment claimed NULL back-pointers are "not reported"; that test only stayed green because the stray-deactivation check fires first, and the comment now says so.
- Full local run: 304 tests, 0 failures across `ParallelIndexerSubscriptionSpec` and the complete `StorageBackendSpecH2` suite.

Not covered locally, deferred to CI: the Postgres storage-backend variant, downstream module compilation, and the integration suites. Two known coverage gaps we chose not to close here because they need the full e2e rig: the production wiring of the invalidation callback is verified by compilation only, and no test pins that the new exception restarts rather than halts the indexer (the sibling `ReferencedContractNotFoundException` has the same gap).

## User-facing changes

New metric, new integrity check message, and a behavior change (indexer restart instead of silent corruption) — documented in `UNRELEASED.md` under Bugfixes.
