### PR TITLE
Fix WebSocket JWT extraction dropping tokens due to unstrimmed whitespace

### DIFF
--- a/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/Endpoints.scala
+++ b/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/Endpoints.scala
@@ -436,6 +436,22 @@ object Endpoints {
   val wsSubprotocol: Header =
     sttp.model.Header("Sec-WebSocket-Protocol", "daml.ws.auth")
 
+  // RFC 6455 clients send comma-space separated subprotocol values (e.g.
+  // "daml.ws.auth, jwt.token.<TOKEN>"), so each element must be trimmed before
+  // matching the jwt.token. prefix, or tokens are silently dropped and the
+  // request proceeds unauthenticated.
+  private[v2] def extractWsJwtToken(header: Option[String]): Option[Jwt] = {
+    val tokenPrefix = "jwt.token."
+    header
+      .map(_.split(",").toSeq)
+      .getOrElse(Seq.empty)
+      .map(_.trim)
+      .filter(_.startsWith(tokenPrefix))
+      .map(_.substring(tokenPrefix.length))
+      .headOption
+      .map(Jwt.apply)
+  }
+
   lazy val baseEndpoint: Endpoint[CallerContext, Unit, Unit, Unit, Any] = endpoint
     .securityIn(
       auth
@@ -447,16 +463,7 @@ object Endpoints {
         .and(
           auth
             .apiKey(header[Option[String]]("Sec-WebSocket-Protocol"))
-            .map { bearer =>
-              val tokenPrefix = "jwt.token." // TODO (i21030) test this
-              bearer
-                .map(_.split(",").toSeq)
-                .getOrElse(Seq.empty)
-                .filter(_.startsWith(tokenPrefix))
-                .map(_.substring(tokenPrefix.length))
-                .headOption
-                .map(Jwt.apply)
-            }(_.map(_.token))
+            .map(extractWsJwtToken)(_.map(_.token))
             .description("Ledger API standard JWT token (websocket)")
         )
         .and(

--- a/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/json/v2/EndpointsTest.scala
+++ b/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/json/v2/EndpointsTest.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.http.json.v2
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EndpointsTest extends AnyWordSpec with Matchers {
+
+  "extractWsJwtToken" should {
+
+    "extract the token from RFC 6455 comma-space separated subprotocols" in {
+      Endpoints.extractWsJwtToken(Some("daml.ws.auth, jwt.token.abc123")) shouldBe Some(
+        Endpoints.Jwt("abc123")
+      )
+    }
+
+    "extract the token when there is no space after the comma" in {
+      Endpoints.extractWsJwtToken(Some("daml.ws.auth,jwt.token.abc123")) shouldBe Some(
+        Endpoints.Jwt("abc123")
+      )
+    }
+
+    "extract the token regardless of extra surrounding whitespace" in {
+      Endpoints.extractWsJwtToken(Some("daml.ws.auth ,  jwt.token.abc123  ")) shouldBe Some(
+        Endpoints.Jwt("abc123")
+      )
+    }
+
+    "extract the token when it appears before the daml.ws.auth marker" in {
+      Endpoints.extractWsJwtToken(Some("jwt.token.abc123, daml.ws.auth")) shouldBe Some(
+        Endpoints.Jwt("abc123")
+      )
+    }
+
+    "return None when no jwt.token. prefixed value is present" in {
+      Endpoints.extractWsJwtToken(Some("daml.ws.auth")) shouldBe None
+    }
+
+    "return None when the header is absent" in {
+      Endpoints.extractWsJwtToken(None) shouldBe None
+    }
+
+    "return None for an empty header value" in {
+      Endpoints.extractWsJwtToken(Some("")) shouldBe None
+    }
+
+    "take the first matching token when multiple are present" in {
+      Endpoints.extractWsJwtToken(
+        Some("daml.ws.auth, jwt.token.first, jwt.token.second")
+      ) shouldBe Some(Endpoints.Jwt("first"))
+    }
+  }
+}


### PR DESCRIPTION
Fixes #614.

RFC 6455 clients send comma-space separated `Sec-WebSocket-Protocol` values (e.g. `"daml.ws.auth, jwt.token.<TOKEN>"`), but the JWT extraction logic in `Endpoints.scala` split on commas without trimming the resulting elements. The leading space on the token segment caused `startsWith("jwt.token.")` to fail, so the token was silently dropped and the request proceeded unauthenticated — surfacing later as gRPC `UNAUTHENTICATED` on the first response frame instead of failing at connection time.

Extracts the parsing logic into `extractWsJwtToken`, trims each element after splitting, and adds unit tests (`EndpointsTest.scala`) covering RFC 6455 formatting, alternate spacing, and multi-token ordering.

Originally raised and fixed against the wrong repo in canton-network/splice#6776 / canton-network/splice#6777, so moving the fix upstream here.
