### PR TITLE
refactor(external-call): dissolve the checker's near-duplicate occurrence record

### DIFF
--- a/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
+++ b/community/participant/src/main/scala/com/digitalasset/canton/participant/protocol/validation/ExternalCallConsistencyChecker.scala
@@ -65,12 +65,12 @@ object ExternalCallConsistencyChecker {
       )
   }
 
-  /** An external-call result recorded in a view that this participant has received. */
-  private final case class VisibleExternalCallOccurrence(
-      key: ExternalCallKey,
-      output: Bytes,
-      occurrence: ExternalCallOccurrence,
-  )
+  /** The output recorded at one visible occurrence of an external call: unlike
+    * [[ExternalCallOccurrence]], which only locates a recorded call within the transaction, this
+    * also carries the output recorded there. The call's identity travels alongside as the
+    * [[com.digitalasset.canton.data.ExternalCallKey]] that [[check]] groups by.
+    */
+  private final case class RecordedOutput(output: Bytes, occurrence: ExternalCallOccurrence)
 
   private implicit val orderBytes: Order[Bytes] =
     Order.by[Bytes, ByteString](_.toByteString)(ByteStringUtil.orderByteString)
@@ -92,9 +92,9 @@ object ExternalCallConsistencyChecker {
 
   private def inconsistencyFor(
       key: ExternalCallKey,
-      outputsAndOccurrences: Seq[(Bytes, ExternalCallOccurrence)],
+      recordedOutputs: Seq[RecordedOutput],
   ): Option[Inconsistency] = {
-    val occurrencesByOutput = outputsAndOccurrences.groupMap(_._1)(_._2)
+    val occurrencesByOutput = recordedOutputs.groupMap(_.output)(_.occurrence)
     Option.when(occurrencesByOutput.sizeCompare(1) > 0)(
       Inconsistency(
         key,
@@ -104,9 +104,9 @@ object ExternalCallConsistencyChecker {
     )
   }
 
-  private def visibleOccurrences(
+  private def visibleRecordedOutputs(
       views: Map[ViewPosition, ParticipantTransactionView]
-  ): Seq[VisibleExternalCallOccurrence] =
+  ): Seq[(ExternalCallKey, RecordedOutput)] =
     views.toSeq
       .sortBy(_._1)(ViewPosition.orderViewPosition.toOrdering)
       .flatMap { case (viewPosition, view) =>
@@ -116,11 +116,8 @@ object ExternalCallConsistencyChecker {
             externalCallResult.exerciseIndex,
             externalCallResult.callIndex,
           )
-          VisibleExternalCallOccurrence(
-            ExternalCallKey.fromResult(externalCallResult.result),
-            externalCallResult.result.output,
-            occurrence,
-          )
+          ExternalCallKey.fromResult(externalCallResult.result) ->
+            RecordedOutput(externalCallResult.result.output, occurrence)
         }
       }
 
@@ -128,11 +125,9 @@ object ExternalCallConsistencyChecker {
     * deterministically (by key, then outputs, then occurrences).
     */
   def check(views: Map[ViewPosition, ParticipantTransactionView]): Seq[Inconsistency] =
-    visibleOccurrences(views)
-      .groupMap(_.key)(occurrence => occurrence.output -> occurrence.occurrence)
+    visibleRecordedOutputs(views)
+      .groupMap(_._1)(_._2)
       .toSeq
-      .flatMap { case (key, outputsAndOccurrences) =>
-        inconsistencyFor(key, outputsAndOccurrences)
-      }
+      .flatMap { case (key, recordedOutputs) => inconsistencyFor(key, recordedOutputs) }
       .sorted(orderInconsistency)
 }


### PR DESCRIPTION
Completes the data-structure ask from the #554 approval ([reorganization](https://github.com/digital-asset/canton/pull/554#discussion_r3528642184), [naming](https://github.com/digital-asset/canton/pull/554#discussion_r3529023582)), tracked on #565 — see the accounting in https://github.com/digital-asset/canton/issues/565#issuecomment-5101022162.

#581 removed the duplication's substance (the `checkingParties` copy and all per-party structures), but the checker-private class kept its `VisibleExternalCallOccurrence` name — still confusably close to `ExternalCallOccurrence`. This PR dissolves it: `visibleRecordedOutputs` now yields `(ExternalCallKey, RecordedOutput)` pairs, where `RecordedOutput(output, occurrence)` carries exactly what distinguishes it from an occurrence — the output recorded at that location — and the call's identity exists only as the grouping key that `check` consumes. No private structure re-bundles the wire record's fields anymore, and no behavior changes (same grouping, ordering, and duplicate handling; `ExternalCallConsistencyCheckerTest` and `ExternalCallProtocolIntegrationTest` pass unchanged at `CANTON_PROTOCOL_VERSION=dev`).

Standalone on current main — independent of the open test PRs.
