### PR TITLE
test(external-call): reject tampered confirmation requests end-to-end

### DIFF
--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
@@ -207,8 +207,9 @@ class ExternalCallTamperingIntegrationTest
           LogEntryOptionality.Required -> modelConformanceReplayMissing("participant2"),
         )
 
-        // Validation fails during re-interpretation, before the extension service would be
-        // re-contacted, so the service observes no call at all.
+        // Re-interpretation replays recorded results instead of contacting the service, and the
+        // stripped views leave the external-call check nothing to re-validate, so the service is
+        // never contacted.
         extensionService.observedCalls shouldBe empty
 
         assertPingSucceeds(participant1, participant2)
@@ -252,8 +253,9 @@ class ExternalCallTamperingIntegrationTest
             |  occurrences = Seq(ExternalCallOccurrence(viewPosition = ViewPosition(L), exerciseIndex = 0, callIndex = 0), ExternalCallOccurrence(viewPosition = ViewPosition(R), exerciseIndex = 0, callIndex = 0))
             |)""".stripMargin
 
-        // The consistency check alarms (WARN) once per confirming participant and, on the strength
-        // of the same disagreement, rejects both root views recording the key (each an INFO-level
+        // The consistency check alarms (WARN) once per request on every participant receiving the
+        // views (both confirm here) and, on the strength of the same disagreement, rejects both
+        // root views recording the key (each an INFO-level
         // LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT verdict, below this WARN suppressor). The
         // alarm carries the full description, including both occurrences, so both confirmers
         // rejecting proves the request cannot be committed.

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.integration.tests.extension
+
+import com.daml.ledger.api.v2.commands.Command
+import com.digitalasset.canton.BaseTest
+import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.crypto.CryptoPureApi
+import com.digitalasset.canton.data.{
+  GenTransactionTree,
+  MerkleSeq,
+  MerkleTree,
+  TransactionView,
+  ViewParticipantData,
+}
+import com.digitalasset.canton.extcall.java as M
+import com.digitalasset.canton.integration.plugins.{UseExtensionService, UseH2}
+import com.digitalasset.canton.integration.util.TestSubmissionService.CommandsWithMetadata
+import com.digitalasset.canton.integration.util.{
+  EntitySyntax,
+  PartiesAllocator,
+  TestSubmissionService,
+}
+import com.digitalasset.canton.integration.{
+  CommunityIntegrationTest,
+  EnvironmentDefinition,
+  SharedEnvironment,
+}
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
+import com.digitalasset.canton.logging.{LogEntry, SuppressingLogger}
+import com.digitalasset.canton.participant.ledger.api.client.JavaDecodeUtil
+import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
+import com.digitalasset.canton.protocol.LocalRejectError.MalformedRejects.ModelConformance
+import com.digitalasset.canton.topology.PartyId
+import com.digitalasset.canton.topology.transaction.ParticipantPermission
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.MaliciousParticipantNode
+import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.daml.lf.engine.Result
+import org.scalatest.Assertion
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.DurationInt
+
+/** End-to-end coverage for a malicious participant that tampers with the recorded external-call
+  * results before sending the confirmation request. Honest participants recompute or replay the
+  * results during validation and reject the request. External-call wire data exists only at
+  * protocol version dev, so the tests are dev-gated and run in the dev-protocol-version CI job.
+  */
+class ExternalCallTamperingIntegrationTest
+    extends CommunityIntegrationTest
+    with SharedEnvironment
+    with EntitySyntax {
+
+  override val loggerFactory: SuppressingLogger =
+    SuppressingLogger(getClass, pollTimeout = 10.seconds)
+
+  private val extensionService = new UseExtensionService(loggerFactory)
+
+  registerPlugin(new UseH2(loggerFactory))
+  registerPlugin(extensionService)
+
+  // Read from various threads, hence an AtomicReference.
+  private lazy val pureCryptoRef: AtomicReference[CryptoPureApi] = new AtomicReference()
+  private def pureCrypto: CryptoPureApi = pureCryptoRef.get()
+
+  private var maliciousP1: MaliciousParticipantNode = _
+  private var owner: PartyId = _
+  private var tester: M.externalcalltest.ExternalCallTester.Contract = _
+
+  /** Records the extension service's default output at submission, mirroring what an honest
+    * submitter would record. The tampering happens later, on the transaction tree.
+    */
+  private val recordingHandler: ExternalCallHandler = new ExternalCallHandler {
+    override def handleExternalCall(
+        extensionId: String,
+        functionId: String,
+        configHash: String,
+        input: String,
+        mode: ExternalCallMode,
+    )(implicit
+        tc: TraceContext
+    ): FutureUnlessShutdown[Either[Result.Need.ExternalCall.Error, String]] =
+      FutureUnlessShutdown.pure(Right(UseExtensionService.defaultResponseHex))
+  }
+
+  override lazy val environmentDefinition: EnvironmentDefinition =
+    EnvironmentDefinition.P2_S1M1.withSetup { implicit env =>
+      import env.*
+
+      participants.all.foreach(_.synchronizers.connect_local(sequencer1, alias = daName))
+      pureCryptoRef.set(sequencer1.crypto.pureCrypto)
+
+      if (testedProtocolVersion >= ProtocolVersion.dev) {
+        participants.all.dars.upload(BaseTest.ExternalCallTestPath)
+
+        PartiesAllocator(Set(participant1, participant2))(
+          newParties = Seq("owner" -> participant1),
+          targetTopology = Map(
+            "owner" -> Map(
+              daId -> (PositiveInt.one, Set(
+                participant1.id -> ParticipantPermission.Submission,
+                participant2.id -> ParticipantPermission.Confirmation,
+              ))
+            )
+          ),
+        )
+        owner = "owner".toPartyId(participant1)
+
+        tester = JavaDecodeUtil
+          .decodeAllCreated(M.externalcalltest.ExternalCallTester.COMPANION)(
+            participant1.ledger_api.javaapi.commands.submit(
+              Seq(owner),
+              Seq(
+                new M.externalcalltest.ExternalCallTester(
+                  owner.toProtoPrimitive
+                ).create.commands.loneElement
+              ),
+            )
+          )
+          .loneElement
+
+        maliciousP1 = MaliciousParticipantNode(
+          participant1,
+          daId,
+          testedProtocolVersion,
+          timeouts,
+          loggerFactory,
+          testSubmissionServiceOverrideO = Some(
+            TestSubmissionService(
+              participant1,
+              checkAuthorization = false,
+              enableLfDev = true,
+              externalCallHandler = recordingHandler,
+            )
+          ),
+        )
+      }
+    }
+
+  private def callExtensionCommand: Command =
+    Command.fromJavaProto(
+      tester.id
+        .exerciseCallExtension(extensionService.extensionId, "test-function", "00ff", "deadbeef")
+        .commands
+        .loneElement
+        .toProtoCommand
+    )
+
+  /** Optic onto every root view's recorded external-call results. */
+  private def externalCallResultsOfRootViews =
+    GenTransactionTree.Optics.rootViewsUnsafe
+      .andThen(MerkleSeq.Optics.toSeq[TransactionView](pureCrypto, testedProtocolVersion))
+      .andThen(MerkleTree.Optics.unblindedSeq[TransactionView])
+      .andThen(TransactionView.Optics.viewParticipantDataUnsafe)
+      .andThen(MerkleTree.Optics.unblinded[ViewParticipantData])
+      .andThen(ViewParticipantData.Optics.externalCallResultsUnsafe)
+
+  "a malicious participant that drops the recorded external-call results" should {
+    "be rejected by a failed model conformance check" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        import env.*
+        extensionService.reset()
+
+        val command = CommandsWithMetadata(Seq(callExtensionCommand), actAs = Seq(owner))
+
+        def modelConformanceReplayMissing(member: String)(entry: LogEntry): Assertion = {
+          entry.shouldBeCantonErrorCode(ModelConformance)
+          entry.message should include(
+            "Rejected transaction due to a failed model conformance check"
+          )
+          entry.message should include("ExternalCallReplayMissing")
+          // The missing key is described by its identity and size-only payload fields, never the
+          // payload bytes themselves (config "00ff" = 2 bytes, input "deadbeef" = 4 bytes).
+          entry.message should include(s"""extension id = "${extensionService.extensionId}"""")
+          entry.message should include("""function id = "test-function"""")
+          entry.message should include("""config bytes = "2 bytes"""")
+          entry.message should include("""input bytes = "4 bytes"""")
+          entry.loggerName should include(member)
+        }
+
+        loggerFactory.assertLogsUnorderedOptional(
+          maliciousP1
+            .submitCommand(
+              command,
+              transactionTreeInterceptor = externalCallResultsOfRootViews.modify(_ => Seq.empty),
+            )
+            .futureValueUS
+            .valueOrFail("malicious submission"),
+          LogEntryOptionality.Required -> modelConformanceReplayMissing("participant1"),
+          LogEntryOptionality.Required -> modelConformanceReplayMissing("participant2"),
+        )
+
+        // Validation fails during re-interpretation, before the extension service would be
+        // re-contacted, so the service observes no call at all.
+        extensionService.observedCalls shouldBe empty
+
+        assertPingSucceeds(participant1, participant2)
+    }
+  }
+}

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/extension/ExternalCallTamperingIntegrationTest.scala
@@ -31,6 +31,7 @@ import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
 import com.digitalasset.canton.logging.{LogEntry, SuppressingLogger}
 import com.digitalasset.canton.participant.ledger.api.client.JavaDecodeUtil
+import com.digitalasset.canton.participant.protocol.validation.ExternalCallValidationError
 import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
 import com.digitalasset.canton.protocol.LocalRejectError.MalformedRejects.ModelConformance
 import com.digitalasset.canton.topology.PartyId
@@ -38,6 +39,7 @@ import com.digitalasset.canton.topology.transaction.ParticipantPermission
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MaliciousParticipantNode
 import com.digitalasset.canton.version.ProtocolVersion
+import com.digitalasset.daml.lf.data.Bytes
 import com.digitalasset.daml.lf.engine.Result
 import org.scalatest.Assertion
 
@@ -158,6 +160,18 @@ class ExternalCallTamperingIntegrationTest
       .andThen(MerkleTree.Optics.unblinded[ViewParticipantData])
       .andThen(ViewParticipantData.Optics.externalCallResultsUnsafe)
 
+  /** Optic onto the first root view's recorded external-call results, so that a single view can be
+    * tampered with while the other is left intact.
+    */
+  private def externalCallResultsOfFirstRootView =
+    GenTransactionTree.Optics.rootViewsUnsafe
+      .andThen(MerkleSeq.Optics.toSeq[TransactionView](pureCrypto, testedProtocolVersion))
+      .index(0)
+      .andThen(MerkleTree.Optics.unblinded[TransactionView])
+      .andThen(TransactionView.Optics.viewParticipantDataUnsafe)
+      .andThen(MerkleTree.Optics.unblinded[ViewParticipantData])
+      .andThen(ViewParticipantData.Optics.externalCallResultsUnsafe)
+
   "a malicious participant that drops the recorded external-call results" should {
     "be rejected by a failed model conformance check" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
       implicit env =>
@@ -195,6 +209,74 @@ class ExternalCallTamperingIntegrationTest
 
         // Validation fails during re-interpretation, before the extension service would be
         // re-contacted, so the service observes no call at all.
+        extensionService.observedCalls shouldBe empty
+
+        assertPingSucceeds(participant1, participant2)
+    }
+  }
+
+  "a malicious participant that records disagreeing external-call results" should {
+    "be rejected with a disagreement alarm on every confirming participant" onlyRunWithOrGreaterThan ProtocolVersion.dev in {
+      implicit env =>
+        import env.*
+        extensionService.reset()
+
+        // Two identical external-call exercises in one command yield two root views that share a
+        // single external-call key, each recording the same honest output.
+        val command = CommandsWithMetadata(
+          Seq(callExtensionCommand, callExtensionCommand),
+          actAs = Seq(owner),
+        )
+
+        // Rewrite the first root view's recorded output to a different value so that the two
+        // visible occurrences of the same key disagree ("c0ffee" recorded honestly, "beef"
+        // tampered in), which the confirming participants detect and reject.
+        val tamperFirstRootViewOutput: GenTransactionTree => GenTransactionTree =
+          externalCallResultsOfFirstRootView.modify(
+            _.map(result =>
+              result.copy(result = result.result.copy(output = Bytes.assertFromString("beef")))
+            )
+          )
+
+        // The disagreement is described by the call's identity, the sorted output byte sizes
+        // ("beef" = 2 bytes, "c0ffee" = 3 bytes, never the output bytes themselves), and the two
+        // occurrences that recorded the disagreeing outputs. The two root views hold one exercise
+        // each, so both occurrences are at exercise 0, call 0; the tampered view is at position L.
+        val expectedInconsistency =
+          """Inconsistency(
+            |  extensionId = test-extension,
+            |  functionId = test-function,
+            |  config = 2 bytes,
+            |  input = 4 bytes,
+            |  outputByteSizes = Seq(2, 3),
+            |  occurrences = Seq(ExternalCallOccurrence(viewPosition = ViewPosition(L), exerciseIndex = 0, callIndex = 0), ExternalCallOccurrence(viewPosition = ViewPosition(R), exerciseIndex = 0, callIndex = 0))
+            |)""".stripMargin
+
+        // The consistency check alarms (WARN) once per confirming participant and, on the strength
+        // of the same disagreement, rejects both root views recording the key (each an INFO-level
+        // LOCAL_VERDICT_EXTERNAL_CALL_RESULT_DISAGREEMENT verdict, below this WARN suppressor). The
+        // alarm carries the full description, including both occurrences, so both confirmers
+        // rejecting proves the request cannot be committed.
+        def disagreementAlarm(member: String)(entry: LogEntry): Assertion =
+          entry.shouldBeCantonError(
+            ExternalCallValidationError.ExternalCallResultDisagreementAlarm,
+            messageAssertion =
+              _ shouldBe s"Observed inconsistent external call results: $expectedInconsistency",
+            contextAssertion = _.keySet should contain("requestId"),
+            loggerAssertion = _ should include(member),
+          )
+
+        loggerFactory.assertLogsUnorderedOptional(
+          maliciousP1
+            .submitCommand(command, transactionTreeInterceptor = tamperFirstRootViewOutput)
+            .futureValueUS
+            .valueOrFail("malicious submission"),
+          LogEntryOptionality.Required -> disagreementAlarm("participant1"),
+          LogEntryOptionality.Required -> disagreementAlarm("participant2"),
+        )
+
+        // The disagreement is decided from the two recorded outputs alone; the disagreeing key is
+        // excluded from re-validation, so the extension service is never contacted.
         extensionService.observedCalls shouldBe empty
 
         assertPingSucceeds(participant1, participant2)

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
@@ -36,6 +36,7 @@ import com.digitalasset.canton.logging.{
 }
 import com.digitalasset.canton.participant.ParticipantNode
 import com.digitalasset.canton.platform.apiserver.SubmissionSeed
+import com.digitalasset.canton.platform.execution.{ExternalCallHandler, ExternalCallMode}
 import com.digitalasset.canton.protocol.*
 import com.digitalasset.canton.time.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.{ParticipantId, PartyId}
@@ -71,6 +72,7 @@ class TestSubmissionService(
     packageResolver: PackageResolver,
     syncService: SyncService,
     mkPackageMap: TraceContext => Future[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]],
+    externalCallHandler: ExternalCallHandler,
     interpretationConfig: InterpretationConfig = InterpretationConfig.Default,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit executionContext: ExecutionContext)
@@ -421,21 +423,19 @@ class TestSubmissionService(
             case Result.Need.Prefetch(_, _) =>
               drive(im.resume(()))
 
-            // TODO(https://github.com/digital-asset/canton/issues/564): skip external calls in
-            // tests, or mock the response instead?
-            case Result.Need.ExternalCall(extensionId, functionId, _, _) =>
-              Future.successful(
-                Left(
-                  Error.Interpretation(
-                    Error.Interpretation.Internal(
-                      "test",
-                      s"External calls are not supported in TestSubmissionService: extension=$extensionId, function=$functionId",
-                      None,
-                    ),
-                    None,
+            case Result.Need.ExternalCall(extensionId, functionId, configHash, input) =>
+              for {
+                result <- externalCallHandler
+                  .handleExternalCall(
+                    extensionId,
+                    functionId,
+                    configHash,
+                    input,
+                    ExternalCallMode.Submission,
                   )
-                )
-              )
+                  .failOnShutdownToAbortException("test external call")
+                r <- drive(im.resume(result))
+              } yield r
           }
       }
 
@@ -469,9 +469,17 @@ object TestSubmissionService {
       customKeyResolver: Option[TestKeyResolver] = None,
       checkAuthorization: Boolean = true,
       enableLfDev: Boolean = false,
-      interpretationConfig: InterpretationConfig = InterpretationConfig.Default,
+      externalCallHandler: ExternalCallHandler = ExternalCallHandler.Unsupported,
+      interpretationConfig: Option[InterpretationConfig] = None,
   )(implicit env: TestConsoleEnvironment): TestSubmissionService = {
     import env.*
+
+    // Keep the interpretation-time allowed versions in step with the engine's: when dev is
+    // enabled, `Engine.checkAllowedDeps` reads the allowed versions from the interpretation
+    // config, not the engine config, so a stable-only config would reject a dev package.
+    val effectiveInterpretationConfig = interpretationConfig.getOrElse(
+      if (enableLfDev) InterpretationConfig.Dev else InterpretationConfig.Default
+    )
 
     val participantNode = participant.underlying.value
     val loggerFactory = participantNode.loggerFactory
@@ -509,7 +517,8 @@ object TestSubmissionService {
       packageResolver,
       participantNode.sync,
       mkPackageMap(participantNode)(_),
-      interpretationConfig,
+      externalCallHandler,
+      effectiveInterpretationConfig,
       loggerFactory,
     )
   }

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/util/TestSubmissionService.scala
@@ -73,7 +73,7 @@ class TestSubmissionService(
     syncService: SyncService,
     mkPackageMap: TraceContext => Future[Map[Ref.PackageId, (Ref.PackageName, Ref.PackageVersion)]],
     externalCallHandler: ExternalCallHandler,
-    interpretationConfig: InterpretationConfig = InterpretationConfig.Default,
+    interpretationConfig: InterpretationConfig,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit executionContext: ExecutionContext)
     extends NamedLogging {


### PR DESCRIPTION
Part of #564 (the external-call e2e + negative-path tests). Adds the two malicious-participant tampering scenarios (items A2 and A3 in the issue #564 tracking comment) plus the shared prerequisite that lets `TestSubmissionService` interpret external calls.

**Stacked on #594** (the honest-path keystone). Only the last **3** commits are new here; the first 4 belong to #594. This branch will be rebased onto `main` once #594 merges.

### Commits (newest last)
1. **interpret external calls in `TestSubmissionService`** — wires an injectable `ExternalCallHandler` (default `ExternalCallHandler.Unsupported`) into `TestSubmissionService`, resuming the interpreter's `Result.Need.ExternalCall` with `ExternalCallMode.Submission`, so a malicious submitter can record external-call results (closes the #564 TODO). Also fixes a latent config bug: `enableLfDev` set only the *engine* config to dev, but `Engine.checkAllowedDeps` reads the allowed LF versions from the *interpretation* config, so a dev package was rejected with a misleading engine-config-shaped error. `interpretationConfig` is now an `Option` defaulting to `.Dev` under `enableLfDev`. No caller passes `interpretationConfig`, so the change is source-compatible; `.Dev` widens the allowed versions over `.Default` (identical `contractStateMode`), so no stable-package suite can regress.
2. **reject a confirmation request with dropped results** (A3) — a malicious participant strips a view's recorded `externalCallResults` to empty; honest participants re-interpret, find no output to replay (`ExternalCallReplayMissing`), and reject with a failed model-conformance check. Size-only key fields are asserted verbatim; the extension service observes zero calls.
3. **reject a confirmation request with disagreeing results** (A2) — a malicious participant records two root views exercising the same external call, then rewrites one view's recorded output. Every confirming participant's consistency check spots the two occurrences disagreeing, alarms once (the full `Inconsistency` description is pinned), and rejects both recording views, so the request cannot be committed. The disagreeing key is excluded from re-validation, so the service is never contacted.

### Gating
The suite uses standard env-driven dev-gating (`onlyRunWithOrGreaterThan ProtocolVersion.dev`) per the no-hardcoded-PV rule from the #552/#567 reviews: external-call wire data exists only at protocol version dev, so it runs in the dev-PV job on `main` and reports "ignored" in the stable-PV PR jobs. A scoped tag-keyed dev job could add PR-time coverage as a follow-up if preferred.

Local gates: dev 2/2, stable 2-ignored; `sbt format` + whole-repo `sbt scalafixCheck` clean; full `community-app` test compile plus a malicious-`TestSubmissionService` H2 suite green at both PVs (shared-infra blast radius).
