### PR TITLE
test(external-call): cover external calls in Daml Script

### DIFF
--- a/community/app/src/test/daml/ExternalCallTest/daml/ExternalCallTest.daml
+++ b/community/app/src/test/daml/ExternalCallTest/daml/ExternalCallTest.daml
@@ -9,6 +9,11 @@ import DA.ExternalCall (externalCall)
 -- external call to a configured extension service in the transaction. The
 -- config and input arguments are hex-encoded byte strings; the result is the
 -- service response as a hex-encoded byte string.
+--
+-- Keep in sync with the copy in
+-- community/daml-script-tests/src/test/resources/daml/ScriptExternalCallTests: the projects
+-- are built by different build systems (sbt DamlPlugin vs dpm at test runtime) and cannot
+-- share sources, but both suites must exercise the same template behavior.
 template ExternalCallTester
   with
     owner : Party

--- a/community/daml-script-tests/src/test/resources/daml/ScriptExternalCallTests/daml.yaml
+++ b/community/daml-script-tests/src/test/resources/daml/ScriptExternalCallTests/daml.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+override-components:
+  damlc:
+    version: $DAML_VERSION
+  daml-script:
+    version: $DAML_VERSION
+build-options:
+  - --target=2.dev
+name: ScriptExternalCallTests
+source: daml
+version: 1.0.0
+dependencies:
+  - daml-prim
+  - daml-stdlib
+  - daml-script

--- a/community/daml-script-tests/src/test/resources/daml/ScriptExternalCallTests/daml/ExternalCallTests.daml
+++ b/community/daml-script-tests/src/test/resources/daml/ScriptExternalCallTests/daml/ExternalCallTests.daml
@@ -1,0 +1,59 @@
+-- Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ExternalCallTests where
+
+import Daml.Script
+import DA.Assert
+import DA.ExternalCall (externalCall)
+import DA.Text
+
+-- Keep in sync with the copy in community/app/src/test/daml/ExternalCallTest: the projects
+-- are built by different build systems (sbt DamlPlugin vs dpm at test runtime) and cannot
+-- share sources, but both suites must exercise the same template behavior.
+template ExternalCallTester
+  with
+    owner : Party
+  where
+    signatory owner
+
+    nonconsuming choice CallExtension : Text
+      with
+        extensionId : Text
+        functionId : Text
+        configHex : Text
+        inputHex : Text
+      controller owner
+      do externalCall extensionId functionId configHex inputHex
+
+-- The service output recorded at submission flows back as the choice result.
+externalCallReturnsServiceOutput : Script Text
+externalCallReturnsServiceOutput = script do
+  owner <- allocateParty "Owner-ExternalCallTests:externalCallReturnsServiceOutput"
+  cid <- owner `submit` createCmd ExternalCallTester with owner
+  result <- owner `submit` exerciseCmd cid CallExtension with
+    extensionId = "test-extension"
+    functionId = "test-function"
+    configHex = "00ff"
+    inputHex = "deadbeef"
+  result === "c0ffee"
+  pure result
+
+-- A call to an unconfigured extension fails at interpretation time and
+-- surfaces to the script as the typed external-call submit error.
+unknownExtensionFailsWithExternalCallError : Script ()
+unknownExtensionFailsWithExternalCallError = script do
+  owner <- allocateParty "Owner-ExternalCallTests:unknownExtensionFailsWithExternalCallError"
+  cid <- owner `submit` createCmd ExternalCallTester with owner
+  res <- owner `trySubmit` exerciseCmd cid CallExtension with
+    extensionId = "missing-extension"
+    functionId = "test-function"
+    configHex = "00ff"
+    inputHex = "deadbeef"
+  case res of
+    Left (ExternalCallError ExecutionFailed extensionId functionId errMsg) -> do
+      extensionId === "missing-extension"
+      functionId === "test-function"
+      assert $ "Extension 'missing-extension' not configured" `isInfixOf` errMsg
+    Left e -> error $ "unknownExtensionFailsWithExternalCallError incorrect error: " <> show e
+    Right _ -> error "unknownExtensionFailsWithExternalCallError incorrectly succeeded"

--- a/community/daml-script-tests/src/test/scala/com/digitalasset/canton/integration/tests/DamlScriptIT.scala
+++ b/community/daml-script-tests/src/test/scala/com/digitalasset/canton/integration/tests/DamlScriptIT.scala
@@ -7,7 +7,7 @@ import com.digitalasset.canton.buildinfo.BuildInfo
 import com.digitalasset.canton.config
 import com.digitalasset.canton.config.DbConfig
 import com.digitalasset.canton.config.RequireTypes.Port
-import com.digitalasset.canton.integration.plugins.UseReferenceBlockSequencer
+import com.digitalasset.canton.integration.plugins.{UseExtensionService, UseReferenceBlockSequencer}
 import com.digitalasset.canton.integration.{
   CantonEnvironmentSetup,
   CommunityIntegrationTest,
@@ -918,6 +918,30 @@ class DamlScriptPVDevLFDevIT extends DamlScriptIT(LanguageVersion.v2_dev) {
     "NUCKTests:queryNByKeyMultiple" -> Success(),
     "NUCKTests:queryNByKeyUnauthorized" -> Success(),
     "NUCKTests:exerciseByKeyWithInvisibleButDisclosedKey" -> Success(),
+  )
+
+  doRunTests(scriptIdsToTest)
+}
+
+/** Runs the external-call Daml Script tests against a mock extension service. The scripts hardcode
+  * the plugin's default extension id and default response, so the plugin is registered with its
+  * defaults. `DA.ExternalCall.externalCall` only exists at LF 2.dev and the external-call wire data
+  * only at protocol version dev, hence the dev gating.
+  */
+class DamlScriptExternalCallIT extends DamlScriptIT(LanguageVersion.v2_dev) {
+  import DamlScriptIT.ExpectedResult.*
+
+  registerPlugin(new UseExtensionService(loggerFactory))
+
+  override lazy val projectName = "ScriptExternalCallTests"
+  override lazy val protocolVersionForTesting = ProtocolVersion.dev
+
+  override protected def scriptIdsToTest: List[String] = listDamlScriptIds(projectName)
+
+  override def expectedResults = super.expectedResults ++ List(
+    "ExternalCallTests:externalCallReturnsServiceOutput" ->
+      Success(Json.fromString(UseExtensionService.defaultResponseHex)),
+    "ExternalCallTests:unknownExtensionFailsWithExternalCallError" -> Success(),
   )
 
   doRunTests(scriptIdsToTest)


### PR DESCRIPTION
Part of #564 (the recovered cross-repo item: Daml Script coverage agreed with @paulbrauner-da in the daml#23099 review, https://github.com/digital-asset/daml/pull/23099#discussion_r3473140101).

**Stacked on #594** — the first four commits are #594 (including the `ExternalCallTest` rename); **only the last commit (27442b32f) is new here.** I will rebase onto main as soon as #594 merges, leaving just that commit.

Adds a dev-LF Daml Script project `ScriptExternalCallTests` and a `DamlScriptExternalCallIT` suite backed by #594's `UseExtensionService` mock:

- `externalCallReturnsServiceOutput`: the recorded service output flows back as the choice result, asserted in-script and pinned as the exact JSON script result.
- `unknownExtensionFailsWithExternalCallError`: a call to an unconfigured extension surfaces to the script as the typed `ExternalCallError` submit error added by daml#23099 (`ExecutionFailed` with the extension and function ids pinned).

Notes:
- No sbt wiring is needed: `DamlScriptIT` builds the project with `dpm` at test runtime.
- Gating follows the sibling `DamlScriptPVDevLFDevIT`: `protocolVersionForTesting = ProtocolVersion.dev`, so the scripts run in the dev-protocol-version job and report ignored at stable PR jobs. Verified locally: 3/3 green at `CANTON_PROTOCOL_VERSION=dev`, 3 ignored at the stable default.
- The `ExternalCallTester` template is duplicated from `community/app/src/test/daml/ExternalCallTest` with keep-in-sync comments in both copies — the two projects are built by different build systems and cannot share sources.
