### PR TITLE
test(external-call): cover the failure scenarios end-to-end

### DIFF
--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallIntegrationTest.scala
@@ -4,14 +4,21 @@
 package com.digitalasset.canton.integration.tests.extension
 
 import com.daml.ledger.api.v2.transaction_filter.TransactionShape.TRANSACTION_SHAPE_LEDGER_EFFECTS
+import com.daml.ledger.javaapi.data.{ExercisedEvent, Transaction}
 import com.digitalasset.canton.BaseTest
+import com.digitalasset.canton.console.CommandFailure
+import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.extcall.java as M
 import com.digitalasset.canton.integration.plugins.{UseExtensionService, UseH2}
 import com.digitalasset.canton.integration.{
   CommunityIntegrationTest,
   EnvironmentDefinition,
   SharedEnvironment,
+  TestConsoleEnvironment,
 }
+import com.digitalasset.canton.logging.LogEntry
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidationError
+import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.version.ProtocolVersion
 
 import scala.jdk.CollectionConverters.*
@@ -35,33 +42,41 @@ class ExternalCallIntegrationTest extends CommunityIntegrationTest with SharedEn
       participant1.synchronizers.connect_local(sequencer1, alias = daName)
     }
 
+  private val uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+  private def setUpOwner(name: String)(implicit env: TestConsoleEnvironment): PartyId = {
+    import env.*
+    participant1.dars.upload(BaseTest.ExternalCallTestPath)
+    participant1.parties.enable(name)
+  }
+
+  private def callExtension(owner: PartyId, extensionId: String)(implicit
+      env: TestConsoleEnvironment
+  ): Transaction = {
+    import env.*
+    participant1.ledger_api.javaapi.commands.submit(
+      Seq(owner),
+      Seq(
+        new M.externalcalltest.ExternalCallTester(owner.toProtoPrimitive).createAnd
+          .exerciseCallExtension(extensionId, "test-function", "00ff", "deadbeef")
+          .commands
+          .loneElement
+      ),
+      transactionShape = TRANSACTION_SHAPE_LEDGER_EFFECTS,
+    )
+  }
+
   "a Daml external call" should {
     "be recorded at submission and re-validated in the confirmation workflow" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       implicit env =>
-        import env.*
+        extensionService.reset()
+        val owner = setUpOwner("external-call-owner")
 
-        participant1.dars.upload(BaseTest.ExternalCallTestPath)
-        val owner = participant1.parties.enable("external-call-owner")
-
-        val transaction = participant1.ledger_api.javaapi.commands.submit(
-          Seq(owner),
-          Seq(
-            new M.externalcalltest.ExternalCallTester(owner.toProtoPrimitive).createAnd
-              .exerciseCallExtension(
-                extensionService.extensionId,
-                "test-function",
-                "00ff",
-                "deadbeef",
-              )
-              .commands
-              .loneElement
-          ),
-          transactionShape = TRANSACTION_SHAPE_LEDGER_EFFECTS,
-        )
+        val transaction = callExtension(owner, extensionService.extensionId)
 
         // The choice returns the service output recorded in the transaction.
         val exercised = transaction.getEvents.asScala.collect {
-          case event: com.daml.ledger.javaapi.data.ExercisedEvent => event
+          case event: ExercisedEvent => event
         }.loneElement
         exercised.getExerciseResult.asText().toScala.value.getValue shouldBe
           UseExtensionService.defaultResponseHex
@@ -82,6 +97,202 @@ class ExternalCallIntegrationTest extends CommunityIntegrationTest with SharedEn
         // attempt.
         calls.map(_.idempotencyKey).distinct should have size 2
         calls.map(_.externalCallId).distinct should have size 2
+    }
+
+    "fail the submission when the extension service cannot be reached" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        extensionService.reset()
+        val owner = setUpOwner("external-call-unreachable-owner")
+
+        loggerFactory.assertThrowsAndLogsSeq[CommandFailure](
+          callExtension(owner, extensionService.unreachableExtensionId).discard,
+          LogEntry.assertLogSeq(
+            Seq(
+              (
+                // The JDK reports a refused connection as either a connect or a generic I/O
+                // failure; both map to the same retryable error and client message.
+                _.warningMessage should fullyMatch regex
+                  s"External call to extension '${extensionService.unreachableExtensionId}' " +
+                  s"(connection failed|I/O error): externalCallId=$uuidRegex",
+                "HTTP client transport warning",
+              ),
+              (
+                _.warningMessage should fullyMatch regex
+                  s"External call to extension '${extensionService.unreachableExtensionId}' " +
+                  "\\(function 'test-function'\\) failed: ExtensionCallError\\(status code = 503, " +
+                  s"""message = "(Connection failed|I/O error)", external call id = '$uuidRegex', """ +
+                  "retryable = true, trace id = tid:[0-9a-f]*\\)",
+                "extension service manager warning",
+              ),
+              (
+                _.commandFailureMessage should include regex
+                  "INTERPRETATION_EXTERNAL_CALL_ERROR_EXECUTION_FAILED\\(9,.*\\): " +
+                  "Interpretation error: Error: External call execution failed " +
+                  s"\\(extensionId=${extensionService.unreachableExtensionId}, functionId=test-function\\): " +
+                  s"call failed: External call failed \\(retryable = true, " +
+                  s"external call id = '$uuidRegex', trace id = '[0-9a-f]*'\\)",
+                "command failure",
+              ),
+            ),
+            Seq.empty,
+          ),
+        )
+        // The transport failure happens before any request reaches a service.
+        extensionService.observedCalls shouldBe empty
+    }
+
+    "fail the submission when the service output is not canonical hex" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        extensionService.reset()
+        try {
+          extensionService.respondWith(_ => UseExtensionService.Response(200, "C0FFEE"))
+          val owner = setUpOwner("external-call-invalid-output-owner")
+
+          assertThrowsAndLogsCommandFailures(
+            callExtension(owner, extensionService.extensionId).discard,
+            _.commandFailureMessage should include regex
+              "INTERPRETATION_EXTERNAL_CALL_ERROR_INVALID_OUTPUT\\(9,.*\\): " +
+              "Interpretation error: Error: External call execution failed " +
+              s"\\(extensionId=${extensionService.extensionId}, functionId=test-function\\): " +
+              "invalid output: Invalid external call output: expected canonical lowercase hex",
+          )
+          // The submission already fails, so nothing is recorded and nothing is re-validated.
+          extensionService.observedCalls.map(_.mode) shouldBe Seq("submission")
+        } finally extensionService.reset()
+    }
+
+    "reject the request when the recorded output cannot be re-validated" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        import env.*
+        extensionService.reset()
+        try {
+          // A transport-level failure between the submission and validation phases of a single
+          // request cannot be injected with a static mock; an HTTP error funnels into the same
+          // validator outcome: the participant cannot re-validate and abstains, and the mediator
+          // rejects the request because the only confirmer abstained.
+          extensionService.respondWith(call =>
+            if (call.mode == "validation") UseExtensionService.Response(503, "")
+            else UseExtensionService.Response(200, UseExtensionService.defaultResponseHex)
+          )
+          val owner = setUpOwner("external-call-abstain-owner")
+
+          loggerFactory.assertThrowsAndLogsSeq[CommandFailure](
+            callExtension(owner, extensionService.extensionId).discard,
+            LogEntry.assertLogSeq(
+              Seq(
+                (
+                  _.warningMessage should fullyMatch regex
+                    s"External call to extension '${extensionService.extensionId}' " +
+                    "\\(function 'test-function'\\) failed: ExtensionCallError\\(status code = 503, " +
+                    s"""message = "Service unavailable", external call id = '$uuidRegex', """ +
+                    "retryable = true, trace id = tid:[0-9a-f]*\\)",
+                  "extension service manager warning",
+                ),
+                (
+                  _.commandFailureMessage should include regex
+                    "CANNOT_PERFORM_ALL_VALIDATIONS\\(9,.*\\): Cannot perform all validations: " +
+                    s"external-call validation failed with status 503, externalCallId=$uuidRegex",
+                  "command failure",
+                ),
+              ),
+              Seq.empty,
+            ),
+          )
+          extensionService.observedCalls.map(_.mode) shouldBe Seq("submission", "validation")
+          // The rejected request must not leave anything on the ledger.
+          participant1.ledger_api.state.acs.of_party(owner) shouldBe empty
+        } finally extensionService.reset()
+    }
+
+    "reject the request when re-validation returns non-canonical output" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        import env.*
+        extensionService.reset()
+        try {
+          extensionService.respondWith(call =>
+            if (call.mode == "validation") UseExtensionService.Response(200, "C0FFEE")
+            else UseExtensionService.Response(200, UseExtensionService.defaultResponseHex)
+          )
+          val owner = setUpOwner("external-call-noncanonical-owner")
+
+          // Non-canonical output at submission rejects the command (INVALID_OUTPUT above), but
+          // at validation the participant merely cannot re-validate and abstains: the service
+          // call itself succeeded, so no warning and no disagreement alarm fires, which the
+          // single log assertion pins.
+          assertThrowsAndLogsCommandFailures(
+            callExtension(owner, extensionService.extensionId).discard,
+            _.commandFailureMessage should include regex
+              "CANNOT_PERFORM_ALL_VALIDATIONS\\(9,.*\\): Cannot perform all validations: " +
+              "external-call validation returned non-canonical output",
+          )
+          extensionService.observedCalls.map(_.mode) shouldBe Seq("submission", "validation")
+          // The rejected request must not leave anything on the ledger.
+          participant1.ledger_api.state.acs.of_party(owner) shouldBe empty
+        } finally extensionService.reset()
+    }
+
+    "reject and alarm when re-validation disagrees with the recorded output" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        import env.*
+        extensionService.reset()
+        try {
+          extensionService.respondWith(call =>
+            if (call.mode == "validation") UseExtensionService.Response(200, "beef")
+            else UseExtensionService.Response(200, UseExtensionService.defaultResponseHex)
+          )
+          val owner = setUpOwner("external-call-disagreement-owner")
+
+          // "c0ffee" (3 bytes) is recorded at submission, re-validation computes "beef"
+          // (2 bytes): the description reports the output byte sizes in ascending order and
+          // never the output bytes themselves.
+          val expectedInconsistency =
+            """Inconsistency(
+              |  extensionId = test-extension,
+              |  functionId = test-function,
+              |  config = 2 bytes,
+              |  input = 4 bytes,
+              |  outputByteSizes = Seq(2, 3),
+              |  occurrences = ExternalCallOccurrence(viewPosition = ViewPosition(R), exerciseIndex = 0, callIndex = 0)
+              |)""".stripMargin
+
+          loggerFactory.assertThrowsAndLogsSeq[CommandFailure](
+            callExtension(owner, extensionService.extensionId).discard,
+            entries => {
+              LogEntry.assertLogSeq(
+                Seq(
+                  (
+                    _.shouldBeCantonError(
+                      ExternalCallValidationError.ExternalCallResultDisagreementAlarm,
+                      messageAssertion = _ shouldBe
+                        s"Observed inconsistent external call results: $expectedInconsistency",
+                      contextAssertion = _.keySet should contain("requestId"),
+                    ),
+                    "disagreement alarm",
+                  ),
+                  (
+                    entry => {
+                      entry.commandFailureMessage should include regex
+                        "LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT\\(8,.*\\): "
+                      entry.commandFailureMessage should include(
+                        "Rejected transaction due to inconsistent external call results: " +
+                          expectedInconsistency
+                      )
+                    },
+                    "command failure",
+                  ),
+                ),
+                Seq.empty,
+              )(entries)
+              // The check alarms once per request, not once per view or occurrence.
+              entries.count(
+                _.message.startsWith("EXTERNAL_CALL_RESULT_DISAGREEMENT_ALARM")
+              ) shouldBe 1
+            },
+          )
+          extensionService.observedCalls.map(_.mode) shouldBe Seq("submission", "validation")
+          // The rejected request must not leave anything on the ledger.
+          participant1.ledger_api.state.acs.of_party(owner) shouldBe empty
+        } finally extensionService.reset()
     }
   }
 }

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallIntegrationTest.scala
@@ -50,15 +50,15 @@ class ExternalCallIntegrationTest extends CommunityIntegrationTest with SharedEn
     participant1.parties.enable(name)
   }
 
-  private def callExtension(owner: PartyId, extensionId: String)(implicit
-      env: TestConsoleEnvironment
+  private def callExtension(owner: PartyId, extensionId: String, configHex: String = "00ff")(
+      implicit env: TestConsoleEnvironment
   ): Transaction = {
     import env.*
     participant1.ledger_api.javaapi.commands.submit(
       Seq(owner),
       Seq(
         new M.externalcalltest.ExternalCallTester(owner.toProtoPrimitive).createAnd
-          .exerciseCallExtension(extensionId, "test-function", "00ff", "deadbeef")
+          .exerciseCallExtension(extensionId, "test-function", configHex, "deadbeef")
           .commands
           .loneElement
       ),
@@ -75,8 +75,8 @@ class ExternalCallIntegrationTest extends CommunityIntegrationTest with SharedEn
         val transaction = callExtension(owner, extensionService.extensionId)
 
         // The choice returns the service output recorded in the transaction.
-        val exercised = transaction.getEvents.asScala.collect {
-          case event: ExercisedEvent => event
+        val exercised = transaction.getEvents.asScala.collect { case event: ExercisedEvent =>
+          event
         }.loneElement
         exercised.getExerciseResult.asText().toScala.value.getValue shouldBe
           UseExtensionService.defaultResponseHex
@@ -159,6 +159,25 @@ class ExternalCallIntegrationTest extends CommunityIntegrationTest with SharedEn
           // The submission already fails, so nothing is recorded and nothing is re-validated.
           extensionService.observedCalls.map(_.mode) shouldBe Seq("submission")
         } finally extensionService.reset()
+    }
+
+    "fail the submission when the call arguments are not canonical hex" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        extensionService.reset()
+        val owner = setUpOwner("external-call-preparation-owner")
+
+        // The stdlib wrapper lowercases the hex arguments, so only genuinely non-hex input
+        // reaches the interpreter's canonicality check.
+        assertThrowsAndLogsCommandFailures(
+          callExtension(owner, extensionService.extensionId, configHex = "zz").discard,
+          _.commandFailureMessage should include regex
+            "INTERPRETATION_EXTERNAL_CALL_ERROR_PREPARATION_FAILED\\(9,.*\\): " +
+            "Interpretation error: Error: External call preparation failed " +
+            s"\\(extensionId=${extensionService.extensionId}, functionId=test-function\\): " +
+            "Invalid external call config or input: expected canonical lowercase hex",
+        )
+        // Preparation fails before the handler is invoked: no request reaches the service.
+        extensionService.observedCalls shouldBe empty
     }
 
     "reject the request when the recorded output cannot be re-validated" onlyRunWithOrGreaterThan ProtocolVersion.dev in {

--- a/community/integration-testing/src/main/scala/com/digitalasset/canton/integration/plugins/UseExtensionService.scala
+++ b/community/integration-testing/src/main/scala/com/digitalasset/canton/integration/plugins/UseExtensionService.scala
@@ -23,15 +23,21 @@ import scala.jdk.CollectionConverters.*
   * end-to-end. The mock serves the external-call endpoint and the version endpoint of the
   * extension-service API, records every external call it receives, and answers with
   * [[UseExtensionService.defaultResponseHex]] unless a test installs its own responder via
-  * [[respondWith]].
+  * [[respondWith]]. A second extension [[unreachableExtensionId]] is configured at an address where
+  * nothing listens, so that tests can exercise transport-level connection failures.
   */
 class UseExtensionService(
     protected val loggerFactory: NamedLoggerFactory,
     val extensionId: String = "test-extension",
+    val unreachableExtensionId: String = "unreachable-extension",
 ) extends EnvironmentSetupPlugin {
   import UseExtensionService.*
 
   private val port = UniquePortGenerator.next
+  // Allocated like every Canton test port so that concurrently running Canton tests stay off
+  // it, but never bound by this plugin: calls to the unreachable extension fail with a
+  // connection refusal. (The generator cannot guard against foreign processes on the host.)
+  private val unreachablePort = UniquePortGenerator.next
 
   private val calls = new CopyOnWriteArrayList[RecordedCall]
 
@@ -66,12 +72,19 @@ class UseExtensionService(
     ConfigTransforms.updateAllParticipantConfigs_(
       _.focus(_.parameters.engine.extensions)
         .modify(
-          _ + (extensionId -> ExtensionServiceConfig(
-            address = "127.0.0.1",
-            port = port,
-            // No retries, so that failure scenarios observe a deterministic number of calls.
-            maxRetries = NonNegativeInt.zero,
-          ))
+          _ ++ Map(
+            extensionId -> ExtensionServiceConfig(
+              address = "127.0.0.1",
+              port = port,
+              // No retries, so that failure scenarios observe a deterministic number of calls.
+              maxRetries = NonNegativeInt.zero,
+            ),
+            unreachableExtensionId -> ExtensionServiceConfig(
+              address = "127.0.0.1",
+              port = unreachablePort,
+              maxRetries = NonNegativeInt.zero,
+            ),
+          )
         )
     )(config)
 


### PR DESCRIPTION
Part of #564: the "service unreachable during submission", "service unreachable during validation", and "recorded output != computed output" scenarios from the issue, plus two cheap siblings the fixture makes free.

**Stacked on #594** — the first four commits are #594 (including the `ExternalCallTest` rename); **only the last commit (b05938196) is new here.** I will rebase onto main as soon as #594 merges, leaving just that commit.

Extends `ExternalCallIntegrationTest` to six tests, each asserting the exact client-visible error, the participant's warnings and alarms (nothing more — the log windows are strict), and that a rejected request leaves nothing on the ledger:

- **Unreachable at submission**: the mock plugin now also configures an extension at a reserved-but-unbound port, so the call fails with a real connection refusal. The command is rejected synchronously with `INTERPRETATION_EXTERNAL_CALL_ERROR_EXECUTION_FAILED` carrying only the generic non-actionable client message, and no request reaches any service.
- **Non-canonical output at submission**: `INTERPRETATION_EXTERNAL_CALL_ERROR_INVALID_OUTPUT`, exactly one service call.
- **Service failure during re-validation**: the only confirmer abstains and the mediator rejects; the completion carries `CANNOT_PERFORM_ALL_VALIDATIONS` with the validator's status-only reason. A transport-level failure between the two phases of a single request cannot be injected with a static mock, but the equivalence is exact: the validator consumes only the error's status code, and a connection refusal maps to the same 503, so the abstain reason is byte-identical either way (the refusal path itself is covered end-to-end by the first scenario).
- **Non-canonical output during re-validation**: same abstain outcome, and the strict log assertion proves no warning and no alarm fires — pinning the deliberate asymmetry with the submission-time `INVALID_OUTPUT` reject.
- **Disagreeing re-validation output**: the `EXTERNAL_CALL_RESULT_DISAGREEMENT_ALARM` security alert fires exactly once per request with the full inconsistency description asserted by equality (output byte sizes only — the assertion proves the output bytes cannot leak into logs), and the completion carries `LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT`.

Gating as in #594 and per the no-hardcoded-PV rule: `onlyRunWithOrGreaterThan ProtocolVersion.dev`, so the tests execute in the dev-protocol-version job and report ignored in stable PR jobs. Verified locally: 6/6 green at `CANTON_PROTOCOL_VERSION=dev`, 6 ignored at the stable default.

The remaining #564 scenarios (disagreeing outputs across participants, missing output, explicit V4 prepare/execute) need a second participant and the malicious-participant machinery and will follow separately on these fixtures.
