### PR TITLE
feat(external-call): enable hashing scheme V4 on protocol version 36

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -86,6 +86,7 @@ The `TransactionFilter`, `TreeEvent`, `CreatedTreeEvent`, `ExercisedTreeEvent`, 
 `JsSubmitAndWaitForTransactionTreeResponse` schemas have been dropped from the OpenAPI and AsyncAPI definitions.
 
 ### Minor Improvements
+- Interactive submissions can use hashing scheme version `HASHING_SCHEME_VERSION_V4` on synchronizers running protocol version 36 or later (previously only on development-protocol synchronizers). V4 additionally covers recorded external-call results in the prepared transaction hash.
 - Security. The HTTP server now rejects too deeply nested json structures. The check uses the same values as the already existing gRPC check for nested daml records. This means
     that the Ledger JSON API client may now observe an error from HTTP (BadRequest) where previously the `INVALID_ARGUMENT/COMMAND_PREPROCESSING_FAILED` or  `INVALID_ARGUMENT/VALUE_NESTING` error was returned.
 - The submitter does not have to be a stakeholder of all contracts during automatic reassignment, only of those that are actually reassigned to a target synchronizer. The previous check was considered too strict: it required the submitter to be a stakeholder of all involved contracts, even ones that were, for instance, disclosed contracts already on the target synchronizer.

--- a/community/app/src/test/scala/com/digitalasset/canton/integration/tests/examples/InteractiveSubmissionDemoExampleIntegrationTest.scala
+++ b/community/app/src/test/scala/com/digitalasset/canton/integration/tests/examples/InteractiveSubmissionDemoExampleIntegrationTest.scala
@@ -80,11 +80,10 @@ sealed abstract class InteractiveSubmissionDemoExampleIntegrationTest
   }
 
   private val supportedHashingSchemeVersions =
-    // TODO(i32856): Remove the get / flatMap when PV Dev has a matching supported scheme
-    HashingSchemeVersion.MinimumProtocolVersionToHashingVersion
-      .get(testedProtocolVersion)
+    HashingSchemeVersion
+      .getHashingSchemeVersionsForProtocolVersion(testedProtocolVersion)
+      .forgetNE
       .toList
-      .flatMap(_.forgetNE)
 
   // TODO(i33946): Implement V4 hashing scheme in the python demo and re-enable the test
   supportedHashingSchemeVersions

--- a/community/base/src/main/scala/com/digitalasset/canton/data/SubmitterMetadata.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/data/SubmitterMetadata.scala
@@ -122,7 +122,7 @@ object SubmitterMetadata
       supportedProtoVersionMemoizedPVV(_)(fromProtoV31),
       _.toProtoV31,
     ),
-    ProtoVersion(32) -> VersionedProtoCodec(ProtocolVersion.dev)(v32.SubmitterMetadata)(
+    ProtoVersion(32) -> VersionedProtoCodec(ProtocolVersion.v36)(v32.SubmitterMetadata)(
       supportedProtoVersionMemoizedPVV(_)(fromProtoV32),
       _.toProtoV32,
     ),

--- a/community/base/src/main/scala/com/digitalasset/canton/protocol/ExternalAuthorization.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/protocol/ExternalAuthorization.scala
@@ -82,7 +82,7 @@ object ExternalAuthorization
     ProtoVersion(31) -> VersionedProtoCodec(ProtocolVersion.v35)(protoCompanion =
       v31.ExternalAuthorization
     )(supportedProtoVersionPVV(_)(fromProtoV31), _.toProtoV31),
-    ProtoVersion(32) -> VersionedProtoCodec(ProtocolVersion.dev)(protoCompanion =
+    ProtoVersion(32) -> VersionedProtoCodec(ProtocolVersion.v36)(protoCompanion =
       v32.ExternalAuthorization
     )(supportedProtoVersionPVV(_)(fromProtoV32), _.toProtoV32),
   )

--- a/community/base/src/main/scala/com/digitalasset/canton/version/HashingSchemeVersion.scala
+++ b/community/base/src/main/scala/com/digitalasset/canton/version/HashingSchemeVersion.scala
@@ -58,13 +58,13 @@ object HashingSchemeVersion {
     Entries (pv=34 -> V2), (pv=35 -> V2, V3) means
       - pv=34 support V2
       - pv=35 and onwards support V2 and V3
-      - dev supports V2, V3, and V4
+      - pv=36 and onwards support V2, V3, and V4
    */
   private[canton] val MinimumProtocolVersionToHashingVersion =
     SortedMap[ProtocolVersion, NonEmpty[SortedSet[HashingSchemeVersion]]](
       ProtocolVersion.v34 -> NonEmpty.mk(SortedSet, V2),
       ProtocolVersion.v35 -> NonEmpty.mk(SortedSet, V2, V3),
-      ProtocolVersion.dev -> NonEmpty.mk(SortedSet, V2, V3, V4),
+      ProtocolVersion.v36 -> NonEmpty.mk(SortedSet, V2, V3, V4),
     )
 
   def minProtocolVersionForHSV(version: HashingSchemeVersion): Option[ProtocolVersion] =

--- a/community/base/src/test/scala/com/digitalasset/canton/version/HashingSchemeVersionSpec.scala
+++ b/community/base/src/test/scala/com/digitalasset/canton/version/HashingSchemeVersionSpec.scala
@@ -21,7 +21,7 @@ class HashingSchemeVersionSpec extends AnyWordSpec with Matchers with OptionValu
       ProtocolVersion.v35
     )
     HashingSchemeVersion.minProtocolVersionForHSV(HashingSchemeVersion.V4) shouldBe Some(
-      ProtocolVersion.dev
+      ProtocolVersion.v36
     )
   }
   "return the protocol hashing version" in {
@@ -31,6 +31,12 @@ class HashingSchemeVersionSpec extends AnyWordSpec with Matchers with OptionValu
         ProtocolVersion.v35
       )
       .forgetNE shouldBe SortedSet[HashingSchemeVersion](V2, V3)
+
+    HashingSchemeVersion
+      .getHashingSchemeVersionsForProtocolVersion(
+        ProtocolVersion.v36
+      )
+      .forgetNE shouldBe SortedSet[HashingSchemeVersion](V2, V3, V4)
 
     HashingSchemeVersion
       .getHashingSchemeVersionsForProtocolVersion(

--- a/community/ledger-api-proto/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto
+++ b/community/ledger-api-proto/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto
@@ -204,8 +204,8 @@ message PrepareSubmissionRequest {
 
   // The hashing scheme version to be used when building the hash.
   // Defaults to HASHING_SCHEME_VERSION_V2.
-  // HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-  // for stable synchronizers.
+  // HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+  // rejected on synchronizers running older protocol versions.
   //
   // Optional
   optional HashingSchemeVersion hashing_scheme_version = 17;
@@ -246,8 +246,8 @@ message PrepareSubmissionResponse {
   bytes prepared_transaction_hash = 2;
 
   // The hashing scheme version used when building the hash.
-  // HASHING_SCHEME_VERSION_V4 is only returned for development-protocol synchronizers and is rejected
-  // for stable synchronizers.
+  // HASHING_SCHEME_VERSION_V4 is only returned for synchronizers running protocol version 36 or
+  // later.
   //
   // Required
   HashingSchemeVersion hashing_scheme_version = 3;
@@ -330,8 +330,8 @@ message ExecuteSubmissionRequest {
   string user_id = 6;
 
   // The hashing scheme version used when building the hash.
-  // HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-  // for stable synchronizers.
+  // HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+  // rejected on synchronizers running older protocol versions.
   //
   // Required
   HashingSchemeVersion hashing_scheme_version = 7;
@@ -390,8 +390,8 @@ message ExecuteSubmissionAndWaitRequest {
   string user_id = 6;
 
   // The hashing scheme version used when building the hash.
-  // HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-  // for stable synchronizers.
+  // HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+  // rejected on synchronizers running older protocol versions.
   //
   // Required
   HashingSchemeVersion hashing_scheme_version = 7;
@@ -461,8 +461,8 @@ message ExecuteSubmissionAndWaitForTransactionRequest {
   string user_id = 6;
 
   // The hashing scheme version used when building the hash.
-  // HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-  // for stable synchronizers.
+  // HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+  // rejected on synchronizers running older protocol versions.
   //
   // Required
   HashingSchemeVersion hashing_scheme_version = 7;

--- a/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
+++ b/community/ledger/ledger-api-core/src/test/scala/com/digitalasset/canton/platform/apiserver/services/command/interactive/codec/ExternalTransactionProcessorSpec.scala
@@ -223,7 +223,7 @@ class ExternalTransactionProcessorSpec
       result.value.hashVersion shouldBe HashingSchemeVersion.V4
     }
 
-    "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is below dev" onlyRunWhen (_ < ProtocolVersion.dev) in {
+    "reject prepared transactions when the requested hashing scheme is V4 and the protocol version is below v36" onlyRunWhen (_ < ProtocolVersion.v36) in {
       val transaction = VersionedTransaction(
         LfSerializationVersion.V2,
         Map.empty,
@@ -236,7 +236,7 @@ class ExternalTransactionProcessorSpec
         .mkString(", ")
       result.left.value.reason shouldBe
         s"Hashing scheme version V4 is not supported on protocol version $testedProtocolVersion." +
-        " Minimum protocol version for hashing version V4: dev." +
+        " Minimum protocol version for hashing version V4: 36." +
         s" Supported hashing version on protocol version $testedProtocolVersion: $supportedSchemes"
     }
   }

--- a/community/ledger/ledger-json-api/src/main/resources/ledger-api/proto-data.yml
+++ b/community/ledger/ledger-json-api/src/main/resources/ledger-api/proto-data.yml
@@ -2901,8 +2901,8 @@ fileComments:
               Required
             hashing_scheme_version: |-
               The hashing scheme version used when building the hash.
-              HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-              for stable synchronizers.
+              HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+              rejected on synchronizers running older protocol versions.
 
               Required
             deduplication_duration: |-
@@ -2964,8 +2964,8 @@ fileComments:
               Required
             hashing_scheme_version: |-
               The hashing scheme version used when building the hash.
-              HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-              for stable synchronizers.
+              HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+              rejected on synchronizers running older protocol versions.
 
               Required
             deduplication_duration: |-
@@ -3023,8 +3023,8 @@ fileComments:
               Required
             hashing_scheme_version: |-
               The hashing scheme version used when building the hash.
-              HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-              for stable synchronizers.
+              HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+              rejected on synchronizers running older protocol versions.
 
               Required
             deduplication_duration: |-
@@ -3269,8 +3269,8 @@ fileComments:
             hashing_scheme_version: |-
               The hashing scheme version to be used when building the hash.
               Defaults to HASHING_SCHEME_VERSION_V2.
-              HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-              for stable synchronizers.
+              HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+              rejected on synchronizers running older protocol versions.
 
               Optional
             read_as: |-
@@ -3338,8 +3338,8 @@ fileComments:
               Optional
             hashing_scheme_version: |-
               The hashing scheme version used when building the hash.
-              HASHING_SCHEME_VERSION_V4 is only returned for development-protocol synchronizers and is rejected
-              for stable synchronizers.
+              HASHING_SCHEME_VERSION_V4 is only returned for synchronizers running protocol version 36 or
+              later.
 
               Required
       PreparedTransaction:

--- a/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml
+++ b/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml
@@ -5290,8 +5290,8 @@ components:
         hashingSchemeVersion:
           description: |-
             The hashing scheme version used when building the hash.
-            HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-            for stable synchronizers.
+            HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+            rejected on synchronizers running older protocol versions.
 
             Required
           type: string
@@ -5376,8 +5376,8 @@ components:
         hashingSchemeVersion:
           description: |-
             The hashing scheme version used when building the hash.
-            HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-            for stable synchronizers.
+            HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+            rejected on synchronizers running older protocol versions.
 
             Required
           type: string
@@ -5439,8 +5439,8 @@ components:
         hashingSchemeVersion:
           description: |-
             The hashing scheme version used when building the hash.
-            HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-            for stable synchronizers.
+            HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+            rejected on synchronizers running older protocol versions.
 
             Required
           type: string
@@ -5795,8 +5795,8 @@ components:
           description: |-
             The hashing scheme version to be used when building the hash.
             Defaults to HASHING_SCHEME_VERSION_V2.
-            HASHING_SCHEME_VERSION_V4 is only supported for development-protocol synchronizers and is rejected
-            for stable synchronizers.
+            HASHING_SCHEME_VERSION_V4 requires a synchronizer running protocol version 36 or later and is
+            rejected on synchronizers running older protocol versions.
 
             Optional
           type: string
@@ -5832,8 +5832,8 @@ components:
         hashingSchemeVersion:
           description: |-
             The hashing scheme version used when building the hash.
-            HASHING_SCHEME_VERSION_V4 is only returned for development-protocol synchronizers and is rejected
-            for stable synchronizers.
+            HASHING_SCHEME_VERSION_V4 is only returned for synchronizers running protocol version 36 or
+            later.
 
             Required
           type: string

--- a/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
+++ b/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
@@ -48,6 +48,7 @@ Protocol Version    Supported Hashing Schemes
 ==================  =========================
 v34                 V2
 v35                 V2, V3
+v36                 V2, V3, V4
 ==================  =========================
 
 Transaction Nodes

--- a/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
+++ b/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
@@ -65,13 +65,27 @@ versioned to accommodate those future changes. In practice, every new Daml langu
     :caption: Versioned Daml Transaction Node
     :dedent: 4
 
+V4
+==
+
+General approach
+----------------
+
+V4 follows the same general hashing approach as V3. The V3 section below defines the common encoding used by V4 unless a V4-specific difference is stated.
+
+Changes from V3
+---------------
+
+- Exercise nodes with version dev include ``external_call_results`` in the prepared transaction hash.
+  This binds the recorded external-call result payloads shown in prepared transaction review to the external party's signature.
+
 V3
 ==
 
 General approach
 ----------------
 
-The hash of the ``PreparedTransaction`` is computed by encoding every protobuf field of the messages to byte arrays,
+The hash of the ``PreparedTransaction`` is computed by encoding the fields specified by this section to byte arrays,
 and feeding those encoded values into a ``SHA-256`` hash builder. The rest of this section details how to deterministically encode
 every proto message into a byte array. Sometimes during the process, partially encoded results are hashed with SHA-256, and the resulting hash value serves as the encoding in messages further up.
 This is explicit when necessary.
@@ -105,7 +119,7 @@ Changes from V1
 
     V3 introduces support for contract keys. Usage of contract keys in externally signed transactions
     requires usage of V3. Contract keys will not work on V2.
-    Also note that V3 is only :ref:`supported <hashing_scheme_version>` on protocol version 35.
+    Also note that V3 is :ref:`supported <hashing_scheme_version>` from protocol version 35 onwards.
 
 
 Notation and Utility Functions
@@ -629,26 +643,56 @@ Create
 Exercise
 ^^^^^^^^
 
-.. code-block::
+.. tabs::
 
-    fn encode_node(exercise):
-        0x01 || # Node encoding version
-        encode(exercise.lf_version) || # Node LF version
-        0x01 || # Exercise node tag
-        encode_seed(find_seed(node.node_id).get) ||
-        encode(exercise.contract_id) ||
-        encode(exercise.package_name) ||
-        encode(exercise.template_id) ||
-        encode(exercise.signatories) ||
-        encode(exercise.stakeholders) ||
-        encode(exercise.acting_parties) ||
-        encode(exercise.interface_id) ||
-        encode(exercise.choice_id) ||
-        encode(exercise.chosen_value) ||
-        encode(exercise.consuming) ||
-        encode(exercise.exercise_result) ||
-        encode(exercise.choice_observers) ||
-        encode(exercise.children)
+   .. tab:: V4
+
+      .. code-block::
+
+          fn encode_node(exercise):
+              encode(exercise.lf_version) || # Node LF version
+              0x01 || # Exercise node tag
+              encode_seed(find_seed(node.node_id).get) ||
+              encode(exercise.contract_id) ||
+              encode(exercise.package_name) ||
+              encode(exercise.template_id) ||
+              encode(exercise.signatories) ||
+              encode(exercise.stakeholders) ||
+              encode(exercise.acting_parties) ||
+              encode(exercise.interface_id) ||
+              encode(exercise.choice_id) ||
+              encode(exercise.chosen_value) ||
+              encode(exercise.consuming) ||
+              encode(exercise.exercise_result) ||
+              encode(exercise.choice_observers) ||
+              encode(exercise.by_key) ||
+              encode(exercise.key) ||
+              encode(exercise.external_call_results) || # new in V4
+              encode(exercise.children)
+
+   .. tab:: V3
+
+      .. code-block::
+
+          fn encode_node(exercise):
+              encode(exercise.lf_version) || # Node LF version
+              0x01 || # Exercise node tag
+              encode_seed(find_seed(node.node_id).get) ||
+              encode(exercise.contract_id) ||
+              encode(exercise.package_name) ||
+              encode(exercise.template_id) ||
+              encode(exercise.signatories) ||
+              encode(exercise.stakeholders) ||
+              encode(exercise.acting_parties) ||
+              encode(exercise.interface_id) ||
+              encode(exercise.choice_id) ||
+              encode(exercise.chosen_value) ||
+              encode(exercise.consuming) ||
+              encode(exercise.exercise_result) ||
+              encode(exercise.choice_observers) ||
+              encode(exercise.by_key) ||
+              encode(exercise.key) ||
+              encode(exercise.children)
 
 .. important::
 
@@ -656,9 +700,19 @@ Exercise
     ``.get`` in ``find_seed(node.node_id).get``. If the seed of an exercise node cannot be found in the list of ``node_seeds``, encoding must be stopped
     and it should be reported as a bug.
 
-.. note::
+External call result
+^^^^^^^^^^^^^^^^^^^^
 
-    The last encoded value of the exercise node is its ``children`` field. This recursively traverses the transaction tree.
+When V4 encodes an ``external_call_results`` element, the element is encoded as follows:
+
+.. code-block::
+
+    fn encode_external_call_result(result):
+        return encode(result.extension_id) ||
+            encode(result.function_id) ||
+            encode(result.config) ||
+            encode(result.input) ||
+            encode(result.output)
 
 .. _fetch_node_encoding:
 
@@ -764,7 +818,7 @@ Finally, compute the hash that needs to be signed to commit to the ledger change
 
     fn encode(prepared_transaction):
         0x00000030 || # Hash purpose
-        0x03 || # Hashing Scheme Version
+        hashing_scheme_version_byte || # e.g. 0x03 for V3, 0x04 for V4
         hash(transaction) ||
         hash(metadata)
 
@@ -798,4 +852,3 @@ Both versions make use of the following common code:
 .. toggle::
 
     .. literalinclude:: CANTON/community/app/src/pack/examples/08-interactive-submission/daml_transaction_hashing_common.py
-

--- a/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
+++ b/docs-open/src/sphinx/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst
@@ -48,7 +48,6 @@ Protocol Version    Supported Hashing Schemes
 ==================  =========================
 v34                 V2
 v35                 V2, V3
-v36                 V2, V3, V4
 ==================  =========================
 
 Transaction Nodes
@@ -65,27 +64,13 @@ versioned to accommodate those future changes. In practice, every new Daml langu
     :caption: Versioned Daml Transaction Node
     :dedent: 4
 
-V4
-==
-
-General approach
-----------------
-
-V4 follows the same general hashing approach as V3. The V3 section below defines the common encoding used by V4 unless a V4-specific difference is stated.
-
-Changes from V3
----------------
-
-- Exercise nodes with version dev include ``external_call_results`` in the prepared transaction hash.
-  This binds the recorded external-call result payloads shown in prepared transaction review to the external party's signature.
-
 V3
 ==
 
 General approach
 ----------------
 
-The hash of the ``PreparedTransaction`` is computed by encoding the fields specified by this section to byte arrays,
+The hash of the ``PreparedTransaction`` is computed by encoding every protobuf field of the messages to byte arrays,
 and feeding those encoded values into a ``SHA-256`` hash builder. The rest of this section details how to deterministically encode
 every proto message into a byte array. Sometimes during the process, partially encoded results are hashed with SHA-256, and the resulting hash value serves as the encoding in messages further up.
 This is explicit when necessary.
@@ -119,7 +104,7 @@ Changes from V1
 
     V3 introduces support for contract keys. Usage of contract keys in externally signed transactions
     requires usage of V3. Contract keys will not work on V2.
-    Also note that V3 is :ref:`supported <hashing_scheme_version>` from protocol version 35 onwards.
+    Also note that V3 is only :ref:`supported <hashing_scheme_version>` on protocol version 35.
 
 
 Notation and Utility Functions
@@ -643,56 +628,26 @@ Create
 Exercise
 ^^^^^^^^
 
-.. tabs::
+.. code-block::
 
-   .. tab:: V4
-
-      .. code-block::
-
-          fn encode_node(exercise):
-              encode(exercise.lf_version) || # Node LF version
-              0x01 || # Exercise node tag
-              encode_seed(find_seed(node.node_id).get) ||
-              encode(exercise.contract_id) ||
-              encode(exercise.package_name) ||
-              encode(exercise.template_id) ||
-              encode(exercise.signatories) ||
-              encode(exercise.stakeholders) ||
-              encode(exercise.acting_parties) ||
-              encode(exercise.interface_id) ||
-              encode(exercise.choice_id) ||
-              encode(exercise.chosen_value) ||
-              encode(exercise.consuming) ||
-              encode(exercise.exercise_result) ||
-              encode(exercise.choice_observers) ||
-              encode(exercise.by_key) ||
-              encode(exercise.key) ||
-              encode(exercise.external_call_results) || # new in V4
-              encode(exercise.children)
-
-   .. tab:: V3
-
-      .. code-block::
-
-          fn encode_node(exercise):
-              encode(exercise.lf_version) || # Node LF version
-              0x01 || # Exercise node tag
-              encode_seed(find_seed(node.node_id).get) ||
-              encode(exercise.contract_id) ||
-              encode(exercise.package_name) ||
-              encode(exercise.template_id) ||
-              encode(exercise.signatories) ||
-              encode(exercise.stakeholders) ||
-              encode(exercise.acting_parties) ||
-              encode(exercise.interface_id) ||
-              encode(exercise.choice_id) ||
-              encode(exercise.chosen_value) ||
-              encode(exercise.consuming) ||
-              encode(exercise.exercise_result) ||
-              encode(exercise.choice_observers) ||
-              encode(exercise.by_key) ||
-              encode(exercise.key) ||
-              encode(exercise.children)
+    fn encode_node(exercise):
+        0x01 || # Node encoding version
+        encode(exercise.lf_version) || # Node LF version
+        0x01 || # Exercise node tag
+        encode_seed(find_seed(node.node_id).get) ||
+        encode(exercise.contract_id) ||
+        encode(exercise.package_name) ||
+        encode(exercise.template_id) ||
+        encode(exercise.signatories) ||
+        encode(exercise.stakeholders) ||
+        encode(exercise.acting_parties) ||
+        encode(exercise.interface_id) ||
+        encode(exercise.choice_id) ||
+        encode(exercise.chosen_value) ||
+        encode(exercise.consuming) ||
+        encode(exercise.exercise_result) ||
+        encode(exercise.choice_observers) ||
+        encode(exercise.children)
 
 .. important::
 
@@ -700,19 +655,9 @@ Exercise
     ``.get`` in ``find_seed(node.node_id).get``. If the seed of an exercise node cannot be found in the list of ``node_seeds``, encoding must be stopped
     and it should be reported as a bug.
 
-External call result
-^^^^^^^^^^^^^^^^^^^^
+.. note::
 
-When V4 encodes an ``external_call_results`` element, the element is encoded as follows:
-
-.. code-block::
-
-    fn encode_external_call_result(result):
-        return encode(result.extension_id) ||
-            encode(result.function_id) ||
-            encode(result.config) ||
-            encode(result.input) ||
-            encode(result.output)
+    The last encoded value of the exercise node is its ``children`` field. This recursively traverses the transaction tree.
 
 .. _fetch_node_encoding:
 
@@ -818,7 +763,7 @@ Finally, compute the hash that needs to be signed to commit to the ledger change
 
     fn encode(prepared_transaction):
         0x00000030 || # Hash purpose
-        hashing_scheme_version_byte || # e.g. 0x03 for V3, 0x04 for V4
+        0x03 || # Hashing Scheme Version
         hash(transaction) ||
         hash(metadata)
 
@@ -852,3 +797,4 @@ Both versions make use of the following common code:
 .. toggle::
 
     .. literalinclude:: CANTON/community/app/src/pack/examples/08-interactive-submission/daml_transaction_hashing_common.py
+


### PR DESCRIPTION
First slice of landing external calls in PV36 (per the Slack plan with @paulbrauner-da; September 2nd train). This slice is self-contained and independent of the serialization-version decision for external-call results, which the remaining slices depend on.

### What it does
- Moves the V4 row of `MinimumProtocolVersionToHashingVersion` from `dev` to `v36` (onwards semantics keep dev supported), mirroring the V3-to-v35 promotion (86cea8e80).
- Binds the `ProtoVersion(32)` codecs of `ExternalAuthorization` and `SubmitterMetadata` to v36. Their v31→v32 delta is exactly the `HASHING_SCHEME_VERSION_V4` enum value plus the Stable→Alpha marker, matching the pre-existing `ViewParticipantData` `ProtoVersion(32) -> v36` binding; codec selection at v35 and below is unchanged.
- Fallout: the `ExternalTransactionProcessorSpec` rejection test expects the v36 minimum and no longer registers at v36; the interactive-submission demo derives its schemes via `getHashingSchemeVersionsForProtocolVersion` (keeps its dev coverage, resolves the TODO on the exact-key lookup); the five ledger-API proto comments claiming V4 is dev-only are updated with `proto-data.yml`/`openapi.yaml` regenerated; `UNRELEASED.md` notes the promotion.
- Second commit restores the V4 hashing specification in `external_signing_hashing_algorithm.rst` (V4 section, V3/V4 tabbed exercise encoding incl. `external_call_results`, V3 wording fixes) that was merged in #549 and unintentionally reverted by the 2026-07-02 internal sync (ff509b03a), with the supported-schemes table saying v36 per this promotion.

### What it deliberately does not do
External-call results themselves remain gated (LF feature at 2.dev; `minExternalCallResults = VDev`; `ViewParticipantData.supportsExternalCallResults` at dev) — a v36 V4 flow never encounters a node it cannot hash. Those gates move in the next slices once the serialization version for external-call results below 2.dev is settled.

### Verification
- `CANTON_PROTOCOL_VERSION=36`: `ExternalTransactionProcessorSpec` (the ungated honor test now runs V4), `InteractiveSubmissionVersioningIntegrationTest` + `ExternalPartyOnboardingIntegrationTest` (external-party flows with V4 as the default scheme, 21 tests green), `SerializationDeserializationTest` (24/24, round-trips V4 through the v36 codecs), `HashingSchemeVersionSpec`.
- Default (v35) and `dev` runs of the same suites green — v35-and-below behavior is unchanged, dev keeps V4 via the map's onwards semantics.
- `sbt format` + whole-repo `sbt scalafixCheck` clean. Comment-only proto changes: `buf breaking` is structure-only, so no snapshot churn.